### PR TITLE
test: module-migration-07 modules test migration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,44 @@
 
 from __future__ import annotations
 
+import importlib
 import os
+import sys
+from contextlib import suppress
+from pathlib import Path
 
 
 os.environ.setdefault("TEST_MODE", "true")
+MODULES_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Ensure local bundle package sources are importable during tests.
+packages_root = MODULES_REPO_ROOT / "packages"
+if packages_root.exists():
+    for bundle_src in packages_root.glob("*/src"):
+        bundle_src_str = str(bundle_src)
+        if bundle_src_str not in sys.path:
+            sys.path.insert(0, bundle_src_str)
+
+# Lock specfact_project to the modules-repo package path to avoid accidental shadowing.
+with suppress(ModuleNotFoundError):
+    importlib.import_module("specfact_project")
+
+
+def _resolve_core_repo() -> Path | None:
+    configured = os.environ.get("SPECFACT_CLI_REPO")
+    if configured:
+        candidate = Path(configured).expanduser().resolve()
+        if (candidate / "src" / "specfact_cli").exists():
+            return candidate
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        sibling = parent.parent / "specfact-cli"
+        if (sibling / "src" / "specfact_cli").exists():
+            return sibling.resolve()
+    return None
+
+
+core_repo = _resolve_core_repo()
+if core_repo is not None:
+    os.environ.setdefault("SPECFACT_REPO_ROOT", str(core_repo))
+    os.environ.setdefault("SPECFACT_MODULES_REPO", str(MODULES_REPO_ROOT))

