### PR TITLE
feat(code-review): add basedpyright and pylint runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this repository will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows SemVer for bundle versions.
+
+## [0.41.4] - 2026-03-13
+
+### Added
+
+- Add `basedpyright` and `pylint` review runners to `specfact-code-review` for governed type-safety and architecture findings.
+
+### Changed
+
+- Document the new code-review tool runners and bump the `specfact-code-review` bundle patch version for the signed module update.

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -52,3 +52,49 @@ Additional behavior:
 - the default Hatch environment installs `radon`, so the runner is usable in standard repo workflows
 - only the provided file list is considered
 - malformed output or a missing Radon executable yields a single `tool_error` finding
+
+### basedpyright runner
+
+`specfact_code_review.tools.basedpyright_runner.run_basedpyright(files)` executes:
+
+```bash
+basedpyright --outputjson --project . <files...>
+```
+
+Diagnostic mapping:
+
+| basedpyright severity | ReviewFinding severity | ReviewFinding category |
+| --- | --- | --- |
+| `error` | `error` | `type_safety` |
+| `warning` | `warning` | `type_safety` |
+| `information` | `info` | `type_safety` |
+
+Additional behavior:
+
+- basedpyright runs with project context and then filters findings back to the provided changed-file list
+- the runner preserves per-diagnostic line numbers and falls back to rule `basedpyright` when the payload omits a specific rule id
+- malformed output or a missing basedpyright executable yields a single `tool_error` finding
+
+### pylint runner
+
+`specfact_code_review.tools.pylint_runner.run_pylint(files)` executes:
+
+```bash
+pylint --output-format json <files...>
+```
+
+Governance-oriented message mapping:
+
+| Pylint message id | ReviewFinding category |
+| --- | --- |
+| `W0702` | `architecture` |
+| `W0703` | `architecture` |
+| `T201` | `architecture` |
+| `W1505` | `architecture` |
+| other ids | `style` |
+
+Additional behavior:
+
+- only the provided changed-file list is reported back, even when pylint emits findings for other files
+- severity is derived from the message id prefix (`E*`/`F*` -> `error`, `I*` -> `info`, otherwise `warning`)
+- malformed output or a missing pylint executable yields a single `tool_error` finding

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.41.3
+version: 0.41.4
 commands:
   - code
 tier: official
@@ -12,5 +12,5 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:efa08dbb3993bd1dd39842b265e8d7d63bb2c1b13babe04556d69181d09d46cc
-  signature: SxHkBwR6yrjHDgaZmu9o9OMZTMPCMJXT452o3VT5eP7Onx+kK+bgQSxQdY7lfQQr7xbiZJKMHVtu0aZiav70Cw==
+  checksum: sha256:df631e801993fe0cffa2417a59e98b87f7edceeb32bfe62b3f243428cb4f22a6
+  signature: lYNJ2jCNHPfy8s6F2chEVX/8APygu/xZCJCRGQ+yw0O4MN3GMxs4V4c30YraIEi0MDBvZwnjpKS6Fz1FZiB8BA==

--- a/packages/specfact-code-review/src/specfact_code_review/tools/__init__.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/__init__.py
@@ -1,7 +1,9 @@
 """Tool runners for code-review analysis."""
 
+from specfact_code_review.tools.basedpyright_runner import run_basedpyright
+from specfact_code_review.tools.pylint_runner import run_pylint
 from specfact_code_review.tools.radon_runner import run_radon
 from specfact_code_review.tools.ruff_runner import run_ruff
 
 
-__all__ = ["run_radon", "run_ruff"]
+__all__ = ["run_basedpyright", "run_pylint", "run_radon", "run_ruff"]

