### PR TITLE
chore(openspec): restore project-runtime-01-safe-artifact-write-policy

### DIFF
--- a/openspec/changes/project-runtime-01-safe-artifact-write-policy/.openspec.yaml
+++ b/openspec/changes/project-runtime-01-safe-artifact-write-policy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-09

--- a/openspec/changes/project-runtime-01-safe-artifact-write-policy/CHANGE_VALIDATION.md
+++ b/openspec/changes/project-runtime-01-safe-artifact-write-policy/CHANGE_VALIDATION.md
@@ -1,0 +1,12 @@
+# CHANGE VALIDATION
+
+- **Change**: `project-runtime-01-safe-artifact-write-policy`
+- **Date**: 2026-04-09
+- **Method**: `openspec validate project-runtime-01-safe-artifact-write-policy --strict`
+- **Result**: PASS
+
+## Notes
+
+- Proposal, design, specs, and tasks are present and parse successfully.
+- This change is the modules-side runtime adoption companion to the core policy change `profile-04-safe-project-artifact-writes`.
+- GitHub tracking is synced to issue [#177](https://github.com/nold-ai/specfact-cli-modules/issues/177) under parent feature [#161](https://github.com/nold-ai/specfact-cli-modules/issues/161), with bug context linked back to `specfact-cli#487`.

--- a/openspec/changes/project-runtime-01-safe-artifact-write-policy/design.md
+++ b/openspec/changes/project-runtime-01-safe-artifact-write-policy/design.md
@@ -1,0 +1,78 @@
+## Context
+
+Many bundle commands in `specfact-cli-modules` write directly into user repositories using local `write_text` or bespoke write logic. Even where behavior is currently harmless, the repo lacks a consistent contract for ownership, merge strategy, preview, and recovery when bundle commands materialize artifacts. If only core init/setup adopts safer semantics, runtime package commands can still recreate the same trust failure elsewhere.
+
+The paired core change defines the authoritative policy language. This modules-side design focuses on adopting that policy in runtime packages without introducing a competing abstraction.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reuse the core safe-write contract from `specfact-cli` in bundle runtime code.
+- Standardize how bundle commands declare file ownership and write intent.
+- Add adoption for first-runner package commands that materialize or mutate local project artifacts.
+- Add tests ensuring bundle commands preserve unrelated user content when they touch partially owned artifacts.
+
+**Non-Goals:**
+- Refactor every single `write_text` call in the repo regardless of target ownership.
+- Move ownership policy definition into modules; core remains authoritative.
+- Turn all bundle writers into interactive review workflows in this change.
+
+## Decisions
+
+### 1. Runtime packages will depend on the core safe-write helper instead of creating a duplicate modules-side helper
+
+Bundle code already imports `specfact_cli` surfaces where needed. This change will reuse the core helper and ownership model so both repos speak the same semantics.
+
+Rationale:
+- One contract, one enforcement surface.
+- Avoids drift between “core-safe” and “runtime-safe” behavior.
+
+Alternative considered:
+- Create a modules-local wrapper and later reconcile. Rejected because it duplicates the core design immediately.
+
+### 2. Adoption scope will prioritize commands that write into user repos, not internal generated temp artifacts
+
+The first slice should cover commands that write persistent user-facing artifacts in target repositories. Internal temp files, caches, or package-build outputs are not the same risk class.
+
+Rationale:
+- Keeps scope manageable while addressing the highest-risk trust boundary.
+
+### 3. Runtime commands must declare artifact ownership at the call site
+
+Each adopting command will explicitly state whether the target artifact is:
+- fully owned by SpecFact
+- partially owned by SpecFact-managed keys/blocks
+- create-only
+
+Rationale:
+- Bundle authors know command intent best.
+- CI can verify helper usage but needs call-site ownership declarations to be meaningful.
+
+### 4. Modules CI should add behavior fixtures rather than a second independent static scanner
+
+The static “unsafe write” rule belongs in core because it defines the helper boundary. Modules-side CI will focus on adoption tests for selected commands and package flows.
+
+Rationale:
+- Keeps enforcement non-duplicative.
+- Core owns the API and static contract; modules own runtime usage proof.
+
+## Risks / Trade-offs
+
+- `[Risk]` Bundle packages may need a raised `core_compatibility` floor to consume the new helper. → Mitigation: stage versioning and compatibility updates as part of adoption tasks.
+- `[Risk]` Adoption can stall if too many commands are targeted at once. → Mitigation: identify first adopters in proposal/tasks and defer remaining paths with explicit follow-up inventory.
+- `[Risk]` Some runtime artifact types may not support structured merge yet. → Mitigation: use create-only or explicit-replace with backup semantics until a sanctioned merge strategy exists.
+
+## Migration Plan
+
+1. Wait for the core helper contract to land or stabilize in the paired core change.
+2. Update selected runtime package commands to call the helper with ownership metadata.
+3. Add tests proving preservation/backup/conflict behavior for those package flows.
+4. Document adoption guidance for future bundle authors.
+
+Rollback strategy:
+- If a specific runtime adoption proves unstable, the command should fail-safe or skip existing-file mutation instead of restoring raw overwrite behavior.
+
+## Open Questions
+
+- Which bundle commands should be first adopters in this change versus a later follow-up inventory?
+- Should bundle manifests or docs carry artifact ownership metadata, or is code-level declaration sufficient for now?

--- a/openspec/changes/project-runtime-01-safe-artifact-write-policy/proposal.md
+++ b/openspec/changes/project-runtime-01-safe-artifact-write-policy/proposal.md
@@ -1,0 +1,39 @@
+# Change: Runtime Adoption Of Safe Artifact Write Policy
+
+## Why
+
+Core can define safer init/setup behavior, but the broader trust problem remains if bundle runtime commands in `specfact-cli-modules` still overwrite or rewrite user-project artifacts ad hoc. To make issue [specfact-cli#487](https://github.com/nold-ai/specfact-cli/issues/487) impossible by design rather than by one-off fix, runtime package commands that write local artifacts need to adopt the same safe-write contract and conflict semantics.
+
+## What Changes
+
+- **NEW**: Introduce a runtime-facing artifact write adapter/utility layer for bundle packages that classifies local writes as create-only, mergeable, append-only, or explicit-replace.
+- **NEW**: Standardize backup, recovery metadata, and dry-run/preview surfaces for bundle commands that emit or mutate project artifacts.
+- **NEW**: Define adoption guidance so bundle authors declare ownership boundaries for every local artifact path they write.
+- **EXTEND**: Update initial adopter package commands in `specfact-project`, `specfact-spec`, and other bundle flows that currently write directly into target repos to use the safe-write utility instead of raw overwrite calls.
+- **EXTEND**: Bundle docs and prompts to state the new preservation guarantees and when explicit force/replace semantics are required.
+
+## Capabilities
+
+### New Capabilities
+- `runtime-artifact-write-safety`: Shared runtime safety contract for bundle commands that create or mutate project artifacts in user repositories.
+
+### Modified Capabilities
+- `backlog-add`: local export helpers and related artifact generation must use the runtime safe-write contract when updating project files.
+- `backlog-sync`: runtime sync/export flows must avoid silent local overwrites and surface preview-or-conflict behavior consistently.
+
+## Impact
+
+- Affected code: bundle runtime helpers in `packages/specfact-project/`, `packages/specfact-spec/`, and any command packages that currently call `write_text` directly against user project files.
+- Affected docs: relevant bundle docs on modules.specfact.io covering setup, sync/export, and local artifact generation.
+- Integration points: depends on the paired core change `specfact-cli/openspec/changes/profile-04-safe-project-artifact-writes` for the authoritative policy and terminology.
+- Dependencies: may require a new modules-side feature issue if no existing feature cleanly groups cross-package local-write safety work.
+
+## Source Tracking
+
+- **GitHub Issue**: #177
+- **Issue URL**: https://github.com/nold-ai/specfact-cli-modules/issues/177
+- **Repository**: nold-ai/specfact-cli-modules
+- **Last Synced Status**: open
+- **Parent Feature**: #161
+- **Parent Feature URL**: https://github.com/nold-ai/specfact-cli-modules/issues/161
+- **Related Core Change**: specfact-cli#487 bug context and paired core change `profile-04-safe-project-artifact-writes`

--- a/openspec/changes/project-runtime-01-safe-artifact-write-policy/specs/backlog-add/spec.md
+++ b/openspec/changes/project-runtime-01-safe-artifact-write-policy/specs/backlog-add/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Backlog add local artifact helpers SHALL preserve user-managed content
+Any `specfact backlog add` helper flow that writes local project artifacts SHALL use the runtime safe-write contract and preserve unrelated user-managed content.
+
+#### Scenario: Existing local config is not silently replaced
+- **WHEN** a backlog-add related local helper targets an existing user-project artifact
+- **THEN** the helper SHALL skip, merge, or require explicit replacement according to declared ownership
+- **AND** SHALL NOT silently overwrite the existing file

--- a/openspec/changes/project-runtime-01-safe-artifact-write-policy/specs/backlog-sync/spec.md
+++ b/openspec/changes/project-runtime-01-safe-artifact-write-policy/specs/backlog-sync/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Backlog sync local export paths SHALL avoid silent overwrite
+Any `specfact backlog sync` local export or artifact materialization path SHALL avoid silent overwrites of existing user-project artifacts.
+
+#### Scenario: Existing export target produces conflict or safe merge
+- **WHEN** backlog sync would write to a local artifact path that already exists
+- **THEN** the command SHALL use the runtime safe-write contract to merge, skip, or require explicit replacement
+- **AND** SHALL surface the chosen behavior in command output

--- a/openspec/changes/project-runtime-01-safe-artifact-write-policy/specs/runtime-artifact-write-safety/spec.md
+++ b/openspec/changes/project-runtime-01-safe-artifact-write-policy/specs/runtime-artifact-write-safety/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Bundle runtime commands SHALL use the core safe-write contract for user-project artifacts
+Bundle commands that create or mutate persistent artifacts inside a user repository SHALL call the core safe-write contract instead of performing ad hoc overwrite logic.
+
+#### Scenario: Runtime command writes owned artifact through safe-write helper
+- **WHEN** a bundle command materializes or updates a persistent artifact in the user's repository
+- **THEN** it SHALL call the core safe-write helper with declared ownership metadata
+- **AND** SHALL NOT write the artifact through a raw overwrite path
+
+#### Scenario: Unsupported merge falls back to explicit safe failure
+- **WHEN** a bundle command targets an existing artifact whose format or ownership cannot be reconciled safely
+- **THEN** the command SHALL fail with actionable guidance or require explicit replacement semantics
+- **AND** SHALL leave the existing artifact unchanged by default
+
+### Requirement: Runtime adoption SHALL be regression-tested against existing user content
+Bundle commands that adopt the safe-write contract SHALL have regression tests proving that unrelated user content survives supported mutations.
+
+#### Scenario: Partially owned runtime artifact preserves unrelated user content
+- **WHEN** a regression fixture contains an existing user-managed artifact with additional custom content
+- **AND** the bundle command updates only a SpecFact-managed section
+- **THEN** the custom content SHALL remain intact
+- **AND** only the managed section SHALL change

--- a/openspec/changes/project-runtime-01-safe-artifact-write-policy/tasks.md
+++ b/openspec/changes/project-runtime-01-safe-artifact-write-policy/tasks.md
@@ -1,0 +1,26 @@
+## 1. Branch and paired-change setup
+
+- [ ] 1.1 Create `bugfix/project-runtime-01-safe-artifact-write-policy` in a dedicated worktree from `origin/dev` and bootstrap the worktree environment.
+- [ ] 1.2 Confirm the paired core change `profile-04-safe-project-artifact-writes` is implemented or available for integration and document the minimum required core compatibility.
+- [ ] 1.3 If a modules-side tracking issue is created, link it back to `specfact-cli#487` and the paired core issue/change for traceability.
+
+## 2. Runtime tests and failing evidence
+
+- [ ] 2.1 Inventory first-adopter bundle commands that write persistent user-project artifacts and select the initial runtime adoption scope.
+- [ ] 2.2 Write tests from the new scenarios proving bundle commands preserve unrelated user content, fail safely on unsupported merges, and surface explicit replacement behavior when required.
+- [ ] 2.3 Run the targeted runtime tests before implementation and record failing commands/timestamps in `openspec/changes/project-runtime-01-safe-artifact-write-policy/TDD_EVIDENCE.md`.
+
+## 3. Runtime safe-write adoption
+
+- [ ] 3.1 Integrate the core safe-write helper into the selected runtime package commands with explicit ownership metadata and required contract decorators on any new public APIs.
+- [ ] 3.2 Update package code paths for the first adopters so they no longer perform raw overwrite behavior against user-project artifacts.
+- [ ] 3.3 Adjust package metadata, compatibility declarations, and any supporting docs/prompts required by the new runtime dependency on the core safe-write contract.
+
+## 4. Verification, docs, and release hygiene
+
+- [ ] 4.1 Re-run the targeted runtime tests and any broader affected package coverage, then record passing evidence in `TDD_EVIDENCE.md`.
+- [ ] 4.2 Update affected modules docs to explain preservation guarantees and explicit replacement semantics for adopted commands.
+- [ ] 4.3 Run quality gates: `hatch run format`, `hatch run type-check`, `hatch run lint`, `hatch run yaml-lint`, `hatch run contract-test`, and the relevant `smart-test`/`test` coverage for changed packages.
+- [ ] 4.4 Run module signature verification, bump package versions where required, re-sign changed manifests if needed, and verify registry consistency.
+- [ ] 4.5 Ensure `.specfact/code-review.json` is fresh, remediate all findings, and record the final review command/timestamp in `TDD_EVIDENCE.md` or PR notes.
+- [ ] 4.6 Open the modules PR to `dev`, cross-link the paired core PR, and note any deferred runtime adoption paths as follow-up issues if the initial scope is intentionally limited.


### PR DESCRIPTION
## Summary

Restores the OpenSpec change folder `openspec/changes/project-runtime-01-safe-artifact-write-policy/` that was added in `bd07b05` and removed in `f174ed0` (review fixes). `openspec/CHANGE_ORDER.md` already references this change and [specfact-cli#490](https://github.com/nold-ai/specfact-cli/issues/490) / [specfact-cli-modules#177](https://github.com/nold-ai/specfact-cli-modules/issues/177).

## Validation

- `openspec validate project-runtime-01-safe-artifact-write-policy --strict` — pass

## Notes

No bundle or registry changes; OpenSpec artifacts only.

Made with [Cursor](https://cursor.com)