### PR TITLE
Release dev to main: docs alignment for code import surface

### DIFF
--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -32,7 +32,7 @@ This guide walks you through your first commands with SpecFact CLI, with step-by
 **Option A: CLI-only Mode** (Quick start, works with uvx):
 
 ```bash
-uvx specfact-cli@latest import from-code my-project --repo .
+uvx specfact-cli@latest code import my-project --repo .
 ```
 
 **Option B: Interactive AI Assistant Mode** (Recommended for better results):

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -177,7 +177,7 @@ SpecFact CLI supports two operational modes:
 
 ```bash
 # CLI-only mode (uvx - no installation)
-uvx specfact-cli@latest import from-code my-project --repo .
+uvx specfact-cli@latest code import my-project --repo .
 
 # Interactive mode (pip + specfact init - recommended)
 # After: pip install specfact-cli && specfact init
@@ -339,7 +339,7 @@ specfact init
 
 ```bash
 # Analyze repository (CI/CD mode - fast)
-specfact import from-code my-project \
+specfact code import my-project \
   --repo ./my-project \
   --shadow-only \
   --report analysis.md

--- a/docs/getting-started/tutorial-openspec-speckit.md
+++ b/docs/getting-started/tutorial-openspec-speckit.md
@@ -122,7 +122,7 @@ openspec init
 ```bash
 # Analyze legacy codebase
 cd /path/to/your-openspec-project
-specfact import from-code legacy-api --repo .
+specfact code import legacy-api --repo .
 
 # Expected output:
 # 🔍 Analyzing codebase...
@@ -143,7 +143,7 @@ specfact import from-code legacy-api --repo .
 **Note**: If using `hatch run specfact`, run from the specfact-cli directory:
 ```bash
 cd /path/to/specfact-cli
-hatch run specfact import from-code legacy-api --repo /path/to/your-openspec-project
+hatch run specfact code import legacy-api --repo /path/to/your-openspec-project
 ```
 
 ### Step 4: Create an OpenSpec Change Proposal

--- a/docs/guides/ai-ide-workflow.md
+++ b/docs/guides/ai-ide-workflow.md
@@ -62,12 +62,12 @@ Once initialized, the following slash commands are available in your IDE:
 
 | Slash Command | Purpose | Equivalent CLI Command |
 |---------------|---------|------------------------|
-| `/specfact.01-import` | Import from codebase | `specfact import from-code` |
+| `/specfact.01-import` | Import from codebase | `specfact code import` |
 | `/specfact.02-plan` | Plan management | `specfact plan init/add-feature/add-story` |
 | `/specfact.03-review` | Review plan | `specfact plan review` |
-| `/specfact.04-sdd` | Create SDD manifest | `specfact enforce sdd` |
-| `/specfact.05-enforce` | SDD enforcement | `specfact enforce sdd` |
-| `/specfact.06-sync` | Sync operations | `specfact sync bridge` |
+| `/specfact.04-sdd` | Create SDD manifest | `specfact govern enforce sdd` |
+| `/specfact.05-enforce` | SDD enforcement | `specfact govern enforce sdd` |
+| `/specfact.06-sync` | Sync operations | `specfact project sync bridge` |
 | `/specfact.07-contracts` | Contract management | `specfact generate contracts-prompt` |
 
 ### Advanced Commands
@@ -75,7 +75,7 @@ Once initialized, the following slash commands are available in your IDE:
 | Slash Command | Purpose | Equivalent CLI Command |
 |---------------|---------|------------------------|
 | `/specfact.compare` | Compare plans | `specfact plan compare` |
-| `/specfact.validate` | Validation suite | `specfact repro` |
+| `/specfact.validate` | Validation suite | `specfact code repro` |
 | `/specfact.backlog-refine` | Backlog refinement (AI IDE interactive loop) | `specfact backlog refine github \| ado` |
 
 For an end-to-end tutorial on backlog refine with your AI IDE (story quality, underspecification, DoR, custom templates), see **[Tutorial: Backlog Refine with AI IDE](../getting-started/tutorial-backlog-refine-ai-ide.md)**.
@@ -104,10 +104,10 @@ graph TD
 
 ```bash
 # Import from codebase
-specfact import from-code my-project --repo .
+specfact code import my-project --repo .
 
 # Run validation to find gaps
-specfact repro --verbose
+specfact code repro --verbose
 ```
 
 #### 2. Generate AI-Ready Prompt
@@ -151,10 +151,10 @@ cat .specfact/prompts/fix-prompt-GAP-001.md
 specfact contract coverage --bundle my-project
 
 # Run validation
-specfact repro --verbose
+specfact code repro --verbose
 
 # Enforce SDD compliance
-specfact enforce sdd --bundle my-project
+specfact govern enforce sdd --bundle my-project
 ```
 
 #### 5. Iterate if Needed
@@ -169,7 +169,7 @@ The AI IDE workflow integrates with several command chains:
 
 ### AI-Assisted Code Enhancement Chain
 
