### PR TITLE
fix(backlog): required ADO custom fields + decoupled modules publish workflow

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -1,0 +1,236 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: publish-modules
+
+on:
+  push:
+    branches: [dev, main]
+  workflow_dispatch:
+    inputs:
+      bundles:
+        description: "Comma-separated bundle names (for example: specfact-backlog,specfact-project). Empty = auto-detect."
+        required: false
+        default: ""
+      dry_run:
+        description: "Prepare registry changes but do not push commit"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-modules-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install publish dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml packaging
+
+      - name: Resolve publish bundle set
+        id: bundles
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_BUNDLES: ${{ github.event.inputs.bundles }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          def normalize_bundle(name: str) -> str:
+            cleaned = name.strip()
+            if not cleaned:
+              return ""
+            if not cleaned.startswith("specfact-"):
+              cleaned = f"specfact-{cleaned}"
+            return cleaned
+
+          event_name = os.environ.get("EVENT_NAME", "")
+          dispatch_bundles = os.environ.get("DISPATCH_BUNDLES", "").strip()
+          bundles: list[str] = []
+
+          if event_name == "workflow_dispatch" and dispatch_bundles:
+            bundles = [normalize_bundle(part) for part in dispatch_bundles.split(",")]
+            bundles = sorted({bundle for bundle in bundles if bundle})
+          else:
+            before_sha = os.environ.get("BEFORE_SHA", "").strip()
+            after_sha = os.environ.get("AFTER_SHA", "").strip() or "HEAD"
+            if not before_sha or before_sha == "0000000000000000000000000000000000000000":
+              before_sha = "HEAD~1"
+
+            try:
+              changed = subprocess.check_output(
+                ["git", "diff", "--name-only", before_sha, after_sha, "--", "packages"],
+                text=True,
+              ).splitlines()
+            except subprocess.CalledProcessError:
+              changed = []
+
+            seen: set[str] = set()
+            for path in changed:
+              parts = Path(path).parts
+              if len(parts) < 2:
+                continue
+              if parts[0] != "packages":
+                continue
+              bundle = parts[1]
+              if not bundle.startswith("specfact-"):
+                continue
+              seen.add(bundle)
+            bundles = sorted(seen)
+
+          out_path = Path(os.environ["GITHUB_OUTPUT"])
+          out_path.write_text(
+            f"bundles_json={json.dumps(bundles)}\ncount={len(bundles)}\n",
+            encoding="utf-8",
+          )
+          print(f"Resolved bundles: {bundles}")
+          PY
+
+      - name: Publish changed bundles into registry
+        if: steps.bundles.outputs.count != '0'
+        env:
+          BUNDLES_JSON: ${{ steps.bundles.outputs.bundles_json }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import subprocess
+          import tarfile
+          from pathlib import Path
+
+          import yaml
+
+          repo_root = Path(".").resolve()
+          import os
+
+          bundles = json.loads(os.environ["BUNDLES_JSON"])
+          registry_index_path = repo_root / "registry" / "index.json"
+          registry_modules_dir = repo_root / "registry" / "modules"
+          registry_signatures_dir = repo_root / "registry" / "signatures"
+          registry_modules_dir.mkdir(parents=True, exist_ok=True)
+          registry_signatures_dir.mkdir(parents=True, exist_ok=True)
+
+          registry = json.loads(registry_index_path.read_text(encoding="utf-8"))
+          modules = registry.get("modules")
+          if not isinstance(modules, list):
+            raise ValueError("registry/index.json must contain a 'modules' list")
+
+          ignored_dir_names = {".git", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "logs"}
+          ignored_suffixes = {".pyc", ".pyo"}
+
+          for bundle in bundles:
+            # Keep existing monotonic version guard logic.
+            subprocess.run(
+              ["python", "scripts/publish-module.py", "--bundle", bundle, "--repo-root", "."],
+              check=True,
+            )
+
+            bundle_dir = repo_root / "packages" / bundle
+            manifest_path = bundle_dir / "module-package.yaml"
+            if not manifest_path.exists():
+              raise FileNotFoundError(f"Missing manifest: {manifest_path}")
+
+            manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+            if not isinstance(manifest, dict):
+              raise ValueError(f"Invalid manifest content: {manifest_path}")
+
+            module_id = str(manifest.get("name") or f"nold-ai/{bundle}")
+            version = str(manifest.get("version") or "").strip()
+            if not version:
+              raise ValueError(f"Manifest missing version: {manifest_path}")
+
+            artifact_name = f"{bundle}-{version}.tar.gz"
+            artifact_path = registry_modules_dir / artifact_name
+            signature_path = registry_signatures_dir / f"{bundle}-{version}.tar.sig"
+
+            with tarfile.open(artifact_path, mode="w:gz") as tar:
+              for path in sorted(bundle_dir.rglob("*")):
+                if not path.is_file():
+                  continue
+                rel = path.relative_to(bundle_dir)
+                if any(part in ignored_dir_names for part in rel.parts):
+                  continue
+                if path.suffix.lower() in ignored_suffixes:
+                  continue
+                tar.add(path, arcname=f"{bundle}/{rel.as_posix()}")
+
+            digest = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+            (artifact_path.with_suffix(artifact_path.suffix + ".sha256")).write_text(f"{digest}\n", encoding="utf-8")
+
+            integrity = manifest.get("integrity")
+            if isinstance(integrity, dict):
+              signature_text = str(integrity.get("signature") or "").strip()
+              if signature_text:
+                signature_path.write_text(signature_text + "\n", encoding="utf-8")
+
+            entry = next(
+              (
+                item
+                for item in modules
+                if isinstance(item, dict) and str(item.get("id") or "").strip() == module_id
+              ),
+              None,
+            )
+            if entry is None:
+              entry = {"id": module_id}
+              modules.append(entry)
+
+            entry["latest_version"] = version
+            entry["download_url"] = f"modules/{artifact_name}"
+            entry["checksum_sha256"] = digest
+            if "tier" in manifest:
+              entry["tier"] = manifest["tier"]
+            if "publisher" in manifest:
+              entry["publisher"] = manifest["publisher"]
+            if "bundle_dependencies" in manifest:
+              entry["bundle_dependencies"] = manifest["bundle_dependencies"]
+            if "description" in manifest:
+              entry["description"] = manifest["description"]
+
+            print(f"Published registry artifact for {module_id} v{version}")
+
+          registry_index_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Commit registry updates
+        if: steps.bundles.outputs.count != '0'
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          if git diff --quiet -- registry/index.json registry/modules registry/signatures; then
+            echo "No registry changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add registry/index.json registry/modules registry/signatures
+          git commit -m "chore(registry): publish changed modules [skip ci]"
+
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            echo "Dry run enabled; skipping push."
+            exit 0
+          fi
+
+          git push

--- a/docs/guides/publishing-modules.md
+++ b/docs/guides/publishing-modules.md
@@ -7,7 +7,7 @@ description: Package and publish SpecFact modules to a registry (tarball, checks
 
 # Publishing modules
 
-This guide describes how to package a SpecFact module for registry publishing: validate structure, create a tarball and checksum, optionally sign the manifest, and automate via CI.
+This guide describes how SpecFact modules are validated and published into this repository's registry (`registry/index.json`, `registry/modules/`, `registry/signatures/`).
 
 ## Module structure
 
@@ -30,32 +30,19 @@ Exclude from the package: `.git`, `__pycache__`, `tests`, `.pytest_cache`, `*.py
 
 ## Script: publish-module.py
 
-Use `scripts/publish-module.py` to validate, package, and optionally sign a module.
+Use `scripts/publish-module.py` as a publish pre-check (monotonic version and manifest/registry consistency):
 
 ```bash
-# Basic: create tarball and SHA-256 checksum
-python scripts/publish-module.py path/to/module -o dist
-
-# Write a registry index fragment (for merging into your registry index)
-python scripts/publish-module.py path/to/module -o dist \
-  --index-fragment dist/entry.yaml \
-  --download-base-url https://registry.example.com/packages/
-
-# Sign the manifest after packaging (requires key)
-python scripts/publish-module.py path/to/module -o dist --sign
-python scripts/publish-module.py path/to/module -o dist --sign --key-file /path/to/private.pem
+python scripts/publish-module.py --bundle specfact-backlog
+python scripts/publish-module.py --bundle backlog
 ```
 
-Options:
+The script validates:
 
-- `module_path`: Path to the module directory or to `module-package.yaml`.
-- `-o` / `--output-dir`: Directory for `<name>-<version>.tar.gz` and `<name>-<version>.tar.gz.sha256`.
-- `--sign`: Run `scripts/sign-modules.py` on the manifest (uses `SPECFACT_MODULE_PRIVATE_SIGN_KEY` or `--key-file`).
-- `--key-file`: Path to PEM private key when using `--sign`.
-- `--index-fragment`: Write a single-module index entry (id, latest_version, download_url, checksum_sha256) to the given path.
-- `--download-base-url`: Base URL for `download_url` in the index fragment.
-
-Namespace and marketplace: If the manifest has `publisher` or `tier`, the script requires `name` in `namespace/name` form and validates format (`^[a-z][a-z0-9-]*/[a-z][a-z0-9-]+$`).
+- target bundle exists under `packages/`
+- manifest version is valid
+- manifest version is greater than current `registry/index.json` `latest_version`
+- `core_compatibility` is present/reviewed (warning)
 
 ## Signing (optional)
 
@@ -68,10 +55,16 @@ For runtime verification, sign the manifest so the tarball includes integrity me
 
 Repository workflow `.github/workflows/publish-modules.yml`:
 
-- **Triggers**: Push to tags matching `*-v*` (e.g. `backlog-v0.29.0`) or manual `workflow_dispatch` with input `module_path`.
-- **Steps**: Checkout → resolve module path from tag → optional **Sign module manifest** (when secrets are set) → run `publish-module.py` → upload `dist/*.tar.gz` and `dist/*.sha256` as artifacts.
-
-Optional signing in CI: Add repository secrets `SPECFACT_MODULE_PRIVATE_SIGN_KEY` and `SPECFACT_MODULE_PRIVATE_SIGN_KEY_PASSPHRASE`. The workflow signs the manifest before packaging when the key secret is present.
+- **Triggers**:
+  - Push to `dev` and `main` (decoupled modules release flow)
+  - Manual `workflow_dispatch` with optional `bundles` input
+- **Flow**:
+  - Detect changed bundles (or use manual bundle list)
+  - Run `scripts/publish-module.py --bundle <name>` pre-check for each bundle
+  - Package bundle into `registry/modules/<bundle>-<version>.tar.gz`
+  - Update `registry/index.json` (`latest_version`, `download_url`, `checksum_sha256`, metadata)
+  - Persist manifest signature copy to `registry/signatures/<bundle>-<version>.tar.sig` when present
+  - Commit/push registry updates back to the same branch
 
 ## Best practices
 

--- a/packages/specfact-backlog/module-package.yaml
+++ b/packages/specfact-backlog/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-backlog
-version: 0.40.16
+version: 0.40.17
 commands:
   - backlog
 tier: official
@@ -12,5 +12,5 @@ description: Official SpecFact backlog bundle package.
 category: backlog
 bundle_group_command: backlog
 integrity:
-  checksum: sha256:4741ab211456ac7892fa1292d3e5c036beb10ba130be0bdce2b45c39ad8cb89e
-  signature: B1sq25Zc4SLOSOtQdSffud4FcNqH7fpkyP7nkHJxhkAuqeS1cnTdExmTGwa7ccYHnR6WMWLy3ILATOlbf2JVAg==
+  checksum: sha256:d3261d72a6357568a945e160ee1dbda56f764147ca9eef2db0508e0a9153753c
+  signature: cc7VjB1hIbwongIzeamRsMu4i6aEUVdYDKZBif4nnLrB9SGBbDSWzvpsjAS1/eyQ3ZtIYjFcZfBIhDBM1bQuDg==

--- a/packages/specfact-backlog/src/specfact_backlog/backlog/commands.py
+++ b/packages/specfact-backlog/src/specfact_backlog/backlog/commands.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import click
 import typer
@@ -4413,6 +4413,11 @@ def map_fields(
     reset: bool = typer.Option(
         False, "--reset", help="Reset custom field mapping to defaults (deletes ado_custom.yaml)"
     ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Auto-map fields without prompts; fails with guidance when required fields cannot be resolved",
+    ),
 ) -> None:
     """
     Interactive command to map ADO fields to canonical field names.
@@ -4498,6 +4503,12 @@ def map_fields(
             selected_providers = ["ado"]
         elif github_project_id or github_project_v2_id or github_type_field_id or github_type_option:
             selected_providers = ["github"]
+        elif non_interactive:
+            console.print(
+                "[red]Error:[/red] Non-interactive mode requires explicit provider selection "
+                "(for example: --provider ado)."
+            )
+            raise typer.Exit(1)
         else:
             try:
                 import questionary  # type: ignore[reportMissingImports]
@@ -5273,13 +5284,18 @@ def map_fields(
         except Exception as e:
             console.print(f"[yellow]⚠[/yellow] Failed to load existing mapping: {e}")
 
-    try:
-        import questionary  # type: ignore[reportMissingImports]
-    except ImportError:
-        console.print(
-            "[red]Interactive field mapping requires the 'questionary' package. Install with: pip install questionary[/red]"
-        )
-        raise typer.Exit(1) from None
+    questionary: Any | None = None
+    if not non_interactive:
+        try:
+            import questionary as questionary_module  # type: ignore[reportMissingImports]
+
+            questionary = questionary_module
+        except ImportError:
+            console.print(
+                "[red]Interactive field mapping requires the 'questionary' package. "
+                "Install with: pip install questionary[/red]"
+            )
+            raise typer.Exit(1) from None
 
     allowed_frameworks = ["scrum", "agile", "safe", "kanban", "default"]
 
@@ -5323,7 +5339,10 @@ def map_fields(
     )
     framework_default = selected_framework or detected_framework or existing_framework or "default"
 
-    if not selected_framework:
+    if not selected_framework and non_interactive:
+        selected_framework = framework_default
+    elif not selected_framework:
+        assert questionary is not None
         framework_choices: list[Any] = []
         for option in allowed_frameworks:
             label = option
@@ -5354,6 +5373,105 @@ def map_fields(
     framework_field_mappings = framework_template.get("field_mappings", {})
     framework_work_item_type_mappings = framework_template.get("work_item_type_mappings", {})
 
+    def _to_canonical_key(field_name: str, fallback_ref: str) -> str:
+        source = (field_name or fallback_ref.split(".")[-1] or fallback_ref).strip().lower()
+        normalized = re.sub(r"[^a-z0-9]+", "_", source).strip("_")
+        if not normalized:
+            normalized = "custom_field"
+        candidate = normalized
+        idx = 2
+        while candidate in canonical_fields:
+            candidate = f"{normalized}_{idx}"
+            idx += 1
+        return candidate
+
+    def _fetch_ado_work_item_types() -> list[str]:
+        work_item_types_url = f"{base_url}/{ado_org}/{ado_project}/_apis/wit/workitemtypes?api-version=7.1"
+        response = requests.get(work_item_types_url, headers=headers, timeout=30)
+        response.raise_for_status()
+        payload = response.json()
+        nodes = payload.get("value", [])
+        return [
+            str(node.get("name") or "").strip()
+            for node in nodes
+            if isinstance(node, dict) and str(node.get("name") or "").strip()
+        ]
+
+    def _extract_allowed_values(raw_allowed: Any) -> list[str]:
+        if not isinstance(raw_allowed, list):
+            return []
+        values: list[str] = []
+        for entry in raw_allowed:
+            if isinstance(entry, dict):
+                value = str(entry.get("value") or entry.get("name") or "").strip()
+            else:
+                value = str(entry or "").strip()
+            if value and value not in values:
+                values.append(value)
+        return values
+
+    def _fetch_allowed_values_for_picklist(picklist_id: str) -> list[str]:
+        if not picklist_id:
+            return []
+        url = f"{base_url}/{ado_org}/_apis/work/processes/lists/{quote(picklist_id, safe='')}?api-version=7.1"
+        try:
+            response = requests.get(url, headers=headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+        except requests.exceptions.RequestException:
+            return []
+        if not isinstance(payload, dict):
+            return []
+        return _extract_allowed_values(payload.get("items"))
+
+    def _fetch_allowed_values_for_field(field_ref: str) -> list[str]:
+        encoded_ref = quote(field_ref, safe="")
+        url = f"{base_url}/{ado_org}/{ado_project}/_apis/wit/fields/{encoded_ref}?api-version=7.1"
+        try:
+            response = requests.get(url, headers=headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+        except requests.exceptions.RequestException:
+            return []
+        if not isinstance(payload, dict):
+            return []
+        allowed_values = _extract_allowed_values(payload.get("allowedValues"))
+        if allowed_values:
+            return allowed_values
+        picklist_id = str(payload.get("picklistId") or "").strip()
+        if not picklist_id:
+            return []
+        return _fetch_allowed_values_for_picklist(picklist_id)
+
+    def _fetch_work_item_type_field_metadata(work_item_type: str) -> tuple[list[str], dict[str, list[str]], list[str]]:
+        encoded_type = quote(work_item_type, safe="")
+        url = f"{base_url}/{ado_org}/{ado_project}/_apis/wit/workitemtypes/{encoded_type}/fields?api-version=7.1"
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        payload = response.json()
+        nodes = payload.get("value", [])
+        required_refs: list[str] = []
+        allowed_values_by_field: dict[str, list[str]] = {}
+        unresolved_required: list[str] = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            ref_name = str(node.get("referenceName") or "").strip()
+            display_name = str(node.get("name") or ref_name or "<unknown>").strip()
+            always_required = bool(node.get("alwaysRequired"))
+            if always_required and not ref_name:
+                unresolved_required.append(display_name)
+            if not ref_name:
+                continue
+            allowed_values = _extract_allowed_values(node.get("allowedValues"))
+            if not allowed_values and ref_name:
+                allowed_values = _fetch_allowed_values_for_field(ref_name)
+            if allowed_values:
+                allowed_values_by_field[ref_name] = allowed_values
+            if always_required:
+                required_refs.append(ref_name)
+        return required_refs, allowed_values_by_field, unresolved_required
+
     # Canonical fields to map
     canonical_fields = {
         "description": "Description",
@@ -5363,6 +5481,68 @@ def map_fields(
         "priority": "Priority",
         "work_item_type": "Work Item Type",
     }
+
+    selected_work_item_type = ""
+    required_fields_for_selected_type: list[str] = []
+    allowed_values_for_selected_type: dict[str, list[str]] = {}
+    unresolved_required_fields: list[str] = []
+    required_custom_canonical_by_ref: dict[str, str] = {}
+
+    work_item_type_options: list[str] = []
+    try:
+        work_item_type_options = _fetch_ado_work_item_types()
+    except requests.exceptions.RequestException:
+        work_item_type_options = []
+
+    default_story_type = ""
+    if isinstance(framework_work_item_type_mappings, dict):
+        default_story_type = str(framework_work_item_type_mappings.get("story") or "").strip()
+
+    if work_item_type_options:
+        if default_story_type and default_story_type in work_item_type_options:
+            selected_work_item_type = default_story_type
+        else:
+            preferred_work_item_types = [
+                "Product Backlog Item",
+                "User Story",
+                "Story",
+                "Feature",
+                "Issue",
+                "Task",
+                "Bug",
+            ]
+            by_lower = {item.lower(): item for item in work_item_type_options}
+            selected_work_item_type = next(
+                (by_lower[name.lower()] for name in preferred_work_item_types if name.lower() in by_lower),
+                work_item_type_options[0],
+            )
+
+        if not non_interactive:
+            assert questionary is not None
+            try:
+                picked_work_item_type = questionary.select(
+                    "Select ADO work item type for required-field validation metadata",
+                    choices=work_item_type_options,
+                    default=selected_work_item_type,
+                    use_arrow_keys=True,
+                    use_jk_keys=False,
+                ).ask()
+                selected_work_item_type = str(picked_work_item_type or selected_work_item_type).strip()
+            except (KeyboardInterrupt, EOFError):
+                console.print("\n[yellow]Selection cancelled.[/yellow]")
+                raise typer.Exit(0) from None
+
+    if selected_work_item_type:
+        try:
+            (
+                required_fields_for_selected_type,
+                allowed_values_for_selected_type,
+                unresolved_required_fields,
+            ) = _fetch_work_item_type_field_metadata(selected_work_item_type)
+        except requests.exceptions.RequestException:
+            required_fields_for_selected_type = []
+            allowed_values_for_selected_type = {}
+            unresolved_required_fields = []
 
     # Load default mappings from AdoFieldMapper
     from specfact_backlog.backlog.mappers.ado_mapper import AdoFieldMapper
@@ -5411,100 +5591,137 @@ def map_fields(
     # Then override with existing mappings
     combined_mapping.update(existing_mapping)
 
-    # Interactive mapping
-    console.print()
-    console.print(Panel("[bold cyan]Interactive Field Mapping[/bold cyan]", border_style="cyan"))
-    console.print("[dim]Use ↑↓ to navigate, ⏎ to select. Map ADO fields to canonical field names.[/dim]")
-    console.print()
+    # Ensure required custom fields are represented in canonical mapping candidates.
+    field_by_ref: dict[str, dict[str, Any]] = {
+        str(field.get("referenceName") or "").strip(): field
+        for field in relevant_fields
+        if isinstance(field, dict) and str(field.get("referenceName") or "").strip()
+    }
+    for required_ref in required_fields_for_selected_type:
+        if not required_ref:
+            continue
+        if required_ref in combined_mapping:
+            continue
+        field_meta = field_by_ref.get(required_ref, {})
+        display_name = str(field_meta.get("name") or required_ref).strip()
+        canonical_key = _to_canonical_key(display_name, required_ref)
+        required_custom_canonical_by_ref[required_ref] = canonical_key
+        canonical_fields[canonical_key] = f"{display_name} (required custom)"
+        combined_mapping[required_ref] = canonical_key
 
-    new_mapping: dict[str, str] = {}
-
-    # Build choice list with display names
-    field_choices_display: list[str] = ["<no mapping>"]
-    field_choices_refs: list[str] = ["<no mapping>"]
-    for field in relevant_fields:
-        ref_name = field.get("referenceName", "")
-        name = field.get("name", ref_name)
-        display = f"{ref_name} ({name})"
-        field_choices_display.append(display)
-        field_choices_refs.append(ref_name)
-
-    for canonical_field, display_name in canonical_fields.items():
-        # Find current mapping (existing > default)
-        current_ado_fields = [
-            ado_field for ado_field, canonical in combined_mapping.items() if canonical == canonical_field
-        ]
-
-        # Determine default selection
-        default_selection = "<no mapping>"
-        if current_ado_fields:
-            # Find the current mapping in the choices list
-            current_ref = current_ado_fields[0]
-            if current_ref in field_choices_refs:
-                default_selection = field_choices_display[field_choices_refs.index(current_ref)]
-            else:
-                # If current mapping not in available fields, use "<no mapping>"
-                default_selection = "<no mapping>"
-
-        # Use interactive selection menu with questionary
-        console.print(f"[bold]{display_name}[/bold] (canonical: {canonical_field})")
-        if current_ado_fields:
-            console.print(f"[dim]Current: {', '.join(current_ado_fields)}[/dim]")
-        else:
-            console.print("[dim]Current: <no mapping>[/dim]")
-
-        # Find default index
-        default_index = 0
-        if default_selection != "<no mapping>" and default_selection in field_choices_display:
-            default_index = field_choices_display.index(default_selection)
-
-        # Use questionary for interactive selection with arrow keys
-        try:
-            selected_display = questionary.select(
-                f"Select ADO field for {display_name}",
-                choices=field_choices_display,
-                default=field_choices_display[default_index] if default_index < len(field_choices_display) else None,
-                use_arrow_keys=True,
-                use_jk_keys=False,
-            ).ask()
-            if selected_display is None:
-                selected_display = "<no mapping>"
-        except (KeyboardInterrupt, EOFError):
-            console.print("\n[yellow]Selection cancelled.[/yellow]")
-            raise typer.Exit(0) from None
-
-        # Convert display name back to reference name
-        if selected_display and selected_display != "<no mapping>" and selected_display in field_choices_display:
-            selected_ref = field_choices_refs[field_choices_display.index(selected_display)]
-            new_mapping[selected_ref] = canonical_field
-
+    if non_interactive:
+        final_mapping = dict(combined_mapping)
+    else:
+        # Interactive mapping
+        console.print()
+        console.print(Panel("[bold cyan]Interactive Field Mapping[/bold cyan]", border_style="cyan"))
+        console.print("[dim]Use ↑↓ to navigate, ⏎ to select. Map ADO fields to canonical field names.[/dim]")
         console.print()
 
-    # Validate mapping
-    console.print("[cyan]Validating mapping...[/cyan]")
-    duplicate_ado_fields = {}
-    for ado_field, canonical in new_mapping.items():
-        if ado_field in duplicate_ado_fields:
-            duplicate_ado_fields[ado_field].append(canonical)
-        else:
-            # Check if this ADO field is already mapped to a different canonical field
-            for other_ado, other_canonical in new_mapping.items():
-                if other_ado == ado_field and other_canonical != canonical:
-                    if ado_field not in duplicate_ado_fields:
-                        duplicate_ado_fields[ado_field] = []
-                    duplicate_ado_fields[ado_field].extend([canonical, other_canonical])
+        new_mapping: dict[str, str] = {}
 
-    if duplicate_ado_fields:
-        console.print("[yellow]⚠[/yellow] Warning: Some ADO fields are mapped to multiple canonical fields:")
-        for ado_field, canonicals in duplicate_ado_fields.items():
-            console.print(f"  {ado_field}: {', '.join(set(canonicals))}")
-        if not Confirm.ask("Continue anyway?", default=False):
-            console.print("[yellow]Mapping cancelled.[/yellow]")
-            raise typer.Exit(0)
+        # Build choice list with display names
+        field_choices_display: list[str] = ["<no mapping>"]
+        field_choices_refs: list[str] = ["<no mapping>"]
+        for field in relevant_fields:
+            ref_name = field.get("referenceName", "")
+            name = field.get("name", ref_name)
+            display = f"{ref_name} ({name})"
+            field_choices_display.append(display)
+            field_choices_refs.append(ref_name)
 
-    # Merge with existing mapping (new mapping takes precedence)
-    final_mapping = existing_mapping.copy()
-    final_mapping.update(new_mapping)
+        for canonical_field, display_name in canonical_fields.items():
+            # Find current mapping (existing > default)
+            current_ado_fields = [
+                ado_field for ado_field, canonical in combined_mapping.items() if canonical == canonical_field
+            ]
+
+            # Determine default selection
+            default_selection = "<no mapping>"
+            if current_ado_fields:
+                # Find the current mapping in the choices list
+                current_ref = current_ado_fields[0]
+                if current_ref in field_choices_refs:
+                    default_selection = field_choices_display[field_choices_refs.index(current_ref)]
+                else:
+                    # If current mapping not in available fields, use "<no mapping>"
+                    default_selection = "<no mapping>"
+
+            # Use interactive selection menu with questionary
+            console.print(f"[bold]{display_name}[/bold] (canonical: {canonical_field})")
+            if current_ado_fields:
+                console.print(f"[dim]Current: {', '.join(current_ado_fields)}[/dim]")
+            else:
+                console.print("[dim]Current: <no mapping>[/dim]")
+
+            # Find default index
+            default_index = 0
+            if default_selection != "<no mapping>" and default_selection in field_choices_display:
+                default_index = field_choices_display.index(default_selection)
+
+            # Use questionary for interactive selection with arrow keys
+            assert questionary is not None
+            try:
+                selected_display = questionary.select(
+                    f"Select ADO field for {display_name}",
+                    choices=field_choices_display,
+                    default=field_choices_display[default_index] if default_index < len(field_choices_display) else None,
+                    use_arrow_keys=True,
+                    use_jk_keys=False,
+                ).ask()
+                if selected_display is None:
+                    selected_display = "<no mapping>"
+            except (KeyboardInterrupt, EOFError):
+                console.print("\n[yellow]Selection cancelled.[/yellow]")
+                raise typer.Exit(0) from None
+
+            # Convert display name back to reference name
+            if selected_display and selected_display != "<no mapping>" and selected_display in field_choices_display:
+                selected_ref = field_choices_refs[field_choices_display.index(selected_display)]
+                new_mapping[selected_ref] = canonical_field
+
+            console.print()
+
+        # Validate mapping
+        console.print("[cyan]Validating mapping...[/cyan]")
+        duplicate_ado_fields = {}
+        for ado_field, canonical in new_mapping.items():
+            if ado_field in duplicate_ado_fields:
+                duplicate_ado_fields[ado_field].append(canonical)
+            else:
+                # Check if this ADO field is already mapped to a different canonical field
+                for other_ado, other_canonical in new_mapping.items():
+                    if other_ado == ado_field and other_canonical != canonical:
+                        if ado_field not in duplicate_ado_fields:
+                            duplicate_ado_fields[ado_field] = []
+                        duplicate_ado_fields[ado_field].extend([canonical, other_canonical])
+
+        if duplicate_ado_fields:
+            console.print("[yellow]⚠[/yellow] Warning: Some ADO fields are mapped to multiple canonical fields:")
+            for ado_field, canonicals in duplicate_ado_fields.items():
+                console.print(f"  {ado_field}: {', '.join(set(canonicals))}")
+            if not Confirm.ask("Continue anyway?", default=False):
+                console.print("[yellow]Mapping cancelled.[/yellow]")
+                raise typer.Exit(0)
+
+        # Merge with existing mapping (new mapping takes precedence)
+        final_mapping = existing_mapping.copy()
+        final_mapping.update(new_mapping)
+
+    missing_required_refs = [ref for ref in required_fields_for_selected_type if ref not in final_mapping]
+    unresolved_required_summary = [item for item in unresolved_required_fields if item]
+    if missing_required_refs or unresolved_required_summary:
+        console.print("[red]Error:[/red] Required ADO fields could not be resolved for mapping.")
+        for missing_ref in missing_required_refs:
+            console.print(f"  - missing mapping for required field: {missing_ref}")
+        for unresolved_label in unresolved_required_summary:
+            console.print(f"  - unresolved required field metadata: {unresolved_label}")
+        if non_interactive:
+            console.print(
+                "[yellow]Hint:[/yellow] Run interactive `specfact backlog map-fields` "
+                "to manually map unresolved required fields."
+            )
+        raise typer.Exit(1)
 
     # Preserve existing work_item_type_mappings if they exist
     # This prevents erasing custom work item type mappings when updating field mappings
@@ -5530,14 +5747,24 @@ def map_fields(
     console.print(Panel("[bold green]✓ Mapping saved successfully[/bold green]", border_style="green"))
     console.print(f"[green]Location:[/green] {custom_mapping_file}")
 
+    settings_update: dict[str, Any] = {
+        "field_mapping_file": ".specfact/templates/backlog/field_mappings/ado_custom.yaml",
+        "ado_org": ado_org,
+        "ado_project": ado_project,
+        "framework": selected_framework,
+    }
+    if selected_work_item_type:
+        settings_update["selected_work_item_type"] = selected_work_item_type
+        settings_update["required_fields_by_work_item_type"] = {
+            selected_work_item_type: required_fields_for_selected_type
+        }
+        settings_update["allowed_values_by_work_item_type"] = {
+            selected_work_item_type: allowed_values_for_selected_type
+        }
+
     provider_cfg_path = _upsert_backlog_provider_settings(
         "ado",
-        {
-            "field_mapping_file": ".specfact/templates/backlog/field_mappings/ado_custom.yaml",
-            "ado_org": ado_org,
-            "ado_project": ado_project,
-            "framework": selected_framework,
-        },
+        settings_update,
         project_id=f"{ado_org}/{ado_project}" if ado_org and ado_project else None,
         adapter="ado",
     )

--- a/tests/unit/specfact_backlog/test_map_fields_command.py
+++ b/tests/unit/specfact_backlog/test_map_fields_command.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+from typer.testing import CliRunner
+
+
+runner = CliRunner()
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def test_map_fields_non_interactive_persists_required_and_allowed_value_metadata(monkeypatch, tmp_path: Path) -> None:
+    backlog_commands = importlib.import_module("specfact_backlog.backlog.commands")
+    backlog_app = backlog_commands.app
+    monkeypatch.chdir(tmp_path)
+
+    fields_payload = {
+        "value": [
+            {"referenceName": "System.Description", "name": "Description"},
+            {"referenceName": "Microsoft.VSTS.Common.AcceptanceCriteria", "name": "Acceptance Criteria"},
+            {"referenceName": "Microsoft.VSTS.Common.Priority", "name": "Priority"},
+            {"referenceName": "Custom.FinOpsCategory", "name": "FinOps Category"},
+        ]
+    }
+    work_item_types_payload = {"value": [{"name": "User Story"}]}
+    work_item_type_fields_payload = {
+        "value": [
+            {
+                "referenceName": "Custom.FinOpsCategory",
+                "name": "FinOps Category",
+                "alwaysRequired": True,
+                "allowedValues": [],
+            }
+        ]
+    }
+
+    def fake_get(url: str, **_kwargs: Any) -> _FakeResponse:
+        if "/_apis/wit/workitemtypes?" in url:
+            return _FakeResponse(work_item_types_payload)
+        if "/_apis/wit/workitemtypes/" in url and "/fields?" in url:
+            return _FakeResponse(work_item_type_fields_payload)
+        if "/_apis/wit/fields/Custom.FinOpsCategory?" in url:
+            return _FakeResponse(
+                {"allowedValues": [], "picklistId": "11111111-1111-1111-1111-111111111111", "isPicklist": True}
+            )
+        if "/_apis/work/processes/lists/11111111-1111-1111-1111-111111111111?api-version=7.1" in url:
+            return _FakeResponse({"items": ["Business", "Compliance"]})
+        if "/_apis/wit/fields?" in url:
+            return _FakeResponse(fields_payload)
+        msg = f"Unexpected URL: {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    result = runner.invoke(
+        backlog_app,
+        [
+            "map-fields",
+            "--provider",
+            "ado",
+            "--ado-org",
+            "noldai",
+            "--ado-project",
+            "specfact-cli",
+            "--ado-token",
+            "token",
+            "--ado-framework",
+            "scrum",
+            "--non-interactive",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    mapping_path = tmp_path / ".specfact" / "templates" / "backlog" / "field_mappings" / "ado_custom.yaml"
+    config_path = tmp_path / ".specfact" / "backlog-config.yaml"
+    assert mapping_path.exists()
+    assert config_path.exists()
+
+    mapping_data = _load_yaml(mapping_path)
+    field_mappings = mapping_data.get("field_mappings")
+    assert isinstance(field_mappings, dict)
+    assert "Custom.FinOpsCategory" in field_mappings
+
+    cfg = _load_yaml(config_path)
+    providers = cfg.get("backlog_config", {}).get("providers", {})
+    ado_settings = providers.get("ado", {}).get("settings", {})
+    required_by_type = ado_settings.get("required_fields_by_work_item_type", {})
+    allowed_by_type = ado_settings.get("allowed_values_by_work_item_type", {})
+    assert required_by_type.get("User Story") == ["Custom.FinOpsCategory"]
+    assert allowed_by_type.get("User Story", {}).get("Custom.FinOpsCategory") == ["Business", "Compliance"]
+
+
+def test_map_fields_non_interactive_fails_when_required_field_cannot_be_mapped(monkeypatch, tmp_path: Path) -> None:
+    backlog_commands = importlib.import_module("specfact_backlog.backlog.commands")
+    backlog_app = backlog_commands.app
+    monkeypatch.chdir(tmp_path)
+
+    fields_payload = {"value": [{"referenceName": "System.Description", "name": "Description"}]}
+    work_item_types_payload = {"value": [{"name": "User Story"}]}
+    # Missing/blank referenceName should be treated as unresolved required field metadata.
+    work_item_type_fields_payload = {"value": [{"referenceName": "", "name": "FinOps Category", "alwaysRequired": True}]}
+
+    def fake_get(url: str, **_kwargs: Any) -> _FakeResponse:
+        if "/_apis/wit/workitemtypes?" in url:
+            return _FakeResponse(work_item_types_payload)
+        if "/_apis/wit/workitemtypes/" in url and "/fields?" in url:
+            return _FakeResponse(work_item_type_fields_payload)
+        if "/_apis/wit/fields/" in url and "?api-version=7.1" in url:
+            return _FakeResponse({"allowedValues": []})
+        if "/_apis/wit/fields?" in url:
+            return _FakeResponse(fields_payload)
+        msg = f"Unexpected URL: {url}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("requests.get", fake_get)
+
+    result = runner.invoke(
+        backlog_app,
+        [
+            "map-fields",
+            "--provider",
+            "ado",
+            "--ado-org",
+            "noldai",
+            "--ado-project",
+            "specfact-cli",
+            "--ado-token",
+            "token",
+            "--ado-framework",
+            "scrum",
+            "--non-interactive",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "run interactive `specfact backlog map-fields`" in result.output.lower()


### PR DESCRIPTION
# Summary

Fixes the ADO required custom-field/picklist runtime gap in the modular backlog bundle and adds decoupled module publishing automation in `specfact-cli-modules`.

Implemented in this PR:
- `map-fields --non-interactive` now resolves required fields and picklist values (including via ADO `picklistId` lists endpoint) and persists metadata.
- Unit coverage for non-interactive map-fields success/failure paths.
- New modules-repo `publish-modules` workflow for branch-based (`dev`/`main`) decoupled registry publishing.
- Publishing guide updated to reflect the new decoupled workflow.

Refs:
- specfact-cli issue: #337
- related module migration item/change: backlog-core-07-ado-required-custom-fields-and-picklists

## Scope

- [x] Bundle source changes under `packages/`
- [ ] Registry/manifest changes (`registry/index.json`, `packages/*/module-package.yaml`)
- [x] CI/workflow changes (`.github/workflows/*`)
- [x] Documentation changes (`docs/*`, `README.md`, `AGENTS.md`)
- [ ] Security/signing changes (`scripts/sign-modules.py`, `scripts/verify-modules-signature.py`)

## Bundle Impact

List impacted bundles and version updates:

- `nold-ai/specfact-project`: `0.40.15 -> 0.40.15` (unchanged)
- `nold-ai/specfact-backlog`: `0.40.15 -> 0.40.17`
- `nold-ai/specfact-codebase`: `0.40.14 -> 0.40.14` (unchanged)
- `nold-ai/specfact-spec`: `0.40.13 -> 0.40.13` (unchanged)
- `nold-ai/specfact-govern`: `0.40.13 -> 0.40.13` (unchanged)

## Validation Evidence

Paste command output snippets or link workflow runs.

- `PYTHONPATH=packages/specfact-backlog/src:/home/dom/git/nold-ai/specfact-cli/src python -m pytest tests/unit/specfact_backlog/test_map_fields_command.py -q` -> `2 passed`
- `hatch run yaml-lint` -> `Validated 5 manifests and registry/index.json`

### Required local gates

- [ ] `hatch run format`
- [ ] `hatch run type-check`
- [ ] `hatch run lint`
- [x] `hatch run yaml-lint`
- [ ] `hatch run check-bundle-imports`
- [ ] `hatch run contract-test`
- [x] `hatch run smart-test` (or `hatch run test`)

### Signature + version integrity (required)

- [ ] `hatch run verify-modules-signature --require-signature --enforce-version-bump`
- [x] Changed bundle versions were bumped before signing
- [ ] Manifests re-signed after bundle content changes

## CI and Branch Protection

- [x] PR orchestrator jobs expected:
  - `verify-module-signatures`
  - `quality (3.11)`
  - `quality (3.12)`
  - `quality (3.13)`
- [x] Branch protection required checks are aligned with the above

## Docs / Pages

- [x] Bundle/module docs updated in this repo (`docs/`)
- [x] Pages workflow impact reviewed (`docs-pages.yml`, if changed)
- [x] Cross-links from `specfact-cli` docs updated (if applicable)

## Checklist

- [x] Self-review completed
- [x] No unrelated files or generated artifacts included
- [x] Backward-compatibility/rollout notes documented (if needed)