--- a/packages/specfact-code-review/src/specfact_code_review/tools/basedpyright_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/basedpyright_runner.py
@@ -1,0 +1,129 @@
+"""basedpyright runner for governed code-review findings."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from beartype import beartype
+from icontract import ensure, require
+
+from specfact_code_review.run.findings import ReviewFinding
+
+
+def _normalize_path_variants(path_value: str | Path) -> set[str]:
+    path = Path(path_value)
+    variants = {
+        os.path.normpath(str(path)),
+        os.path.normpath(path.as_posix()),
+    }
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return variants
+    variants.add(os.path.normpath(str(resolved)))
+    variants.add(os.path.normpath(resolved.as_posix()))
+    return variants
+
+
+def _allowed_paths(files: list[Path]) -> set[str]:
+    allowed: set[str] = set()
+    for file_path in files:
+        allowed.update(_normalize_path_variants(file_path))
+    return allowed
+
+
+def _map_severity(raw_severity: str) -> str:
+    if raw_severity == "error":
+        return "error"
+    if raw_severity == "warning":
+        return "warning"
+    return "info"
+
+
+def _tool_error(file_path: Path, message: str) -> list[ReviewFinding]:
+    return [
+        ReviewFinding(
+            category="tool_error",
+            severity="error",
+            tool="basedpyright",
+            rule="tool_error",
+            file=str(file_path),
+            line=1,
+            message=message,
+            fixable=False,
+        )
+    ]
+
+
+@beartype
+@require(lambda files: isinstance(files, list), "files must be a list")
+@require(lambda files: all(isinstance(file_path, Path) for file_path in files), "files must contain Path instances")
+@ensure(lambda result: isinstance(result, list), "result must be a list")
+@ensure(
+    lambda result: all(isinstance(finding, ReviewFinding) for finding in result),
+    "result must contain ReviewFinding instances",
+)
+def run_basedpyright(files: list[Path]) -> list[ReviewFinding]:
+    """Run basedpyright and map diagnostics into ReviewFinding records."""
+    if not files:
+        return []
+
+    try:
+        result = subprocess.run(
+            ["basedpyright", "--outputjson", "--project", ".", *(str(file_path) for file_path in files)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        payload = json.loads(result.stdout)
+        if not isinstance(payload, dict):
+            raise ValueError("basedpyright output must be an object")
+        diagnostics = payload["generalDiagnostics"]
+        if not isinstance(diagnostics, list):
+            raise ValueError("generalDiagnostics must be a list")
+    except (FileNotFoundError, OSError, ValueError, json.JSONDecodeError, KeyError, subprocess.TimeoutExpired) as exc:
+        return _tool_error(files[0], f"Unable to parse basedpyright output: {exc}")
+
+    allowed_paths = _allowed_paths(files)
+    findings: list[ReviewFinding] = []
+    try:
+        for diagnostic in diagnostics:
+            if not isinstance(diagnostic, dict):
+                raise ValueError("basedpyright diagnostic must be an object")
+            filename = diagnostic["file"]
+            if not isinstance(filename, str):
+                raise ValueError("basedpyright filename must be a string")
+            if _normalize_path_variants(filename).isdisjoint(allowed_paths):
+                continue
+            raw_severity = diagnostic["severity"]
+            if not isinstance(raw_severity, str):
+                raise ValueError("basedpyright severity must be a string")
+            message = diagnostic["message"]
+            if not isinstance(message, str):
+                raise ValueError("basedpyright message must be a string")
+            line = diagnostic["range"]["start"]["line"]
+            if not isinstance(line, int):
+                raise ValueError("basedpyright line must be an integer")
+            rule = diagnostic.get("rule")
+            if rule is not None and not isinstance(rule, str):
+                raise ValueError("basedpyright rule must be a string when present")
+            findings.append(
+                ReviewFinding(
+                    category="type_safety",
+                    severity=_map_severity(raw_severity),
+                    tool="basedpyright",
+                    rule=rule or "basedpyright",
+                    file=filename,
+                    line=line + 1,
+                    message=message,
+                    fixable=False,
+                )
+            )
+    except (KeyError, TypeError, ValueError) as exc:
+        return _tool_error(files[0], f"Unable to parse basedpyright finding payload: {exc}")
+
+    return findings

--- a/packages/specfact-code-review/src/specfact_code_review/tools/pylint_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/pylint_runner.py
@@ -1,0 +1,131 @@
+"""pylint runner for governed code-review findings."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from beartype import beartype
+from icontract import ensure, require
+
+from specfact_code_review.run.findings import ReviewFinding
+
+
+PYLINT_CATEGORY_MAP = {
+    "W0702": "architecture",
+    "W0703": "architecture",
+    "T201": "architecture",
+    "W1505": "architecture",
+}
+
+
+def _normalize_path_variants(path_value: str | Path) -> set[str]:
+    path = Path(path_value)
+    variants = {
+        os.path.normpath(str(path)),
+        os.path.normpath(path.as_posix()),
+    }
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return variants
+    variants.add(os.path.normpath(str(resolved)))
+    variants.add(os.path.normpath(resolved.as_posix()))
+    return variants
+
+
+def _allowed_paths(files: list[Path]) -> set[str]:
+    allowed: set[str] = set()
+    for file_path in files:
+        allowed.update(_normalize_path_variants(file_path))
+    return allowed
+
+
+def _map_severity(message_id: str) -> str:
+    if message_id.startswith(("E", "F")):
+        return "error"
+    if message_id.startswith("I"):
+        return "info"
+    return "warning"
+
+
+def _tool_error(file_path: Path, message: str) -> list[ReviewFinding]:
+    return [
+        ReviewFinding(
+            category="tool_error",
+            severity="error",
+            tool="pylint",
+            rule="tool_error",
+            file=str(file_path),
+            line=1,
+            message=message,
+            fixable=False,
+        )
+    ]
+
+
+@beartype
+@require(lambda files: isinstance(files, list), "files must be a list")
+@require(lambda files: all(isinstance(file_path, Path) for file_path in files), "files must contain Path instances")
+@ensure(lambda result: isinstance(result, list), "result must be a list")
+@ensure(
+    lambda result: all(isinstance(finding, ReviewFinding) for finding in result),
+    "result must contain ReviewFinding instances",
+)
+def run_pylint(files: list[Path]) -> list[ReviewFinding]:
+    """Run pylint and map message IDs into ReviewFinding records."""
+    if not files:
+        return []
+
+    try:
+        result = subprocess.run(
+            ["pylint", "--output-format", "json", *(str(file_path) for file_path in files)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        payload = json.loads(result.stdout)
+        if not isinstance(payload, list):
+            raise ValueError("pylint output must be a list")
+    except (FileNotFoundError, OSError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as exc:
+        return _tool_error(files[0], f"Unable to parse pylint output: {exc}")
+
+    allowed_paths = _allowed_paths(files)
+    findings: list[ReviewFinding] = []
+    try:
+        for item in payload:
+            if not isinstance(item, dict):
+                raise ValueError("pylint finding must be an object")
+            filename = item["path"]
+            if not isinstance(filename, str):
+                raise ValueError("pylint path must be a string")
+            if _normalize_path_variants(filename).isdisjoint(allowed_paths):
+                continue
+            message_id = item["message-id"]
+            if not isinstance(message_id, str):
+                raise ValueError("pylint message-id must be a string")
+            line = item["line"]
+            if not isinstance(line, int):
+                raise ValueError("pylint line must be an integer")
+            message = item["message"]
+            if not isinstance(message, str):
+                raise ValueError("pylint message must be a string")
+            findings.append(
+                ReviewFinding(
+                    category=PYLINT_CATEGORY_MAP.get(message_id, "style"),
+                    severity=_map_severity(message_id),
+                    tool="pylint",
+                    rule=message_id,
+                    file=filename,
+                    line=line,
+                    message=message,
+                    fixable=False,
+                )
+            )
+    except (KeyError, TypeError, ValueError) as exc:
+        return _tool_error(files[0], f"Unable to parse pylint finding payload: {exc}")
+
+    return findings

--- a/tests/unit/specfact_code_review/tools/test_basedpyright_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_basedpyright_runner.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+from pytest import MonkeyPatch
+
+from specfact_code_review.tools.basedpyright_runner import run_basedpyright
+from tests.unit.specfact_code_review.tools.helpers import assert_tool_run, completed_process
+
+
+def test_run_basedpyright_maps_error_diagnostic_to_type_safety(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = {
+        "generalDiagnostics": [
+            {
+                "file": str(file_path),
+                "range": {"start": {"line": 3, "character": 0}},
+                "severity": "error",
+                "message": 'Argument of type "int" cannot be assigned to parameter of type "str"',
+            }
+        ]
+    }
+    run_mock = Mock(return_value=completed_process("basedpyright", stdout=json.dumps(payload), returncode=1))
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    findings = run_basedpyright([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "type_safety"
+    assert findings[0].severity == "error"
+    assert findings[0].tool == "basedpyright"
+    assert findings[0].file == str(file_path)
+    assert findings[0].line == 4
+    assert_tool_run(run_mock, ["basedpyright", "--outputjson", "--project", ".", str(file_path)])
+
+
+def test_run_basedpyright_maps_warning_severity(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = {
+        "generalDiagnostics": [
+            {
+                "file": str(file_path),
+                "range": {"start": {"line": 6, "character": 0}},
+                "severity": "warning",
+                "message": "Code is unreachable",
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        Mock(return_value=completed_process("basedpyright", stdout=json.dumps(payload), returncode=1)),
+    )
+
+    findings = run_basedpyright([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert findings[0].rule == "basedpyright"
+
+
+def test_run_basedpyright_filters_findings_to_requested_files(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    other_path = tmp_path / "other.py"
+    payload = {
+        "generalDiagnostics": [
+            {
+                "file": str(file_path),
+                "range": {"start": {"line": 1, "character": 0}},
+                "severity": "error",
+                "message": "Type mismatch",
+            },
+            {
+                "file": str(other_path),
+                "range": {"start": {"line": 2, "character": 0}},
+                "severity": "error",
+                "message": "Skip me",
+            },
+        ]
+    }
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        Mock(return_value=completed_process("basedpyright", stdout=json.dumps(payload), returncode=1)),
+    )
+
+    findings = run_basedpyright([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].file == str(file_path)
+    assert findings[0].message == "Type mismatch"
+
+
+def test_run_basedpyright_returns_tool_error_when_unavailable(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    run_mock = Mock(side_effect=FileNotFoundError("basedpyright not found"))
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    findings = run_basedpyright([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "tool_error"
+    assert findings[0].tool == "basedpyright"

--- a/tests/unit/specfact_code_review/tools/test_pylint_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_pylint_runner.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+from pytest import MonkeyPatch
+
+from specfact_code_review.tools.pylint_runner import run_pylint
+from tests.unit.specfact_code_review.tools.helpers import assert_tool_run, completed_process
+
+
+def test_run_pylint_maps_bare_except_to_architecture(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = [
+        {
+            "message-id": "W0702",
+            "path": str(file_path),
+            "line": 7,
+            "message": "No exception type(s) specified",
+        }
+    ]
+    run_mock = Mock(return_value=completed_process("pylint", stdout=json.dumps(payload), returncode=16))
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "architecture"
+    assert findings[0].severity == "warning"
+    assert findings[0].rule == "W0702"
+    assert_tool_run(run_mock, ["pylint", "--output-format", "json", str(file_path)])
+
+
+def test_run_pylint_maps_broad_except_to_architecture(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = [
+        {
+            "message-id": "W0703",
+            "path": str(file_path),
+            "line": 11,
+            "message": "Catching too general exception Exception",
+        }
+    ]
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=completed_process("pylint", stdout=json.dumps(payload))))
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "architecture"
+    assert findings[0].rule == "W0703"
+
+
+def test_run_pylint_filters_findings_to_requested_files(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    other_path = tmp_path / "other.py"
+    payload = [
+        {
+            "message-id": "W0702",
+            "path": str(file_path),
+            "line": 7,
+            "message": "No exception type(s) specified",
+        },
+        {
+            "message-id": "W0703",
+            "path": str(other_path),
+            "line": 9,
+            "message": "Catching too general exception Exception",
+        },
+    ]
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=completed_process("pylint", stdout=json.dumps(payload))))
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].file == str(file_path)
+    assert findings[0].rule == "W0702"
+
+
+def test_run_pylint_returns_tool_error_on_parse_error(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        Mock(return_value=completed_process("pylint", stdout="not-json", returncode=32)),
+    )
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "tool_error"
+    assert findings[0].tool == "pylint"


### PR DESCRIPTION
# Summary

Add `basedpyright` and `pylint` runners to `specfact-code-review` so the bundle can surface governed type-safety and architecture findings alongside the existing Ruff and Radon checks.

Refs:
- specfact-cli issue: not created in this PR
- related module migration item/change: `code-review-03-type-governance-runners`

## Scope

- [x] Bundle source changes under `packages/`
- [x] Registry/manifest changes (`registry/index.json`, `packages/*/module-package.yaml`)
- [ ] CI/workflow changes (`.github/workflows/*`)
- [x] Documentation changes (`docs/*`, `README.md`, `AGENTS.md`)
- [ ] Security/signing changes (`scripts/sign-modules.py`, `scripts/verify-modules-signature.py`)

## Bundle Impact

List impacted bundles and version updates:

- `nold-ai/specfact-code-review`: `0.41.3 -> 0.41.4`
- `nold-ai/specfact-project`: `no change`
- `nold-ai/specfact-backlog`: `no change`
- `nold-ai/specfact-codebase`: `no change`
- `nold-ai/specfact-spec`: `no change`
- `nold-ai/specfact-govern`: `no change`

## Validation Evidence

Local validation completed in the feature worktree, including a live runner sanity check against a temporary Python file.

### Required local gates

- [x] `hatch run format`
- [x] `hatch run type-check`
- [x] `hatch run lint`
- [x] `hatch run yaml-lint`
- [x] `hatch run check-bundle-imports`
- [x] `hatch run contract-test`
- [x] `hatch run smart-test` (or `hatch run test`)

### Signature + version integrity (required)

- [x] `hatch run verify-modules-signature --require-signature --enforce-version-bump`
- [x] Changed bundle versions were bumped before signing
- [x] Manifests re-signed after bundle content changes

## CI and Branch Protection

- [x] PR orchestrator jobs expected:
  - `verify-module-signatures`
  - `quality (3.11)`
  - `quality (3.12)`
  - `quality (3.13)`
- [x] Branch protection required checks are aligned with the above

## Docs / Pages

- [x] Bundle/module docs updated in this repo (`docs/`)
- [x] Pages workflow impact reviewed (`docs-pages.yml`, if changed)
- [ ] Cross-links from `specfact-cli` docs updated (if applicable)

## Checklist

- [x] Self-review completed
- [x] No unrelated files or generated artifacts included
- [x] Backward-compatibility/rollout notes documented (if needed)

Made with [Cursor](https://cursor.com)