--- a/tests/integration/specfact_project/test_plan_compare_command_from_core.py
+++ b/tests/integration/specfact_project/test_plan_compare_command_from_core.py
@@ -1,0 +1,606 @@
+# pylint: skip-file
+"""Integration tests for plan compare command."""
+
+import pytest
+from specfact_cli.cli import app
+from specfact_cli.models.plan import Feature, Idea, PlanBundle, Product, Story
+from specfact_cli.utils.yaml_utils import dump_yaml
+from typer.testing import CliRunner
+
+
+pytestmark = pytest.mark.skip(
+    reason="Retired during module-migration-07: legacy 'project plan compare' topology is no longer part of supported CLI surface."
+)
+
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def tmp_plans(tmp_path):
+    """Create temporary plan files for testing."""
+    plans_dir = tmp_path / "plans"
+    plans_dir.mkdir()
+    return plans_dir
+
+
+class TestPlanCompareCommand:
+    """Test suite for plan compare command."""
+
+    def test_compare_identical_plans(self, tmp_plans):
+        """Test comparing identical plans produces no deviations."""
+        idea = Idea(title="Test Project", narrative="A test project", metrics=None)
+        product = Product(themes=["AI"], releases=[])
+        feature = Feature(
+            key="FEATURE-001",
+            title="User Auth",
+            outcomes=["Secure login"],
+            acceptance=["Login works"],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature],
+            metadata=None,
+            clarifications=None,
+        )
+
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+
+        dump_yaml(plan.model_dump(exclude_none=True), manual_path)
+        dump_yaml(plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            ["project", "plan", "compare", "--manual", str(manual_path), "--auto", str(auto_path)],
+        )
+
+        assert result.exit_code == 0
+        assert "No deviations found" in result.stdout
+        assert "Plans are identical" in result.stdout
+
+    def test_compare_with_missing_feature(self, tmp_plans):
+        """Test detecting missing feature in auto plan."""
+        idea = Idea(title="Test Project", narrative="A test project", metrics=None)
+        product = Product(themes=[], releases=[])
+
+        feature1 = Feature(
+            key="FEATURE-001",
+            title="User Auth",
+            outcomes=["Secure login"],
+            acceptance=["Login works"],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        feature2 = Feature(
+            key="FEATURE-002",
+            title="Dashboard",
+            outcomes=["View metrics"],
+            acceptance=["Dashboard loads"],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        manual_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1, feature2],
+            metadata=None,
+            clarifications=None,
+        )
+
+        auto_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1],
+            metadata=None,
+            clarifications=None,
+        )
+
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+
+        dump_yaml(manual_plan.model_dump(exclude_none=True), manual_path)
+        dump_yaml(auto_plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            ["project", "plan", "compare", "--manual", str(manual_path), "--auto", str(auto_path)],
+        )
+
+        assert result.exit_code == 0  # Succeeds even with deviations
+        assert "1 deviation(s) found" in result.stdout
+        assert "FEATURE-002" in result.stdout
+        assert "HIGH" in result.stdout
+
+    def test_compare_code_vs_plan_alias(self, tmp_plans):
+        """Test --code-vs-plan convenience alias for code vs plan drift detection."""
+        idea = Idea(title="Test Project", narrative="A test project", metrics=None)
+        product = Product(themes=[], releases=[])
+
+        feature1 = Feature(
+            key="FEATURE-001",
+            title="User Auth",
+            outcomes=["Secure login"],
+            acceptance=["Login works"],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        feature2 = Feature(
+            key="FEATURE-002",
+            title="Dashboard",
+            outcomes=["View metrics"],
+            acceptance=["Dashboard loads"],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        manual_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1, feature2],
+            metadata=None,
+            clarifications=None,
+        )
+
+        auto_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1],
+            metadata=None,
+            clarifications=None,
+        )
+
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+
+        dump_yaml(manual_plan.model_dump(exclude_none=True), manual_path)
+        dump_yaml(auto_plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            ["project", "plan", "compare", "--code-vs-plan", "--manual", str(manual_path), "--auto", str(auto_path)],
+        )
+
+        assert result.exit_code == 0  # Succeeds even with deviations
+        assert "Code vs Plan Drift Detection" in result.stdout
+        assert "intended design" in result.stdout.lower()
+        assert "actual implementation" in result.stdout.lower()
+        assert "1 deviation(s) found" in result.stdout
+        assert "FEATURE-002" in result.stdout
+
+    def test_compare_with_extra_feature(self, tmp_plans):
+        """Test detecting extra feature in auto plan."""
+        idea = Idea(title="Test Project", narrative="A test project", metrics=None)
+        product = Product(themes=[], releases=[])
+
+        feature1 = Feature(
+            key="FEATURE-001",
+            title="User Auth",
+            outcomes=["Secure login"],
+            acceptance=["Login works"],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        feature2 = Feature(
+            key="FEATURE-002",
+            title="Dashboard",
+            outcomes=["View metrics"],
+            acceptance=["Dashboard loads"],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        manual_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1],
+            metadata=None,
+            clarifications=None,
+        )
+
+        auto_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1, feature2],
+            metadata=None,
+            clarifications=None,
+        )
+
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+
+        dump_yaml(manual_plan.model_dump(exclude_none=True), manual_path)
+        dump_yaml(auto_plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            ["project", "plan", "compare", "--manual", str(manual_path), "--auto", str(auto_path)],
+        )
+
+        assert result.exit_code == 0  # Succeeds even with deviations
+        assert "1 deviation(s) found" in result.stdout
+        assert "FEATURE-002" in result.stdout
+        assert "MEDIUM" in result.stdout
+
+    def test_compare_with_missing_story(self, tmp_plans):
+        """Test detecting missing story in feature."""
+        idea = Idea(title="Test Project", narrative="A test project", metrics=None)
+        product = Product(themes=[], releases=[])
+
+        story1 = Story(
+            key="STORY-001",
+            title="Login API",
+            acceptance=["API works"],
+            story_points=None,
+            value_points=None,
+            scenarios=None,
+            contracts=None,
+        )
+        story2 = Story(
+            key="STORY-002",
+            title="Login UI",
+            acceptance=["UI works"],
+            story_points=None,
+            value_points=None,
+            scenarios=None,
+            contracts=None,
+        )
+
+        feature_manual = Feature(
+            key="FEATURE-001",
+            title="User Auth",
+            outcomes=["Secure login"],
+            acceptance=["Login works"],
+            stories=[story1, story2],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        feature_auto = Feature(
+            key="FEATURE-001",
+            title="User Auth",
+            outcomes=["Secure login"],
+            acceptance=["Login works"],
+            stories=[story1],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        manual_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature_manual],
+            metadata=None,
+            clarifications=None,
+        )
+
+        auto_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature_auto],
+            metadata=None,
+            clarifications=None,
+        )
+
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+
+        dump_yaml(manual_plan.model_dump(exclude_none=True), manual_path)
+        dump_yaml(auto_plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            ["project", "plan", "compare", "--manual", str(manual_path), "--auto", str(auto_path)],
+        )
+
+        assert result.exit_code == 0  # Succeeds even with deviations
+        assert "1 deviation(s) found" in result.stdout
+        assert "STORY-002" in result.stdout
+
+    def test_compare_with_markdown_output(self, tmp_plans):
+        """Test generating markdown report."""
+        idea = Idea(title="Test Project", narrative="A test project", metrics=None)
+        product = Product(themes=[], releases=[])
+
+        feature1 = Feature(
+            key="FEATURE-001",
+            title="Auth",
+            outcomes=[],
+            acceptance=[],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+        feature2 = Feature(
+            key="FEATURE-002",
+            title="Dashboard",
+            outcomes=[],
+            acceptance=[],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        manual_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1],
+            metadata=None,
+            clarifications=None,
+        )
+
+        auto_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1, feature2],
+            metadata=None,
+            clarifications=None,
+        )
+
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+        report_path = tmp_plans / "report.md"
+
+        dump_yaml(manual_plan.model_dump(exclude_none=True), manual_path)
+        dump_yaml(auto_plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "plan",
+                "compare",
+                "--manual",
+                str(manual_path),
+                "--auto",
+                str(auto_path),
+                "--output-format",
+                "markdown",
+                "--out",
+                str(report_path),
+            ],
+        )
+
+        assert result.exit_code == 0  # Succeeds even with deviations
+        assert report_path.exists()
+        assert "Report written to" in result.stdout
+
+        # Verify report content
+        content = report_path.read_text()
+        assert "# Deviation Report" in content
+        assert "FEATURE-002" in content
+
+    def test_compare_with_json_output(self, tmp_plans):
+        """Test generating JSON report."""
+        idea = Idea(title="Test Project", narrative="A test project", metrics=None)
+        product = Product(themes=[], releases=[])
+
+        feature1 = Feature(
+            key="FEATURE-001",
+            title="Auth",
+            outcomes=[],
+            acceptance=[],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+        feature2 = Feature(
+            key="FEATURE-002",
+            title="Dashboard",
+            outcomes=[],
+            acceptance=[],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        manual_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1],
+            metadata=None,
+            clarifications=None,
+        )
+
+        auto_plan = PlanBundle(
+            version="1.0",
+            idea=idea,
+            business=None,
+            product=product,
+            features=[feature1, feature2],
+            metadata=None,
+            clarifications=None,
+        )
+
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+        report_path = tmp_plans / "report.json"
+
+        dump_yaml(manual_plan.model_dump(exclude_none=True), manual_path)
+        dump_yaml(auto_plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "plan",
+                "compare",
+                "--manual",
+                str(manual_path),
+                "--auto",
+                str(auto_path),
+                "--output-format",
+                "json",
+                "--out",
+                str(report_path),
+            ],
+        )
+
+        assert result.exit_code == 0  # Succeeds even with deviations
+        assert report_path.exists()
+
+        # Verify JSON can be loaded
+        import json
+
+        data = json.loads(report_path.read_text())
+        assert "manual_plan" in data
+        assert "auto_plan" in data
+        assert "deviations" in data
+        assert len(data["deviations"]) == 1
+
+    def test_compare_invalid_manual_plan(self, tmp_plans):
+        """Test error handling for invalid manual plan."""
+        manual_path = tmp_plans / "nonexistent.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+
+        # Create valid auto plan
+        idea = Idea(title="Test", narrative="Test", metrics=None)
+        product = Product(themes=[], releases=[])
+        plan = PlanBundle(
+            version="1.0", idea=idea, business=None, product=product, features=[], metadata=None, clarifications=None
+        )
+        dump_yaml(plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            ["project", "plan", "compare", "--manual", str(manual_path), "--auto", str(auto_path)],
+        )
+
+        assert result.exit_code == 1  # Error: file not found
+        assert "Manual plan not found" in result.stdout
+
+    def test_compare_invalid_auto_plan(self, tmp_plans):
+        """Test error handling for invalid auto plan."""
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "nonexistent.yaml"
+
+        # Create valid manual plan
+        idea = Idea(title="Test", narrative="Test", metrics=None)
+        product = Product(themes=[], releases=[])
+        plan = PlanBundle(
+            version="1.0", idea=idea, business=None, product=product, features=[], metadata=None, clarifications=None
+        )
+        dump_yaml(plan.model_dump(exclude_none=True), manual_path)
+
+        result = runner.invoke(
+            app,
+            ["project", "plan", "compare", "--manual", str(manual_path), "--auto", str(auto_path)],
+        )
+
+        assert result.exit_code == 1  # Error: file not found
+        assert "Auto plan not found" in result.stdout
+
+    def test_compare_multiple_deviations(self, tmp_plans):
+        """Test detecting multiple deviations at once."""
+        idea1 = Idea(title="Project A", narrative="Original", metrics=None)
+        idea2 = Idea(title="Project B", narrative="Modified", metrics=None)
+
+        product1 = Product(themes=["AI"], releases=[])
+        product2 = Product(themes=["ML"], releases=[])
+
+        feature1 = Feature(
+            key="FEATURE-001",
+            title="Auth",
+            outcomes=[],
+            acceptance=[],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+        feature2 = Feature(
+            key="FEATURE-002",
+            title="Dashboard",
+            outcomes=[],
+            acceptance=[],
+            stories=[],
+            source_tracking=None,
+            contract=None,
+            protocol=None,
+        )
+
+        manual_plan = PlanBundle(
+            version="1.0",
+            idea=idea1,
+            business=None,
+            product=product1,
+            features=[feature1],
+            metadata=None,
+            clarifications=None,
+        )
+
+        auto_plan = PlanBundle(
+            version="1.0",
+            idea=idea2,
+            business=None,
+            product=product2,
+            features=[feature1, feature2],
+            metadata=None,
+            clarifications=None,
+        )
+
+        manual_path = tmp_plans / "manual.yaml"
+        auto_path = tmp_plans / "auto.yaml"
+
+        dump_yaml(manual_plan.model_dump(exclude_none=True), manual_path)
+        dump_yaml(auto_plan.model_dump(exclude_none=True), auto_path)
+
+        result = runner.invoke(
+            app,
+            ["project", "plan", "compare", "--manual", str(manual_path), "--auto", str(auto_path)],
+        )
+
+        assert result.exit_code == 0  # Succeeds even with deviations
+        assert "deviation(s) found" in result.stdout
+        # Should detect: idea title mismatch, theme mismatch, extra feature
+        assert int(result.stdout.split("deviation(s) found")[0].split()[-1]) >= 3

--- a/tests/integration/specfact_project/test_plan_upgrade_from_core.py
+++ b/tests/integration/specfact_project/test_plan_upgrade_from_core.py
@@ -1,0 +1,227 @@
+# pylint: skip-file
+"""
+Integration tests for plan bundle upgrade command.
+"""
+
+import pytest
+import yaml
+from specfact_cli.cli import app
+from specfact_cli.utils.yaml_utils import load_yaml
+from typer.testing import CliRunner
+
+
+pytestmark = pytest.mark.skip(
+    reason="Retired during module-migration-07: legacy 'project plan upgrade' topology is no longer part of supported CLI surface."
+)
+
+
+runner = CliRunner()
+
+
+class TestPlanUpgrade:
+    """Integration tests for plan upgrade command."""
+
+    def test_upgrade_active_plan_dry_run(self, tmp_path, monkeypatch):
+        """Test upgrading active plan in dry-run mode."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create .specfact structure with modular bundle
+        projects_dir = tmp_path / ".specfact" / "projects"
+        projects_dir.mkdir(parents=True)
+        bundle_dir = projects_dir / "test-bundle"
+        bundle_dir.mkdir()
+
+        # Create bundle manifest with old schema (1.0, no summary)
+        manifest_path = bundle_dir / "bundle.manifest.yaml"
+        plan_data = {
+            "version": "1.0",
+            "product": {"themes": ["Theme1"]},
+            "features": [{"key": "FEATURE-001", "title": "Feature 1"}],
+        }
+        with manifest_path.open("w") as f:
+            yaml.dump(plan_data, f)
+
+        # Set active bundle
+        config_path = tmp_path / ".specfact" / "config.yaml"
+        with config_path.open("w") as f:
+            yaml.dump({"active_bundle": "test-bundle"}, f)
+
+        # Run upgrade in dry-run mode
+        result = runner.invoke(app, ["project", "plan", "upgrade", "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Would upgrade" in result.stdout or "upgrade" in result.stdout.lower()
+        assert "dry run" in result.stdout.lower()
+
+        # Verify plan wasn't changed (dry run)
+        plan_data_after = load_yaml(manifest_path)
+        assert plan_data_after.get("version") == "1.0"
+
+    def test_upgrade_active_plan_actual(self, tmp_path, monkeypatch):
+        """Test actually upgrading active plan."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create .specfact structure with modular bundle
+        projects_dir = tmp_path / ".specfact" / "projects"
+        projects_dir.mkdir(parents=True)
+        bundle_dir = projects_dir / "test-bundle"
+        bundle_dir.mkdir()
+
+        # Create bundle manifest with old schema (1.0, no summary)
+        manifest_path = bundle_dir / "bundle.manifest.yaml"
+        plan_data = {
+            "version": "1.0",
+            "product": {"themes": ["Theme1"]},
+            "features": [{"key": "FEATURE-001", "title": "Feature 1"}],
+        }
+        with manifest_path.open("w") as f:
+            yaml.dump(plan_data, f)
+
+        # Set active bundle
+        config_path = tmp_path / ".specfact" / "config.yaml"
+        with config_path.open("w") as f:
+            yaml.dump({"active_bundle": "test-bundle"}, f)
+
+        # Run upgrade
+        result = runner.invoke(app, ["project", "plan", "upgrade"])
+
+        assert result.exit_code == 0
+        assert "Upgraded" in result.stdout or "upgrade" in result.stdout.lower()
+
+        # Verify plan was updated
+        plan_data_after = load_yaml(manifest_path)
+        assert plan_data_after.get("version") == "1.1"
+        assert "summary" in plan_data_after.get("metadata", {})
+
+    def test_upgrade_specific_plan(self, tmp_path, monkeypatch):
+        """Test upgrading a specific plan by path."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create a plan bundle with old schema
+        plan_path = tmp_path / "test.bundle.yaml"
+        plan_data = {
+            "version": "1.0",
+            "product": {"themes": ["Theme1"]},
+            "features": [],
+        }
+        with plan_path.open("w") as f:
+            yaml.dump(plan_data, f)
+
+        # Run upgrade on specific plan
+        result = runner.invoke(app, ["project", "plan", "upgrade", "--plan", str(plan_path)])
+
+        assert result.exit_code == 0
+
+        # Verify plan was updated
+        plan_data_after = load_yaml(plan_path)
+        assert plan_data_after.get("version") == "1.1"
+
+    def test_upgrade_all_plans(self, tmp_path, monkeypatch):
+        """Test upgrading all plans."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create .specfact structure
+        plans_dir = tmp_path / ".specfact" / "plans"
+        plans_dir.mkdir(parents=True)
+
+        # Create multiple plan bundles with old schema
+        for i in range(3):
+            plan_path = plans_dir / f"plan{i}.bundle.yaml"
+            plan_data = {
+                "version": "1.0",
+                "product": {"themes": [f"Theme{i}"]},
+                "features": [],
+            }
+            with plan_path.open("w") as f:
+                yaml.dump(plan_data, f)
+
+        # Run upgrade on all plans
+        result = runner.invoke(app, ["project", "plan", "upgrade", "--all"])
+
+        assert result.exit_code == 0
+        assert "3" in result.stdout or "upgraded" in result.stdout.lower()
+
+        # Verify all plans were updated
+        for i in range(3):
+            plan_path = plans_dir / f"plan{i}.bundle.yaml"
+            plan_data_after = load_yaml(plan_path)
+            assert plan_data_after.get("version") == "1.1"
+
+    def test_upgrade_already_up_to_date(self, tmp_path, monkeypatch):
+        """Test upgrading a plan that's already up to date."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create .specfact structure with modular bundle
+        projects_dir = tmp_path / ".specfact" / "projects"
+        projects_dir.mkdir(parents=True)
+        bundle_dir = projects_dir / "test-bundle"
+        bundle_dir.mkdir()
+
+        # Create a plan bundle with current schema (1.1, with summary)
+        from specfact_cli.generators.plan_generator import PlanGenerator
+        from specfact_cli.models.plan import PlanBundle, Product
+
+        product = Product(themes=["Theme1"])
+        bundle = PlanBundle(
+            version="1.1",
+            product=product,
+            features=[],
+            idea=None,
+            business=None,
+            metadata=None,
+            clarifications=None,
+        )
+        bundle.update_summary(include_hash=True)
+
+        manifest_path = bundle_dir / "bundle.manifest.yaml"
+        generator = PlanGenerator()
+        generator.generate(bundle, manifest_path, update_summary=True)
+
+        # Set active bundle
+        config_path = tmp_path / ".specfact" / "config.yaml"
+        with config_path.open("w") as f:
+            yaml.dump({"active_bundle": "test-bundle"}, f)
+
+        # Run upgrade
+        result = runner.invoke(app, ["project", "plan", "upgrade"])
+
+        assert result.exit_code == 0
+        assert "up to date" in result.stdout.lower() or "Up to date" in result.stdout
+
+    def test_upgrade_plan_missing_product_field(self, tmp_path, monkeypatch):
+        """Test upgrading a plan bundle with missing product field (backward compatibility)."""
+        monkeypatch.chdir(tmp_path)
+
+        # Create .specfact structure with modular bundle
+        projects_dir = tmp_path / ".specfact" / "projects"
+        projects_dir.mkdir(parents=True)
+        bundle_dir = projects_dir / "test-bundle"
+        bundle_dir.mkdir()
+
+        # Create bundle manifest without product field (old schema)
+        manifest_path = bundle_dir / "bundle.manifest.yaml"
+        plan_data = {
+            "version": "1.0",
+            "features": [{"key": "FEATURE-001", "title": "Feature 1"}],
+        }
+        with manifest_path.open("w") as f:
+            yaml.dump(plan_data, f)
+
+        # Set active bundle
+        config_path = tmp_path / ".specfact" / "config.yaml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with config_path.open("w") as f:
+            yaml.dump({"active_bundle": "test-bundle"}, f)
+
+        # Run upgrade
+        result = runner.invoke(app, ["project", "plan", "upgrade"])
+
+        assert result.exit_code == 0
+        assert "Upgraded" in result.stdout or "upgrade" in result.stdout.lower()
+
+        # Verify plan was updated with default product
+        plan_data_after = load_yaml(manifest_path)
+        assert plan_data_after.get("version") == "1.1"
+        assert "product" in plan_data_after
+        assert plan_data_after["product"] == {"themes": [], "releases": []}
+        assert "summary" in plan_data_after.get("metadata", {})


### PR DESCRIPTION
## Summary
- migrate module-owned project plan integration tests from core to modules repo
- mark legacy topology assertions as retired where no supported runtime command exists
- harden modules test conftest import resolution to avoid cross-repo import shadowing

## Validation
- hatch run type-check
- hatch run lint
- hatch run contract-test
- hatch run test -q (141 passed, 16 skipped)
