### PR TITLE
fix: skip no-op module publishes in workflow

### DIFF
--- a/.github/workflows/publish-modules.yml
+++ b/.github/workflows/publish-modules.yml
@@ -140,12 +140,34 @@ jobs:
           ignored_dir_names = {".git", "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "logs"}
           ignored_suffixes = {".pyc", ".pyo"}
 
+          skipped_bundles: list[str] = []
+
           for bundle in bundles:
             # Keep existing monotonic version guard logic.
-            subprocess.run(
+            publish_check = subprocess.run(
               ["python", "scripts/publish-module.py", "--bundle", bundle, "--repo-root", "."],
-              check=True,
+              check=False,
+              capture_output=True,
+              text=True,
             )
+            combined_output = "\n".join(
+              part.strip() for part in (publish_check.stdout, publish_check.stderr) if part and part.strip()
+            )
+            if publish_check.returncode != 0:
+              if "Bundle version must be greater than registry latest_version" in combined_output:
+                print(f"Skipping {bundle}: registry already at manifest version.")
+                if combined_output:
+                  print(combined_output)
+                skipped_bundles.append(bundle)
+                continue
+              if combined_output:
+                print(combined_output)
+              raise subprocess.CalledProcessError(
+                publish_check.returncode,
+                publish_check.args,
+                output=publish_check.stdout,
+                stderr=publish_check.stderr,
+              )
 
             bundle_dir = repo_root / "packages" / bundle
             manifest_path = bundle_dir / "module-package.yaml"
@@ -210,6 +232,9 @@ jobs:
               entry["description"] = manifest["description"]
 
             print(f"Published registry artifact for {module_id} v{version}")
+
+          if skipped_bundles:
+            print(f"Skipped already-published bundles: {skipped_bundles}")
 
           registry_index_path.write_text(json.dumps(registry, indent=2) + "\n", encoding="utf-8")
           PY


### PR DESCRIPTION
# Summary

Handle no-op module publish runs gracefully in `publish-modules`.

The workflow previously failed when a changed bundle was already published at the same version and `scripts/publish-module.py` rejected the monotonic version check. This change treats that specific condition as a skip, while still failing on real publish errors.

Refs:
- specfact-cli issue: #
- related module migration item/change: #

## Scope

- [ ] Bundle source changes under `packages/`
- [ ] Registry/manifest changes (`registry/index.json`, `packages/*/module-package.yaml`)
- [x] CI/workflow changes (`.github/workflows/*`)
- [ ] Documentation changes (`docs/*`, `README.md`, `AGENTS.md`)
- [ ] Security/signing changes (`scripts/sign-modules.py`, `scripts/verify-modules-signature.py`)

## Bundle Impact

List impacted bundles and version updates:

- `nold-ai/specfact-project`: `unchanged`
- `nold-ai/specfact-backlog`: `unchanged`
- `nold-ai/specfact-codebase`: `unchanged`
- `nold-ai/specfact-spec`: `unchanged`
- `nold-ai/specfact-govern`: `unchanged`

## Validation Evidence

Paste command output snippets or link workflow runs.

- Reproduced failure shape from Actions run `22744589694`: same-version publish precheck caused workflow failure
- `hatch run yaml-lint` -> pass
- Local no-op publish path check against `specfact-govern` same-version case -> skip path exercised successfully

### Required local gates

- [ ] `hatch run format`
- [ ] `hatch run type-check`
- [ ] `hatch run lint`
- [x] `hatch run yaml-lint`
- [ ] `hatch run check-bundle-imports`
- [ ] `hatch run contract-test`
- [ ] `hatch run smart-test` (or `hatch run test`)

### Signature + version integrity (required)

- [x] `hatch run verify-modules-signature --require-signature --enforce-version-bump`
- [x] Changed bundle versions were bumped before signing
- [x] Manifests re-signed after bundle content changes

## CI and Branch Protection

- [x] PR orchestrator jobs expected:
  - `verify-module-signatures`
  - `quality (3.11)`
  - `quality (3.12)`
  - `quality (3.13)`
- [x] Branch protection required checks are aligned with the above

## Docs / Pages

- [ ] Bundle/module docs updated in this repo (`docs/`)
- [x] Pages workflow impact reviewed (`docs-pages.yml`, if changed)
- [ ] Cross-links from `specfact-cli` docs updated (if applicable)

## Checklist

- [x] Self-review completed
- [x] No unrelated files or generated artifacts included
- [x] Backward-compatibility/rollout notes documented (if needed)
