### PR TITLE
fix(tools): remove unused validate_repo_manifests backward-compat aliases

### DIFF
--- a/tools/validate_repo_manifests.py
+++ b/tools/validate_repo_manifests.py
@@ -100,9 +100,5 @@ def main() -> int:
     return 0
 
 
-# Backward-compatible names (older tests or dynamic imports)
-_registry_module_ids = registry_module_ids
-_validate_manifest_bundle_dependency_refs = validate_manifest_bundle_dependency_refs
-
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
Removes `_registry_module_ids` and `_validate_manifest_bundle_dependency_refs` module-level assignments. They were unused (no repo references; unit tests use `registry_module_ids` / `validate_manifest_bundle_dependency_refs`) and triggered GitHub code-quality unused-global notes.

Made with [Cursor](https://cursor.com)