### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,22 @@ Do not manually move folders under `openspec/changes/` into `openspec/changes/ar
 4. Publish with project tooling (`scripts/publish-module.py --bundle <name>` wrapper + packaging flow).
 5. Update `registry/index.json` with new `latest_version`, artifact URL, and checksum.
 6. Tag release and merge via PR after quality gates pass.
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- Python 3.12 is available at `/usr/bin/python3`. Hatch is at `$HOME/.local/bin/hatch`; ensure `$HOME/.local/bin` is on `PATH`.
+- The update script runs `hatch env create` and `hatch run pip install specfact-cli` on every VM startup.
+- There is **no sibling `specfact-cli` repo** in the Cloud VM. `hatch run dev-deps` will fail. Instead, `specfact-cli` is installed from PyPI into the hatch venv. This is sufficient for all quality gates and tests.
+
+### Running quality gates
+
+All standard quality gates are documented in the "Quality gates" section above. Key notes for Cloud:
+
+- `hatch run verify-modules-signature --require-signature --payload-from-filesystem --enforce-version-bump` **will fail** without the module-signing public key (env var `SPECFACT_MODULE_SIGNING_PUBLIC_KEY_PEM` or a key file). This is expected — signature verification is a CI-only gate.
+- All other gates (`format`, `type-check`, `lint`, `yaml-lint`, `contract-test`, `smart-test`, `test`) work out of the box.
+
+### No long-running services
+
+This is a pure Python library/tooling repo with no servers, databases, or Docker. "Running the application" means executing the hatch quality-gate scripts and test suite.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

Add Cursor Cloud-specific development environment instructions to `AGENTS.md` so future cloud agents can set up and run quality gates without manual intervention.

Refs:
- specfact-cli issue: N/A
- related module migration item/change: N/A

## Scope

- [x] Documentation changes (`docs/*`, `README.md`, `AGENTS.md`)

## Bundle Impact

No bundle changes — documentation only.

## Validation Evidence

All quality gates pass in the Cloud VM environment:

- `hatch run format` — All checks passed, 396 files unchanged
- `hatch run type-check` — 0 errors, 0 warnings, 0 notes
- `hatch run lint` — Pylint 10.00/10, ruff all checks passed
- `hatch run yaml-lint` — Validated 6 manifests and registry/index.json
- `hatch run contract-test` — 470 passed
- `hatch run smart-test` — 470 passed
- `hatch run test` — 470 passed

### Required local gates

- [x] `hatch run format`
- [x] `hatch run type-check`
- [x] `hatch run lint`
- [x] `hatch run yaml-lint`
- [x] `hatch run check-bundle-imports` (covered by lint)
- [x] `hatch run contract-test`
- [x] `hatch run smart-test` (or `hatch run test`)

### Signature + version integrity (required)

- [ ] `hatch run verify-modules-signature` — N/A (no signing key in Cloud VM; CI-only gate; no bundle changes in this PR)

## CI and Branch Protection

- [ ] PR orchestrator jobs expected (docs-only change)

## Docs / Pages

- [x] `AGENTS.md` updated with Cloud-specific instructions
- [ ] No bundle/module docs changes needed

## Checklist

- [x] Self-review completed
- [x] No unrelated files or generated artifacts included
- [x] Backward-compatibility/rollout notes documented (if needed) — N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4121a377-5729-43b9-b8dd-96337caa8849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4121a377-5729-43b9-b8dd-96337caa8849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

