### PR TITLE
Add house-rules skill to specfact-code-review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this repository will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows SemVer for bundle versions.
 
+## [0.42.1] - 2026-03-16
+
+### Added
+
+- Add `specfact code review rules show|init|update` to manage a generated
+  `skills/specfact-code-review/SKILL.md` house-rules skill from recent ledger
+  history.
+
+### Changed
+
+- Document the house-rules workflow, including the 35-line skill budget and the
+  optional `.cursor/rules/house_rules.mdc` mirror updated from ledger data.
+
 ## [0.42.0] - 2026-03-16
 
 ### Added

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -204,6 +204,34 @@ specfact module init --scope project
 
 Then rerun the ledger command from the same repository checkout.
 
+## House rules skill
+
+The `specfact-code-review` bundle can derive a compact house-rules skill from the
+reward ledger and keep it small enough for AI session context injection.
+
+### Command flow
+
+```bash
+specfact code review rules init
+specfact code review rules show
+specfact code review rules update
+```
+
+### Generated files
+
+- `rules init` creates `skills/specfact-code-review/SKILL.md` in the current
+  project without touching `CLAUDE.md`.
+- `rules show` prints the current `SKILL.md` content and suggests `rules init`
+  when the file is missing.
+- `rules update` reads the last 20 ledger runs, surfaces rule IDs with at least
+  three hits in the auto-managed `TOP VIOLATIONS` section, prunes stale entries
+  that have disappeared for 10 runs, and increments the skill version header.
+- The updater preserves the curated `DO` and `DON'T` sections, updates the
+  `Updated:` timestamp, and enforces a 35-line hard cap by removing the
+  lowest-frequency violation entries first.
+- When `.cursor/rules/` already exists in the current project, `rules update`
+  also mirrors the generated content to `.cursor/rules/house_rules.mdc`.
+
 ## Review orchestration
 
 `specfact_code_review.run.runner.run_review(files, no_tests=False)` orchestrates the

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.42.0
+version: 0.42.1
 commands:
   - code
 tier: official
@@ -12,5 +12,5 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:d1be400445c194a80caa44e711d82c582f6f3a94875d5c1f07f8744ed940b536
-  signature: 32d7FpwI2LDzVC9s4yax27lFmJiebAlQhgPrHBBgQgGHuW9Z5xLiER04gs2M+JUEA8OSqIRDP4IL+aDa5BXMDA==
+  checksum: sha256:9209645b82cf2776d2853c7ba5142954ee6202f3312ddbd7366330de6d6c605c
+  signature: ILNlkWUgYGAPLegYIPURz/p8yIaHGWZ8BTXGqzZSgmEyjL3IAgkUvv0Nd90zTLe4I65Q1vWikcU9Edli1rJOAg==

--- a/packages/specfact-code-review/src/specfact_code_review/ledger/client.py
+++ b/packages/specfact-code-review/src/specfact_code_review/ledger/client.py
@@ -91,6 +91,15 @@ class LedgerClient:
         return self._status_payload(state)
 
     @beartype
+    @ensure(lambda result: isinstance(result, list), "get_recent_runs must return a list")
+    def get_recent_runs(self, *, limit: int = 20) -> list[LedgerRun]:
+        """Return the most recent persisted review runs."""
+        runs = self._read_supabase_runs(limit=limit) if self._supabase_enabled else None
+        if runs is None:
+            runs = self._read_local_state().runs[-limit:]
+        return list(runs)
+
+    @beartype
     @ensure(lambda result: isinstance(result, bool), "reset_local must return a boolean")
     def reset_local(self) -> bool:
         """Delete the local fallback ledger if it exists."""
@@ -160,6 +169,35 @@ class LedgerClient:
     def _write_local_state(self, state: LedgerState) -> None:
         self._local_path.parent.mkdir(parents=True, exist_ok=True)
         self._local_path.write_text(state.model_dump_json(indent=2), encoding="utf-8")