-**Workflow**: `generate contracts-prompt` → [AI IDE] → `contracts-apply` → `contract coverage` → `repro`
+**Workflow**: `generate contracts-prompt` → [AI IDE] → `contracts-apply` → `contract coverage` → `code repro`
 
 **Related**: [AI-Assisted Code Enhancement Chain](command-chains.md#7-ai-assisted-code-enhancement-chain-emerging)
 
@@ -181,7 +181,7 @@ The AI IDE workflow integrates with several command chains:
 
 ### Gap Discovery & Fixing Chain
 
-**Workflow**: `repro --verbose` → `generate fix-prompt` → [AI IDE] → `enforce sdd`
+**Workflow**: `code repro --verbose` → `generate fix-prompt` → [AI IDE] → `govern enforce sdd`
 
 **Related**: [Gap Discovery & Fixing Chain](command-chains.md#9-gap-discovery--fixing-chain-emerging)
 
@@ -193,10 +193,10 @@ The AI IDE workflow integrates with several command chains:
 
 ```bash
 # 1. Analyze codebase
-specfact import from-code legacy-api --repo .
+specfact code import legacy-api --repo .
 
 # 2. Find gaps
-specfact repro --verbose
+specfact code repro --verbose
 
 # 3. Generate contract prompt
 specfact generate contracts-prompt --bundle legacy-api --feature FEATURE-001
@@ -208,8 +208,8 @@ specfact generate contracts-prompt --bundle legacy-api --feature FEATURE-001
 
 # 5. Validate
 specfact contract coverage --bundle legacy-api
-specfact repro --verbose
-specfact enforce sdd --bundle legacy-api
+specfact code repro --verbose
+specfact govern enforce sdd --bundle legacy-api
 ```
 
 ---

--- a/docs/guides/brownfield-engineer.md
+++ b/docs/guides/brownfield-engineer.md
@@ -43,11 +43,11 @@ SpecFact CLI is designed specifically for your situation. It provides:
 
 ```bash
 # Analyze your legacy codebase
-specfact import from-code legacy-api --repo ./legacy-app
+specfact code import legacy-api --repo ./legacy-app
 
 # For large codebases or multi-project repos, analyze specific modules:
-specfact import from-code core-module --repo ./legacy-app --entry-point src/core
-specfact import from-code api-module --repo ./legacy-app --entry-point src/api
+specfact code import core-module --repo ./legacy-app --entry-point src/core
+specfact code import api-module --repo ./legacy-app --entry-point src/api
 ```
 
 **What you get:**
@@ -81,10 +81,10 @@ For large codebases or monorepos with multiple projects, you can analyze specifi
 
 ```bash
 # Analyze only the core module
-specfact import from-code core-module --repo . --entry-point src/core
+specfact code import core-module --repo . --entry-point src/core
 
 # Analyze only the API service
-specfact import from-code api-service --repo . --entry-point projects/api-service
+specfact code import api-service --repo . --entry-point projects/api-service
 ```
 
 This enables:
@@ -227,7 +227,7 @@ You inherited a 3-year-old Django app with:
 
 ```bash
 # Step 1: Extract specs
-specfact import from-code customer-portal --repo ./legacy-django-app
+specfact code import customer-portal --repo ./legacy-django-app
 
 # Output:
 ✅ Analyzed 47 Python files
@@ -289,7 +289,7 @@ SpecFact CLI integrates seamlessly with your existing tools:
 Begin in shadow mode to observe without blocking:
 
 ```bash
-specfact import from-code legacy-api --repo . --shadow-only
+specfact code import legacy-api --repo . --shadow-only
 ```
 
 ### 2. Add Contracts Incrementally

--- a/docs/guides/brownfield-faq.md
+++ b/docs/guides/brownfield-faq.md
@@ -164,7 +164,7 @@ For large codebases, run CrossHair on critical functions first, then expand.
 
 **Recommended workflow:**
 
-1. **Extract specs** (`specfact import from-code`)
+1. **Extract specs** (`specfact code import`)
 2. **Add contracts** to 3-5 critical functions
 3. **Run CrossHair** to discover edge cases
 4. **Refactor incrementally** (one function at a time)

--- a/docs/guides/brownfield-journey.md
+++ b/docs/guides/brownfield-journey.md
@@ -35,7 +35,7 @@ This guide walks you through the complete brownfield modernization journey:
 
 ```bash
 # Analyze your legacy codebase
-specfact import from-code legacy-api --repo ./legacy-app
+specfact code import legacy-api --repo ./legacy-app
 ```
 
 **What happens:**
@@ -328,7 +328,7 @@ Legacy Django app:
 
 #### Week 1: Understand
 
-- Ran `specfact import from-code legacy-api --repo .` → 23 features extracted in 8 seconds
+- Ran `specfact code import legacy-api --repo .` → 23 features extracted in 8 seconds
 - Reviewed extracted plan → Identified 5 critical features
 - Time: 2 hours (vs. 60 hours manual)
 

--- a/docs/guides/brownfield-roi.md
+++ b/docs/guides/brownfield-roi.md
@@ -150,7 +150,7 @@ SpecFact's code2spec provides similar automation:
 
 **Solution:**
 
-1. Ran `specfact import from-code` → 47 features extracted in 12 seconds
+1. Ran `specfact code import` → 47 features extracted in 12 seconds
 2. Added contracts to 23 critical data transformation functions
 3. CrossHair discovered 6 edge cases in legacy validation logic
 4. Enforced contracts during migration, blocked 11 regressions
@@ -199,7 +199,7 @@ Calculate your ROI:
 1. **Run code2spec** on your legacy codebase:
 
    ```bash
-   specfact import from-code legacy-api --repo ./your-legacy-app
+   specfact code import legacy-api --repo ./your-legacy-app
    ```
 
 2. **Time the extraction** (typically < 10 seconds)

--- a/docs/guides/command-chains.md
+++ b/docs/guides/command-chains.md
@@ -83,7 +83,7 @@ Start: What do you want to accomplish?
 
 ```bash
 # Step 1: Extract specifications from legacy code
-specfact import from-code legacy-api --repo .
+specfact code import legacy-api --repo .
 
 # Step 2: Review the extracted plan
 specfact plan review legacy-api
@@ -444,7 +444,7 @@ graph LR
 
 ```bash
 # Step 1: Import current code state
-specfact import from-code current-state --repo .
+specfact code import current-state --repo .
 
 # Step 2: Compare code against plan
 specfact plan compare --bundle <plan-bundle> --code-vs-plan

--- a/docs/guides/common-tasks.md
+++ b/docs/guides/common-tasks.md
@@ -29,7 +29,7 @@ This guide maps common user goals to recommended SpecFact CLI commands or comman
 **Quick Example**:
 
 ```bash
-specfact import from-code legacy-api --repo .
+specfact code import legacy-api --repo .
 ```
 
 **Detailed Guide**: [Brownfield Engineer Guide](brownfield-engineer.md)
@@ -80,7 +80,7 @@ specfact sync bridge --adapter speckit --bundle <bundle-name> --bidirectional --
 **Quick Example**:
 
 ```bash
-specfact import from-code legacy-api --repo ./legacy-app
+specfact code import legacy-api --repo ./legacy-app
 ```
 
 **Detailed Guide**: [Brownfield Engineer Guide](brownfield-engineer.md#step-1-understand-what-you-have)
@@ -111,7 +111,7 @@ specfact plan update-feature --bundle legacy-api --feature <feature-id>
 **Quick Example**:
 
 ```bash
-specfact import from-code current-state --repo .
+specfact code import current-state --repo .
 specfact plan compare --bundle <plan-bundle> --code-vs-plan
 specfact drift detect --bundle <bundle-name>
 ```

--- a/docs/guides/competitive-analysis.md
+++ b/docs/guides/competitive-analysis.md
@@ -222,7 +222,7 @@ specfact repro --budget 120 --report evidence.md
 
 ```bash
 # Primary use case: Analyze legacy code
-specfact import from-code legacy-api --repo ./legacy-app
+specfact code import legacy-api --repo ./legacy-app
 
 # Extract specs from existing code in < 10 seconds
 # Then enforce contracts to prevent regressions
@@ -307,7 +307,7 @@ uvx specfact-cli@latest plan init --interactive
 
 ```bash
 # Primary use case: Analyze legacy codebase
-specfact import from-code legacy-api --repo ./legacy-app
+specfact code import legacy-api --repo ./legacy-app
 ```
 
 See [Use Cases: Brownfield Modernization](use-cases.md#use-case-1-brownfield-code-modernization-primary) ⭐
@@ -327,7 +327,7 @@ See [Use Cases: Spec-Kit Migration](use-cases.md#use-case-2-github-spec-kit-migr
 **Add validation layer**:
 
 1. Let AI generate code as usual
-2. Run `specfact import from-code --repo .` (auto-detects CoPilot mode)
+2. Run `specfact code import --repo .` (auto-detects CoPilot mode)
 3. Review auto-generated plan
 4. Enable `specfact enforce stage --preset balanced`
 

--- a/docs/guides/copilot-mode.md
+++ b/docs/guides/copilot-mode.md
@@ -31,7 +31,7 @@ Mode is auto-detected based on environment, or you can explicitly set it with `-
 specfact --mode copilot import from-code legacy-api --repo . --confidence 0.7
 
 # Mode is auto-detected based on environment (IDE integration, CoPilot API availability)
-specfact import from-code legacy-api --repo . --confidence 0.7  # Auto-detects CoPilot if available
+specfact code import legacy-api --repo . --confidence 0.7  # Auto-detects CoPilot if available
 ```
 
 ### What You Get with CoPilot Mode

--- a/docs/guides/dual-stack-enrichment.md
+++ b/docs/guides/dual-stack-enrichment.md
@@ -186,7 +186,7 @@ The enrichment parser expects a specific Markdown format. Follow this structure 
 
 ```bash
 # Use enrichment to update plan via CLI
-specfact import from-code [<bundle-name>] --repo <path> --enrichment <enrichment-report> --no-interactive
+specfact code import [<bundle-name>] --repo <path> --enrichment <enrichment-report> --no-interactive
 ```
 
 **Result**: Final artifacts are CLI-generated with validated enrichments
@@ -323,7 +323,7 @@ specfact generate contracts-apply enhanced_login.py --original src/auth/login.py
 
 - `specfact plan init <bundle-name>` - Initialize project bundle
 - `specfact plan select <bundle-name>` - Set active plan (used as default for other commands)
-- `specfact import from-code [<bundle-name>] --repo <path>` - Import from codebase (uses active plan if bundle not specified)
+- `specfact code import [<bundle-name>] --repo <path>` - Import from codebase (uses active plan if bundle not specified)
 - `specfact plan review [<bundle-name>]` - Review plan (uses active plan if bundle not specified)
 - `specfact plan harden [<bundle-name>]` - Create SDD manifest (uses active plan if bundle not specified)
 - `specfact enforce sdd [<bundle-name>]` - Validate SDD (uses active plan if bundle not specified)

--- a/docs/guides/ide-integration.md
+++ b/docs/guides/ide-integration.md
@@ -161,12 +161,12 @@ Detailed instructions for the AI assistant...
 
 | Command | Description | CLI Equivalent |
 |---------|-------------|----------------|
-| `/specfact.01-import` | Import codebase into plan bundle | `specfact import from-code <bundle-name>` |
+| `/specfact.01-import` | Import codebase into plan bundle | `specfact code import <bundle-name>` |
 | `/specfact.02-plan` | Plan management (init, add-feature, add-story, update-idea, update-feature, update-story) | `specfact plan <operation> <bundle-name>` |
 | `/specfact.03-review` | Review plan and promote through stages | `specfact plan review <bundle-name>`, `specfact plan promote <bundle-name>` |
 | `/specfact.04-sdd` | Create SDD manifest from plan | `specfact plan harden <bundle-name>` |
-| `/specfact.05-enforce` | Validate SDD and contracts | `specfact enforce sdd <bundle-name>` |
-| `/specfact.06-sync` | Sync with external tools or repository | `specfact sync bridge --adapter <adapter>` |
+| `/specfact.05-enforce` | Validate SDD and contracts | `specfact govern enforce sdd <bundle-name>` |
+| `/specfact.06-sync` | Sync with external tools or repository | `specfact project sync bridge --adapter <adapter>` |
 | `/specfact.07-contracts` | Contract enhancement workflow: analyze → generate prompts → apply sequentially | `specfact analyze contracts`, `specfact generate contracts-prompt`, `specfact generate contracts-apply` |
 
 **Advanced Commands** (no numbering):
@@ -174,7 +174,7 @@ Detailed instructions for the AI assistant...
 | Command | Description | CLI Equivalent |
 |---------|-------------|----------------|
 | `/specfact.compare` | Compare manual vs auto plans | `specfact plan compare` |
-| `/specfact.validate` | Run validation suite | `specfact repro` |
+| `/specfact.validate` | Run validation suite | `specfact code repro` |
 | `/specfact.generate-contracts-prompt` | Generate AI IDE prompt for adding contracts | `specfact generate contracts-prompt <file> --apply <contracts>` |
 
 ---

--- a/docs/guides/import-features.md
+++ b/docs/guides/import-features.md
@@ -60,10 +60,10 @@ When you restart an import on an existing bundle, the command automatically vali
 
 ```bash
 # First import
-specfact import from-code my-project --repo .
+specfact code import my-project --repo .
 
 # Later, restart import (validates existing features automatically)
-specfact import from-code my-project --repo .
+specfact code import my-project --repo .
 ```
 
 ### Validation Results
@@ -112,7 +112,7 @@ Features are saved immediately after the initial codebase analysis, before expen
 
 ```bash
 # Start import
-specfact import from-code my-project --repo .
+specfact code import my-project --repo .
 
 # Output shows:
 # ✓ Found 3156 features
@@ -120,7 +120,7 @@ specfact import from-code my-project --repo .
 # ✓ Features saved (can resume if interrupted)
 
 # If you press Ctrl+C during source linking, you can restart:
-specfact import from-code my-project --repo .
+specfact code import my-project --repo .
 # The command will detect existing features and resume from checkpoint
 ```
 
@@ -165,7 +165,7 @@ Use `--revalidate-features` to force re-analysis even if source files haven't ch
 
 ```bash
 # Re-analyze all features even if files unchanged
-specfact import from-code my-project --repo . --revalidate-features
+specfact code import my-project --repo . --revalidate-features
 
 # Output shows:
 # ⚠ --revalidate-features enabled: Will re-analyze features even if files unchanged

--- a/docs/guides/migration-cli-reorganization.md
+++ b/docs/guides/migration-cli-reorganization.md
@@ -197,7 +197,7 @@ Example: 'specfact constitution bootstrap' → 'specfact sdd constitution bootst
 ### Brownfield Import Workflow
 
 ```bash
-specfact import from-code legacy-api --repo .
+specfact code import legacy-api --repo .
 specfact sdd constitution bootstrap --repo .
 specfact sync bridge --adapter speckit
 ```

--- a/docs/guides/openspec-journey.md
+++ b/docs/guides/openspec-journey.md
@@ -312,7 +312,7 @@ Here's how to use both tools together for legacy code modernization:
 
 ```bash
 # Step 1: Analyze legacy code with SpecFact
-specfact import from-code legacy-api --repo ./legacy-app
+specfact code import legacy-api --repo ./legacy-app
 # → Extracts features from existing code
 # → Creates SpecFact bundle: .specfact/projects/legacy-api/
 

--- a/docs/guides/speckit-journey.md
+++ b/docs/guides/speckit-journey.md
@@ -79,7 +79,7 @@ When modernizing legacy code, you can use **both tools together** for maximum va
 
 ```bash
 # Step 1: Use SpecFact to extract specs from legacy code
-specfact import from-code customer-portal --repo ./legacy-app
+specfact code import customer-portal --repo ./legacy-app
 
 # Output: Auto-generated project bundle from existing code
 # ✅ Analyzed 47 Python files

--- a/docs/guides/specmatic-integration.md
+++ b/docs/guides/specmatic-integration.md
@@ -248,7 +248,7 @@ Here's a full workflow from contract to tested implementation:
 
 ```bash
 # 1. Import existing code and extract contracts
-specfact import from-code user-api --repo .
+specfact code import user-api --repo .
 
 # 2. Validate contracts are correct
 specfact spec validate --bundle user-api
@@ -422,7 +422,7 @@ When importing code, SpecFact auto-detects and validates OpenAPI/AsyncAPI specs:
 
 ```bash
 # Import with bundle (uses active plan if --bundle not specified)
-specfact import from-code legacy-api --repo .
+specfact code import legacy-api --repo .
 
 # Automatically validates:
 # - Repo-level OpenAPI/AsyncAPI specs (openapi.yaml, asyncapi.yaml)
@@ -500,7 +500,7 @@ SpecFact calls Specmatic via subprocess:
 
 ```bash
 # Project has openapi.yaml
-specfact import from-code api-service --repo .
+specfact code import api-service --repo .
 
 # Output:
 # ✓ Import complete!

--- a/docs/guides/testing-terminal-output.md
+++ b/docs/guides/testing-terminal-output.md
@@ -20,7 +20,7 @@ NO_COLOR=1 specfact --help
 
 # Or export for the entire session
 export NO_COLOR=1
-specfact import from-code my-bundle
+specfact code import my-bundle
 unset NO_COLOR  # Re-enable colors
 ```
 
@@ -33,7 +33,7 @@ Simulate a CI/CD pipeline (BASIC mode):
 CI=true specfact --help
 
 # Or simulate GitHub Actions
-GITHUB_ACTIONS=true specfact import from-code my-bundle
+GITHUB_ACTIONS=true specfact code import my-bundle
 ```
 
 ### Method 3: Use Dumb Terminal Type

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -115,13 +115,13 @@ specfact plan select --last 5
 1. **Check repository path**:
 
    ```bash
-   specfact import from-code legacy-api --repo . --verbose
+   specfact code import legacy-api --repo . --verbose
    ```
 
 2. **Lower confidence threshold** (for legacy code with less structure):
 
    ```bash
-   specfact import from-code legacy-api --repo . --confidence 0.3
+   specfact code import legacy-api --repo . --confidence 0.3
    ```
 
 3. **Check file structure**:
@@ -139,7 +139,7 @@ specfact plan select --last 5
 5. **For legacy codebases**, start with minimal confidence and review extracted features:
 
    ```bash
-   specfact import from-code legacy-api --repo . --confidence 0.2
+   specfact code import legacy-api --repo . --confidence 0.2
    ```
 
 ---
@@ -254,7 +254,7 @@ specfact plan select --last 5
 2. **Adjust confidence threshold**:
 
    ```bash
-   specfact import from-code legacy-api --repo . --confidence 0.7
+   specfact code import legacy-api --repo . --confidence 0.7
    ```
 
 3. **Check enforcement rules** (use CLI commands):
@@ -374,7 +374,7 @@ specfact plan select --last 5
 3. **Generate auto-derived plan first**:
 
    ```bash
-   specfact import from-code legacy-api --repo .
+   specfact code import legacy-api --repo .
    ```
 
 ### No Deviations Found (Expected Some)
@@ -481,7 +481,7 @@ specfact plan select --last 5
 
    ```bash
    export SPECFACT_MODE=copilot
-   specfact import from-code legacy-api --repo .
+   specfact code import legacy-api --repo .
    ```
 
 4. **See [Operational Modes](../reference/modes.md)** for details
@@ -505,14 +505,14 @@ specfact plan select --last 5
 2. **Increase confidence threshold** (fewer features):
 
    ```bash
-   specfact import from-code legacy-api --repo . --confidence 0.8
+   specfact code import legacy-api --repo . --confidence 0.8
    ```
 
 3. **Exclude directories**:
 
    ```bash
    # Use .gitignore or exclude patterns
-   specfact import from-code legacy-api --repo . --exclude "tests/"
+   specfact code import legacy-api --repo . --exclude "tests/"
    ```
 
 ### Watch Mode High CPU
@@ -588,17 +588,17 @@ You can override auto-detection using standard environment variables:
 
 ```bash
 # Auto-detection (default behavior)
-specfact import from-code my-bundle
+specfact code import my-bundle
 # → Automatically detects terminal and uses appropriate mode
 
 # Manual override: Disable colors
-NO_COLOR=1 specfact import from-code my-bundle
+NO_COLOR=1 specfact code import my-bundle
 
 # Manual override: Force colors in CI/CD
 FORCE_COLOR=1 specfact sync bridge
 
 # Manual override: Explicit CI/CD mode
-CI=true specfact import from-code my-bundle
+CI=true specfact code import my-bundle
 ```
 
 ### No Progress Visible in Embedded Terminals
@@ -631,7 +631,7 @@ CI=true specfact import from-code my-bundle
 
    ```bash
    # Force basic mode
-   CI=true specfact import from-code my-bundle
+   CI=true specfact code import my-bundle
    ```
 
 ### Colors Not Working in CI/CD
@@ -643,7 +643,7 @@ CI=true specfact import from-code my-bundle
 **Solution**: This is expected behavior. CI/CD logs are more readable without colors. To force colors:
 
 ```bash
-FORCE_COLOR=1 specfact import from-code my-bundle
+FORCE_COLOR=1 specfact code import my-bundle
 ```
 
 ---

--- a/docs/guides/use-cases.md
+++ b/docs/guides/use-cases.md
@@ -29,14 +29,14 @@ Detailed use cases and examples for SpecFact CLI.
 
 ```bash
 # CI/CD mode (fast, deterministic) - Full repository
-specfact import from-code \
+specfact code import \
   --repo . \
   --shadow-only \
   --confidence 0.7 \
   --report analysis.md
 
 # Partial analysis (large codebases or monorepos)
-specfact import from-code \
+specfact code import \
   --repo . \
   --entry-point src/core \
   --confidence 0.7 \

--- a/docs/guides/ux-features.md
+++ b/docs/guides/ux-features.md
@@ -17,7 +17,7 @@ SpecFact CLI uses progressive disclosure to show the most important options firs
 By default, `--help` shows only the most commonly used options:
 
 ```bash
-specfact import from-code --help
+specfact code import --help
 ```
 
 This displays:
@@ -32,7 +32,7 @@ This displays:
 To see all options including advanced configuration, use `--help-advanced` (alias: `-ha`):
 
 ```bash
-specfact import from-code --help-advanced
+specfact code import --help-advanced
 ```
 
 This reveals:
@@ -88,10 +88,10 @@ The following options are hidden by default across commands:
 
 ```bash
 # This works even though --confidence is hidden in regular help:
-specfact import from-code my-bundle --confidence 0.7 --key-format sequential
+specfact code import my-bundle --confidence 0.7 --key-format sequential
 
 # To see all options in help:
-specfact import from-code --help-advanced  # or -ha
+specfact code import --help-advanced  # or -ha
 ```
 
 ## Context Detection
@@ -126,7 +126,7 @@ You can also explicitly check your project context:
 
 ```bash
 # Context detection is automatic, but you can verify
-specfact import from-code my-bundle --repo .
+specfact code import my-bundle --repo .
 # CLI automatically detects Python, FastAPI, existing specs, etc.
 ```
 
@@ -139,7 +139,7 @@ SpecFact provides context-aware suggestions to guide your workflow.
 After running commands, SpecFact suggests logical next steps:
 
 ```bash
-$ specfact import from-code legacy-api
+$ specfact code import legacy-api
 ✓ Import complete
 
 💡 Suggested next steps:
@@ -158,7 +158,7 @@ $ specfact analyze --bundle missing-bundle
 
 💡 Suggested fixes:
   • specfact plan select  # Select an active plan bundle
-  • specfact import from-code missing-bundle  # Create a new bundle
+  • specfact code import missing-bundle  # Create a new bundle
 ```
 
 ### Improvements
@@ -171,7 +171,7 @@ $ specfact analyze --bundle legacy-api
 
 💡 Suggested improvements:
   • specfact analyze --bundle legacy-api  # Identify missing contracts
-  • specfact import from-code legacy-api  # Extract contracts from code
+  • specfact code import legacy-api  # Extract contracts from code
 ```
 
 ## Template-Driven Quality

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -29,11 +29,11 @@ Reverse engineer existing code and enforce contracts incrementally.
 
 ```bash
 # Full repository analysis
-specfact import from-code legacy-api --repo .
+specfact code import legacy-api --repo .
 
 # For large codebases, analyze specific modules:
-specfact import from-code core-module --repo . --entry-point src/core
-specfact import from-code api-module --repo . --entry-point src/api
+specfact code import core-module --repo . --entry-point src/core
+specfact code import api-module --repo . --entry-point src/api
 ```
 
 ### Step 2: Review Extracted Specs
@@ -63,13 +63,13 @@ For large codebases or monorepos with multiple projects, use `--entry-point` to 
 
 ```bash
 # Analyze individual projects in a monorepo
-specfact import from-code api-service --repo . --entry-point projects/api-service
-specfact import from-code web-app --repo . --entry-point projects/web-app
-specfact import from-code mobile-app --repo . --entry-point projects/mobile-app
+specfact code import api-service --repo . --entry-point projects/api-service
+specfact code import web-app --repo . --entry-point projects/web-app
+specfact code import mobile-app --repo . --entry-point projects/mobile-app
 
 # Analyze specific modules for incremental modernization
-specfact import from-code core-module --repo . --entry-point src/core
-specfact import from-code integrations-module --repo . --entry-point src/integrations
+specfact code import core-module --repo . --entry-point src/core
+specfact code import integrations-module --repo . --entry-point src/integrations
 ```
 
 **Benefits:**

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -30,13 +30,13 @@ Complete technical reference for SpecFact CLI.
 
 ### Commands
 
-- `specfact import from-bridge --adapter speckit` - Import from external tools via bridge adapter
-- `specfact import from-code <bundle-name>` - Reverse-engineer plans from code
+- `specfact project import from-bridge --adapter speckit` - Import from external tools via bridge adapter
+- `specfact code import <bundle-name>` - Reverse-engineer plans from code
 - `specfact plan init <bundle-name>` - Initialize new development plan
 - `specfact plan compare` - Compare manual vs auto plans
-- `specfact enforce stage` - Configure quality gates
-- `specfact repro` - Run full validation suite
-- `specfact sync bridge --adapter <adapter> --bundle <bundle-name>` - Sync with external tools via bridge adapter
+- `specfact govern enforce stage` - Configure quality gates
+- `specfact code repro` - Run full validation suite
+- `specfact project sync bridge --adapter <adapter> --bundle <bundle-name>` - Sync with external tools via bridge adapter
 - `specfact spec validate [--bundle <name>]` - Validate OpenAPI/AsyncAPI specifications
 - `specfact spec generate-tests [--bundle <name>]` - Generate contract tests from specifications
 - `specfact spec mock [--bundle <name>]` - Launch mock server for development

--- a/docs/reference/command-syntax-policy.md
+++ b/docs/reference/command-syntax-policy.md
@@ -19,7 +19,7 @@ Always document commands exactly as implemented by `specfact <command> --help` i
 ## Bundle Argument Conventions (v0.30.x baseline)
 
 - Positional bundle argument:
-  - `specfact import from-code [BUNDLE]`
+  - `specfact code import [BUNDLE]`
   - `specfact plan init BUNDLE`
   - `specfact plan review [BUNDLE]`
 - `--bundle` option:
@@ -43,7 +43,7 @@ Before merging command docs updates:
 ## Quick Verification Commands
 
 ```bash
-hatch run specfact import from-code --help
+hatch run specfact code import --help
 hatch run specfact plan init --help
 hatch run specfact plan review --help
 hatch run specfact plan add-feature --help

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -41,7 +41,7 @@ After bundle install, command groups are mounted by category:
 |---|---|---|
 | `nold-ai/specfact-project` | `project` | `project`, `plan`, `import`, `sync`, `migrate` |
 | `nold-ai/specfact-backlog` | `backlog` | `backlog`, `policy` |
-| `nold-ai/specfact-codebase` | `code` | `analyze`, `drift`, `validate`, `repro` |
+| `nold-ai/specfact-codebase` | `code` | `import`, `analyze`, `drift`, `validate`, `repro` |
 | `nold-ai/specfact-spec` | `spec` | `contract`, `api`, `sdd`, `generate` |
 | `nold-ai/specfact-govern` | `govern` | `enforce`, `patch` |
 
@@ -52,7 +52,8 @@ Flat compatibility shims were removed in this change. Use grouped commands.
 | Removed | Replacement |
 |---|---|
 | `specfact plan ...` | `specfact project plan ...` |
-| `specfact import ...` | `specfact project import ...` |
+| `specfact import from-code ...` | `specfact code import ...` |
+| `specfact import from-bridge ...` | `specfact project import from-bridge ...` |
 | `specfact sync ...` | `specfact project sync ...` |
 | `specfact migrate ...` | `specfact project migrate ...` |
 | `specfact backlog ...` (flat module) | `specfact backlog ...` (bundle group) |
@@ -77,7 +78,7 @@ specfact init --profile solo-developer
 specfact module install nold-ai/specfact-backlog
 
 # Project workflow examples
-specfact project import from-code legacy-api --repo .
+specfact code import legacy-api --repo .
 specfact project plan review legacy-api
 
 # Code workflow examples

--- a/docs/reference/directory-structure.md
+++ b/docs/reference/directory-structure.md
@@ -355,13 +355,13 @@ See [`plan upgrade`](../reference/commands.md#plan-upgrade) for details.
 
 ## Default Command Paths
 
-### `specfact import from-code` ⭐ PRIMARY
+### `specfact code import` ⭐ PRIMARY
 
 **Primary use case**: Reverse-engineer existing codebases into project bundles.
 
 ```bash
 # Command syntax
-specfact import from-code <bundle-name> --repo . [OPTIONS]
+specfact code import <bundle-name> --repo . [OPTIONS]
 
 # Creates modular bundle at:
 .specfact/projects/<bundle-name>/
@@ -382,7 +382,7 @@ specfact import from-code <bundle-name> --repo . [OPTIONS]
 
 ```bash
 # Analyze legacy codebase
-specfact import from-code legacy-api --repo . --confidence 0.7
+specfact code import legacy-api --repo . --confidence 0.7
 
 # Creates:
 # - .specfact/projects/legacy-api/bundle.manifest.yaml (versioned)
@@ -713,7 +713,7 @@ SpecFact supports multiple plan bundles for:
 
 ```bash
 # Step 1: Reverse-engineer legacy codebase
-specfact import from-code legacy-api \
+specfact code import legacy-api \
   --repo src/legacy-api \
   --confidence 0.7
 
@@ -723,7 +723,7 @@ specfact plan compare \
   --auto .specfact/projects/modernized-api
 
 # Step 3: Analyze specific legacy component
-specfact import from-code legacy-payment \
+specfact code import legacy-payment \
   --repo src/legacy-payment \
   --confidence 0.7
 ```

--- a/docs/reference/feature-keys.md
+++ b/docs/reference/feature-keys.md
@@ -19,7 +19,7 @@ SpecFact CLI supports multiple feature key formats to accommodate different use 
 **Generation**:
 
 ```bash
-specfact import from-code --key-format classname
+specfact code import --key-format classname
 ```
 
 ### 2. Sequential Format
@@ -33,7 +33,7 @@ specfact import from-code --key-format classname
 **Generation**:
 
 ```bash
-specfact import from-code --key-format sequential
+specfact code import --key-format sequential
 ```
 
 **Manual creation**: When creating plans interactively, use `FEATURE-001` format:
@@ -171,7 +171,7 @@ specfact plan init
 When analyzing existing codebases:
 
 ```bash
-specfact import from-code --key-format classname  # ← Default, explicit for clarity
+specfact code import --key-format classname  # ← Default, explicit for clarity
 ```
 
 **Why**: Classname format directly maps to codebase structure, making it easy to trace features back to classes.

--- a/docs/reference/modes.md
+++ b/docs/reference/modes.md
@@ -223,7 +223,7 @@ print(f'Execution mode: {result.execution_mode}')
 # In GitHub Actions or CI/CD
 # No environment variables set
 # Should auto-detect CI/CD mode (bundle name as positional argument)
-hatch run specfact import from-code my-project --repo . --confidence 0.7
+hatch run specfact code import my-project --repo . --confidence 0.7
 
 # Expected: Mode: CI/CD (direct execution)
 ```
@@ -234,7 +234,7 @@ hatch run specfact import from-code my-project --repo . --confidence 0.7
 # Developer running in VS Code/Cursor with CoPilot enabled
 # IDE environment variables automatically set
 # Should auto-detect CoPilot mode (bundle name as positional argument)
-hatch run specfact import from-code my-project --repo . --confidence 0.7
+hatch run specfact code import my-project --repo . --confidence 0.7
 
 # Expected: Mode: CoPilot (agent routing)
 ```

--- a/docs/reference/telemetry.md
+++ b/docs/reference/telemetry.md
@@ -488,7 +488,7 @@ Only if you explicitly opt in. We recommend enabling telemetry in CI/CD to track
 **How do I verify telemetry is working?**
 
 1. Enable debug mode: `export SPECFACT_TELEMETRY_DEBUG=true`
-2. Run a command: `specfact import from-code --repo .`
+2. Run a command: `specfact code import --repo .`
 3. Check local log: `tail -f ~/.specfact/telemetry.log`
 4. Verify events appear in your OTLP collector (if configured)
 


### PR DESCRIPTION
# Summary

Promote the latest `dev` changes to `main` after the post-release docs alignment follow-up.

This release PR carries the documentation and reference cleanup that aligns the published `specfact-cli-modules` docs with the canonical `specfact code import` command surface and current grouped command ownership model.

Refs:
- specfact-cli issue: #407
- related module migration item/change: #408

## Scope

- [ ] Bundle source changes under `packages/`
- [ ] Registry/manifest changes (`registry/index.json`, `packages/*/module-package.yaml`)
- [ ] CI/workflow changes (`.github/workflows/*`)
- [x] Documentation changes (`docs/*`, `README.md`, `AGENTS.md`)
- [ ] Security/signing changes (`scripts/sign-modules.py`, `scripts/verify-modules-signature.py`)

## Bundle Impact

List impacted bundles and version updates:

- `nold-ai/specfact-project`: `0.40.20 -> 0.40.20`
- `nold-ai/specfact-backlog`: `0.41.12 -> 0.41.12`
- `nold-ai/specfact-codebase`: `0.41.0 -> 0.41.0`
- `nold-ai/specfact-spec`: `0.40.14 -> 0.40.14`
- `nold-ai/specfact-govern`: `0.40.17 -> 0.40.17`

## Validation Evidence

Merged PR evidence:
- #60 `Align modules docs with code import command surface`

Current `dev` CI evidence should run on this release PR as usual.

### Required local gates

- [ ] `hatch run format`
- [ ] `hatch run type-check`
- [ ] `hatch run lint`
- [ ] `hatch run yaml-lint`
- [ ] `hatch run check-bundle-imports`
- [ ] `hatch run contract-test`
- [ ] `hatch run smart-test` (or `hatch run test`)

### Signature + version integrity (required)

- [x] `hatch run verify-modules-signature --require-signature --enforce-version-bump`
- [x] Changed bundle versions were bumped before signing
- [x] Manifests re-signed after bundle content changes

## CI and Branch Protection

- [x] PR orchestrator jobs expected:
  - `verify-module-signatures`
  - `quality (3.11)`
  - `quality (3.12)`
  - `quality (3.13)`
- [x] Branch protection required checks are aligned with the above

## Docs / Pages

- [x] Bundle/module docs updated in this repo (`docs/`)
- [x] Pages workflow impact reviewed (`docs-pages.yml`, if changed)
- [x] Cross-links from `specfact-cli` docs updated (if applicable)

## Checklist

- [x] Self-review completed
- [x] No unrelated files or generated artifacts included
- [x] Backward-compatibility/rollout notes documented (if needed)