+
+    def _read_supabase_runs(self, *, limit: int) -> list[LedgerRun] | None:
+        try:
+            response = requests.get(
+                f"{self._supabase_url}/rest/v1/review_runs",
+                headers=self._supabase_headers(),
+                params={
+                    "agent": f"eq.{self._agent}",
+                    "order": "created_at.desc",
+                    "limit": str(limit),
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except (requests.RequestException, ValueError):
+            return None
+
+        if not isinstance(payload, list):
+            return None
+
+        runs: list[LedgerRun] = []
+        for entry in reversed(payload):
+            if isinstance(entry, dict):
+                try:
+                    runs.append(LedgerRun.model_validate(entry))
+                except Exception:
+                    return None
+        return runs
 
     def _read_supabase_state(self) -> LedgerState | None:
         if not self._supabase_enabled:

--- a/packages/specfact-code-review/src/specfact_code_review/review/commands.py
+++ b/packages/specfact-code-review/src/specfact_code_review/review/commands.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import typer
 
 from specfact_code_review.ledger.commands import app as ledger_app
+from specfact_code_review.rules.commands import app as rules_app
 from specfact_code_review.run.commands import app as run_app
 
 
 app = typer.Typer(help="Code command extensions for structured review workflows.", no_args_is_help=True)
 review_app = typer.Typer(help="Governed code review workflows.", no_args_is_help=True)
-rules_app = typer.Typer(help="Review house rules commands (stub).", no_args_is_help=False)
 
 review_app.add_typer(run_app, name="run")
 review_app.add_typer(ledger_app, name="ledger")

--- a/packages/specfact-code-review/src/specfact_code_review/rules/__init__.py
+++ b/packages/specfact-code-review/src/specfact_code_review/rules/__init__.py
@@ -1,0 +1,7 @@
+"""House-rules helpers for the code-review bundle."""
+
+from specfact_code_review.rules.commands import app
+from specfact_code_review.rules.updater import default_skill_content, update_house_rules
+
+
+__all__ = ["app", "default_skill_content", "update_house_rules"]

--- a/packages/specfact-code-review/src/specfact_code_review/rules/commands.py
+++ b/packages/specfact-code-review/src/specfact_code_review/rules/commands.py
@@ -1,0 +1,70 @@
+"""Typer command surface for house-rules skill management."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from specfact_code_review.ledger.client import LedgerClient
+from specfact_code_review.rules.updater import MIRROR_PATH, SKILL_PATH, default_skill_content, update_house_rules
+
+
+app = typer.Typer(help="Manage the code-review house-rules skill.", no_args_is_help=True)
+
+
+@app.command("show")
+def show() -> None:
+    """Print the current skill content."""
+    skill_path = _skill_path()
+    if not skill_path.exists():
+        typer.echo(
+            f"No house-rules skill found at {skill_path}. Run `specfact code review rules init` first.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    typer.echo(skill_path.read_text(encoding="utf-8"), nl=False)
+
+
+@app.command("init")
+def init() -> None:
+    """Create the default skill file for the current project."""
+    skill_path = _skill_path()
+    if skill_path.exists():
+        typer.echo(f"House-rules skill already exists at {skill_path}.", err=True)
+        raise typer.Exit(code=1)
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_text(default_skill_content(), encoding="utf-8")
+    typer.echo(f"Created {skill_path}")
+
+
+@app.command("update")
+def update() -> None:
+    """Update the TOP VIOLATIONS section from recent ledger data."""
+    skill_path = _skill_path()
+    if not skill_path.exists():
+        typer.echo(
+            f"No house-rules skill found at {skill_path}. Run `specfact code review rules init` first.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    runs = LedgerClient().get_recent_runs(limit=20)
+    mirror_path = _mirror_path()
+    update_house_rules(
+        skill_path,
+        runs,
+        mirror_path=mirror_path if mirror_path.parent.exists() else None,
+    )
+    typer.echo(f"Updated {skill_path}")
+
+
+def _skill_path() -> Path:
+    return Path.cwd() / SKILL_PATH
+
+
+def _mirror_path() -> Path:
+    return Path.cwd() / MIRROR_PATH
+
+
+__all__ = ["app"]

--- a/packages/specfact-code-review/src/specfact_code_review/rules/updater.py
+++ b/packages/specfact-code-review/src/specfact_code_review/rules/updater.py
@@ -1,0 +1,188 @@
+"""House-rules skill template and update algorithm."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Callable, Sequence
+from datetime import date
+from pathlib import Path
+
+from beartype import beartype
+from icontract import ensure, require
+
+from specfact_code_review.ledger.client import LedgerRun
+
+
+MAX_SKILL_LINES = 35
+SKILL_PATH = Path("skills/specfact-code-review/SKILL.md")
+MIRROR_PATH = Path(".cursor/rules/house_rules.mdc")
+TITLE_PREFIX = "# House Rules - AI Coding Context"
+MODULE_LABEL = "nold-ai/specfact-code-review"
+TOP_VIOLATIONS_HEADER = "## TOP VIOLATIONS (auto-updated by specfact code review rules update)"
+TOP_VIOLATIONS_MARKER = "<!-- auto-managed: do not edit manually -->"
+DEFAULT_DO_RULES = (
+    "- Keep functions under 120 LOC and cyclomatic complexity <= 12",
+    "- Add @require/@ensure (icontract) + @beartype to all new public APIs",
+    "- Run hatch run contract-test-contracts before any commit",
+    "- Guard all chained attribute access: a.b.c needs null-check or early return",
+    "- Return typed values from all public methods",
+    "- Write the test file BEFORE the feature file (TDD-first)",
+    "- Use get_logger(__name__) from common.logger_setup, never print()",
+)
+DEFAULT_DONT_RULES = (
+    "- Don't mix read + write in the same method; split responsibilities",
+    "- Don't use bare except: or except Exception: pass",
+    "- Don't add # noqa / # type: ignore without inline justification",
+    "- Don't call repository.* and http_client.* in the same function",
+    "- Don't import at module level if it triggers network calls",
+    "- Don't hardcode secrets; use env vars via pydantic.BaseSettings",
+    "- Don't create functions > 120 lines",
+)
+
+
+@beartype
+@ensure(
+    lambda result: len(result.splitlines()) <= MAX_SKILL_LINES,
+    f"house-rules skill must stay within {MAX_SKILL_LINES} lines",
+)
+def default_skill_content(*, updated_on: date | None = None) -> str:
+    """Return the default house-rules skill content."""
+    stamp = (updated_on or date.today()).isoformat()
+    lines = [
+        "---",
+        "name: specfact-code-review",
+        "description: House rules for AI coding sessions derived from review findings",
+        "allowed-tools: []",
+        "---",
+        "",
+        f"{TITLE_PREFIX} (v1)",
+        "",
+        f"Updated: {stamp} | Module: {MODULE_LABEL}",
+        "",
+        "## DO",
+        *DEFAULT_DO_RULES,
+        "",
+        "## DON'T",
+        *DEFAULT_DONT_RULES,
+        "",
+        TOP_VIOLATIONS_HEADER,
+        TOP_VIOLATIONS_MARKER,
+    ]
+    return "\n".join(lines) + "\n"
+
+
+@beartype
+@require(lambda skill_path: skill_path.exists(), "skill_path must exist before update")
+def update_house_rules(
+    skill_path: Path,
+    runs: Sequence[LedgerRun],
+    *,
+    updated_on: date | None = None,
+    mirror_path: Path | None = None,
+) -> str:
+    """Update the skill file from recent ledger runs and return the new content."""
+    content = skill_path.read_text(encoding="utf-8")
+    updated = _render_updated_skill(content, runs=runs, updated_on=updated_on)
+    skill_path.write_text(updated, encoding="utf-8")
+    if mirror_path is not None:
+        mirror_path.parent.mkdir(parents=True, exist_ok=True)
+        mirror_path.write_text(updated, encoding="utf-8")
+    return updated
+
+
+@beartype
+@ensure(
+    lambda result: len(result.splitlines()) <= MAX_SKILL_LINES,
+    f"house-rules skill must stay within {MAX_SKILL_LINES} lines",
+)
+def _render_updated_skill(content: str, *, runs: Sequence[LedgerRun], updated_on: date | None = None) -> str:
+    lines = content.rstrip("\n").splitlines()
+    title_index = _find_index(lines, lambda line: line.startswith(TITLE_PREFIX))
+    updated_index = _find_index(lines, lambda line: line.startswith("Updated: "))
+    top_header_index = _find_index(lines, lambda line: line == TOP_VIOLATIONS_HEADER)
+    marker_index = top_header_index + 1
+
+    if marker_index >= len(lines) or lines[marker_index] != TOP_VIOLATIONS_MARKER:
+        msg = "Skill file is missing the auto-managed TOP VIOLATIONS marker."
+        raise ValueError(msg)
+
+    next_version = _next_version(lines[title_index])
+    stamp = (updated_on or date.today()).isoformat()
+    current_lines = list(lines)
+    current_lines[title_index] = f"{TITLE_PREFIX} (v{next_version})"
+    current_lines[updated_index] = f"Updated: {stamp} | Module: {MODULE_LABEL}"
+
+    recent_runs = sorted(runs, key=lambda run: run.created_at)[-20:]
+    recent_ten_runs = recent_runs[-10:]
+    rule_counts = _count_rules(recent_runs)
+    recent_ten_counts = _count_rules(recent_ten_runs)
+
+    existing_rules = _parse_existing_rules(current_lines[marker_index + 1 :])
+    candidate_counts: dict[str, int] = {rule: count for rule, count in rule_counts.items() if count >= 3}
+    for rule in existing_rules:
+        if recent_ten_counts.get(rule, 0) > 0:
+            candidate_counts.setdefault(rule, rule_counts.get(rule, 0))
+
+    ranked_rules = sorted(candidate_counts.items(), key=lambda item: (-item[1], item[0]))
+    preserved_lines = current_lines[: marker_index + 1]
+    rendered_lines = _render_with_budget(preserved_lines, ranked_rules)
+    return "\n".join(rendered_lines) + "\n"
+
+
+def _find_index(lines: list[str], predicate: Callable[[str], bool]) -> int:
+    for index, line in enumerate(lines):
+        if predicate(line):
+            return index
+    msg = "Skill file is missing a required section."
+    raise ValueError(msg)
+
+
+def _next_version(title_line: str) -> int:
+    match = re.search(r"\(v(?P<version>\d+)\)", title_line)
+    current = int(match.group("version")) if match else 1
+    return current + 1
+
+
+def _count_rules(runs: Sequence[LedgerRun]) -> Counter[str]:
+    counts: Counter[str] = Counter()
+    for run in runs:
+        for finding in run.findings_json:
+            rule = finding.get("rule")
+            if isinstance(rule, str) and rule.strip():
+                counts[rule] += 1
+    return counts
+
+
+def _parse_existing_rules(lines: Sequence[str]) -> list[str]:
+    rules: list[str] = []
+    for line in lines:
+        if not line.startswith("- "):
+            continue
+        rule = line[2:].split(" ", maxsplit=1)[0]
+        if rule:
+            rules.append(rule)
+    return rules
+
+
+def _render_with_budget(prefix_lines: list[str], ranked_rules: list[tuple[str, int]]) -> list[str]:
+    kept_rules = list(ranked_rules)
+    rendered = _materialize_lines(prefix_lines, kept_rules)
+    while len(rendered) > MAX_SKILL_LINES and kept_rules:
+        kept_rules.pop()
+        rendered = _materialize_lines(prefix_lines, kept_rules)
+    return rendered
+
+
+def _materialize_lines(prefix_lines: list[str], ranked_rules: Sequence[tuple[str, int]]) -> list[str]:
+    rule_lines = [f"- {rule} ({count} hits in last 20 runs)" for rule, count in ranked_rules]
+    return [*prefix_lines, *rule_lines]
+
+
+__all__ = [
+    "MAX_SKILL_LINES",
+    "MIRROR_PATH",
+    "SKILL_PATH",
+    "default_skill_content",
+    "update_house_rules",
+]

--- a/tests/unit/specfact_code_review/rules/test_updater.py
+++ b/tests/unit/specfact_code_review/rules/test_updater.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from icontract.errors import ViolationError
+from typer.testing import CliRunner
+
+from specfact_code_review.ledger.client import LedgerRun
+from specfact_code_review.review.commands import app
+from specfact_code_review.rules.updater import MAX_SKILL_LINES, SKILL_PATH, default_skill_content, update_house_rules
+
+
+runner = CliRunner()
+
+
+def _skill_text(
+    *,
+    version: int = 1,
+    updated_on: str = "2026-03-10",
+    top_rules: list[str] | None = None,
+    extra_do_rules: list[str] | None = None,
+) -> str:
+    do_rules = [
+        "- Keep functions under 120 LOC and cyclomatic complexity <= 12",
+        "- Add @require/@ensure (icontract) + @beartype to all new public APIs",
+        "- Run hatch run contract-test-contracts before any commit",
+        "- Guard all chained attribute access: a.b.c needs null-check or early return",
+        "- Return typed values from all public methods",
+        "- Write the test file BEFORE the feature file (TDD-first)",
+        "- Use get_logger(__name__) from common.logger_setup, never print()",
+    ]
+    if extra_do_rules:
+        do_rules.extend(extra_do_rules)
+
+    dont_rules = [
+        "- Don't mix read + write in the same method; split responsibilities",
+        "- Don't use bare except: or except Exception: pass",
+        "- Don't add # noqa / # type: ignore without inline justification",
+        "- Don't call repository.* and http_client.* in the same function",
+        "- Don't import at module level if it triggers network calls",
+        "- Don't hardcode secrets; use env vars via pydantic.BaseSettings",
+        "- Don't create functions > 120 lines",
+    ]
+
+    lines = [
+        "---",
+        "name: specfact-code-review",
+        "description: House rules for AI coding sessions derived from review findings",
+        "allowed-tools: []",
+        "---",
+        "",
+        f"# House Rules - AI Coding Context (v{version})",
+        "",
+        f"Updated: {updated_on} | Module: nold-ai/specfact-code-review",
+        "",
+        "## DO",
+        *do_rules,
+        "",
+        "## DON'T",
+        *dont_rules,
+        "",
+        "## TOP VIOLATIONS (auto-updated by specfact code review rules update)",
+        "<!-- auto-managed: do not edit manually -->",
+    ]
+    if top_rules:
+        lines.extend(top_rules)
+    return "\n".join(lines) + "\n"
+
+
+def _run(*rules: str, created_at: datetime | None = None) -> LedgerRun:
+    when = created_at or datetime(2026, 3, 10, tzinfo=UTC)
+    findings = [
+        {
+            "category": "clean_code",
+            "severity": "warning",
+            "tool": "ruff",
+            "rule": rule,
+            "file": "packages/specfact-code-review/src/specfact_code_review/run/runner.py",
+            "line": 10,
+            "message": f"{rule} finding",
+            "fixable": False,
+        }
+        for rule in rules
+    ]
+    return LedgerRun(
+        session_id=f"run-{when.isoformat()}",
+        score=80,
+        reward_delta=0,
+        verdict="PASS",
+        findings_json=findings,
+        created_at=when,
+    )
+
+
+def test_default_skill_content_stays_within_line_budget() -> None:
+    skill = default_skill_content(updated_on=date(2026, 3, 10))
+
+    assert len(skill.splitlines()) <= MAX_SKILL_LINES
+    assert "name: specfact-code-review" in skill
+    assert "allowed-tools: []" in skill
+
+
+def test_update_house_rules_surfaces_rule_with_three_hits(tmp_path: Path) -> None:
+    skill_path = tmp_path / "skills/specfact-code-review/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(_skill_text(), encoding="utf-8")
+
+    runs = [_run("C901"), _run("C901"), _run("C901"), _run("T201")]
+
+    updated = update_house_rules(skill_path, runs, updated_on=date(2026, 3, 16))
+
+    assert "- C901 (3 hits in last 20 runs)" in updated
+
+
+def test_update_house_rules_does_not_add_rule_below_threshold(tmp_path: Path) -> None:
+    skill_path = tmp_path / "skills/specfact-code-review/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(_skill_text(), encoding="utf-8")
+
+    updated = update_house_rules(skill_path, [_run("T201"), _run("T201")], updated_on=date(2026, 3, 16))
+
+    assert "- T201 (2 hits in last 20 runs)" not in updated
+
+
+def test_update_house_rules_prunes_rule_missing_for_ten_runs(tmp_path: Path) -> None:
+    skill_path = tmp_path / "skills/specfact-code-review/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(_skill_text(top_rules=["- W0702 (4 hits in last 20 runs)"]), encoding="utf-8")
+
+    runs = [_run("C901", created_at=datetime(2026, 3, 1, tzinfo=UTC) + timedelta(days=index)) for index in range(10)]
+
+    updated = update_house_rules(skill_path, runs, updated_on=date(2026, 3, 16))
+
+    assert "W0702" not in updated
+
+
+def test_update_house_rules_increments_version_and_updates_timestamp(tmp_path: Path) -> None:
+    skill_path = tmp_path / "skills/specfact-code-review/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(_skill_text(version=3, updated_on="2026-03-10"), encoding="utf-8")
+
+    updated = update_house_rules(skill_path, [_run("C901"), _run("C901"), _run("C901")], updated_on=date(2026, 3, 16))
+
+    assert "# House Rules - AI Coding Context (v4)" in updated
+    assert "Updated: 2026-03-16 | Module: nold-ai/specfact-code-review" in updated
+
+
+def test_update_house_rules_enforces_line_cap_by_pruning_lowest_frequency(tmp_path: Path) -> None:
+    skill_path = tmp_path / "skills/specfact-code-review/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(_skill_text(), encoding="utf-8")
+
+    runs = []
+    for index, rule in enumerate(("A100", "B200", "C300", "D400", "E500", "F600", "G700"), start=3):
+        runs.extend(_run(rule) for _ in range(index))
+
+    updated = update_house_rules(skill_path, runs, updated_on=date(2026, 3, 16))
+
+    assert len(updated.splitlines()) <= MAX_SKILL_LINES
+    assert "A100" not in updated
+    assert "B200" not in updated
+    assert "G700" in updated
+
+
+def test_update_house_rules_preserves_do_and_dont_sections(tmp_path: Path) -> None:
+    skill_path = tmp_path / "skills/specfact-code-review/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    original = _skill_text()
+    skill_path.write_text(original, encoding="utf-8")
+
+    updated = update_house_rules(skill_path, [_run("C901"), _run("C901"), _run("C901")], updated_on=date(2026, 3, 16))
+
+    original_do_dont = original.split("## TOP VIOLATIONS", maxsplit=1)[0]
+    updated_do_dont = updated.split("## TOP VIOLATIONS", maxsplit=1)[0]
+    assert updated_do_dont.replace("(v2)", "(v1)").replace("2026-03-16", "2026-03-10") == original_do_dont
+
+
+def test_update_house_rules_raises_when_output_exceeds_line_cap(tmp_path: Path) -> None:
+    skill_path = tmp_path / "skills/specfact-code-review/SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(
+        _skill_text(extra_do_rules=[f"- Extra rule {index}" for index in range(1, 8)]),
+        encoding="utf-8",
+    )
+
+    try:
+        update_house_rules(skill_path, [], updated_on=date(2026, 3, 16))
+    except ViolationError as error:
+        assert str(MAX_SKILL_LINES) in str(error)
+    else:
+        raise AssertionError("Expected icontract line-budget assertion to fail")
+
+
+def test_rules_show_prints_current_skill_content(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    skill_path = tmp_path / SKILL_PATH
+    skill_path.parent.mkdir(parents=True)
+    content = _skill_text()
+    skill_path.write_text(content, encoding="utf-8")
+
+    result = runner.invoke(app, ["review", "rules", "show"])
+
+    assert result.exit_code == 0
+    assert result.output == content
+
+
+def test_rules_show_missing_skill_prints_helpful_error(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["review", "rules", "show"])
+
+    assert result.exit_code == 1
+    assert "rules init" in result.output
+
+
+def test_rules_init_creates_default_skill_without_modifying_claude(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    claude_path = tmp_path / "CLAUDE.md"
+    claude_path.write_text("keep me\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["review", "rules", "init"])
+
+    assert result.exit_code == 0
+    assert (tmp_path / SKILL_PATH).exists()
+    assert claude_path.read_text(encoding="utf-8") == "keep me\n"
+
+
+def test_rules_update_rederives_top_violations_from_ledger(monkeypatch: Any, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    skill_path = tmp_path / SKILL_PATH
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text(_skill_text(version=3), encoding="utf-8")
+    (tmp_path / ".cursor/rules").mkdir(parents=True)
+
+    class FakeLedgerClient:
+        def get_recent_runs(self, limit: int = 20) -> list[LedgerRun]:
+            assert limit == 20
+            return [_run("C901"), _run("C901"), _run("C901"), _run("W0702")]
+
+    monkeypatch.setattr("specfact_code_review.rules.commands.LedgerClient", FakeLedgerClient)
+
+    result = runner.invoke(app, ["review", "rules", "update"])
+
+    assert result.exit_code == 0
+    updated = skill_path.read_text(encoding="utf-8")
+    assert "# House Rules - AI Coding Context (v4)" in updated
+    assert "C901" in updated
+    assert (tmp_path / ".cursor/rules/house_rules.mdc").read_text(encoding="utf-8") == updated


### PR DESCRIPTION
# Summary

Describe what changed in `specfact-cli-modules` and why.

Refs:
- specfact-cli issue: #
- related module migration item/change: #

## Scope

- [ ] Bundle source changes under `packages/`
- [ ] Registry/manifest changes (`registry/index.json`, `packages/*/module-package.yaml`)
- [ ] CI/workflow changes (`.github/workflows/*`)
- [ ] Documentation changes (`docs/*`, `README.md`, `AGENTS.md`)
- [ ] Security/signing changes (`scripts/sign-modules.py`, `scripts/verify-modules-signature.py`)

## Bundle Impact

List impacted bundles and version updates:

- `nold-ai/specfact-project`: `old -> new`
- `nold-ai/specfact-backlog`: `old -> new`
- `nold-ai/specfact-codebase`: `old -> new`
- `nold-ai/specfact-spec`: `old -> new`
- `nold-ai/specfact-govern`: `old -> new`

## Validation Evidence

Paste command output snippets or link workflow runs.

### Required local gates

- [ ] `hatch run format`
- [ ] `hatch run type-check`
- [ ] `hatch run lint`
- [ ] `hatch run yaml-lint`
- [ ] `hatch run check-bundle-imports`
- [ ] `hatch run contract-test`
- [ ] `hatch run smart-test` (or `hatch run test`)

### Signature + version integrity (required)

- [ ] `hatch run verify-modules-signature --require-signature --enforce-version-bump`
- [ ] Changed bundle versions were bumped before signing
- [ ] Manifests re-signed after bundle content changes

## CI and Branch Protection

- [ ] PR orchestrator jobs expected:
  - `verify-module-signatures`
  - `quality (3.11)`
  - `quality (3.12)`
  - `quality (3.13)`
- [ ] Branch protection required checks are aligned with the above

## Docs / Pages

- [ ] Bundle/module docs updated in this repo (`docs/`)
- [ ] Pages workflow impact reviewed (`docs-pages.yml`, if changed)
- [ ] Cross-links from `specfact-cli` docs updated (if applicable)

## Checklist

- [ ] Self-review completed
- [ ] No unrelated files or generated artifacts included
- [ ] Backward-compatibility/rollout notes documented (if needed)

Made with [Cursor](https://cursor.com)