### PR TITLE
docs-15: bundle link validation, OpenSpec deltas, Code Review run guide

### DIFF
--- a/docs/bundles/code-review/overview.md
+++ b/docs/bundles/code-review/overview.md
@@ -12,7 +12,7 @@ expertise_level: [beginner, intermediate]
 
 The **Code Review** bundle (`nold-ai/specfact-code-review`) extends the shared **`specfact code`** command group with **`review`** workflows: governed review runs, **reward ledger** history, and **house-rules** skill management.
 
-Use it together with the [Codebase](../codebase/overview/) bundle (`import`, `analyze`, `drift`, `validate`, `repro`) on the same `code` surface.
+Use it together with the [Codebase](/bundles/codebase/overview/) bundle (`import`, `analyze`, `drift`, `validate`, `repro`) on the same `code` surface.
 
 ## Prerequisites
 
@@ -63,5 +63,5 @@ specfact code review rules show --help
 - [Code review run](../run/)
 - [Code review ledger](../ledger/)
 - [Code review rules](../rules/)
-- [Code review module](../../modules/code-review/)
-- [Codebase bundle overview](../codebase/overview/) — import, drift, validation, repro
+- [Code review module](/modules/code-review/)
+- [Codebase bundle overview](/bundles/codebase/overview/) — import, drift, validation, repro

--- a/docs/bundles/code-review/run.md
+++ b/docs/bundles/code-review/run.md
@@ -16,6 +16,8 @@ expertise_level: [intermediate, advanced]
 
 The command prints **progress** to the terminal (spinner/status while the pipeline prepares and runs). With **`--json`**, it writes a machine-readable **`ReviewReport`** JSON file (defaulting to **`review-report.json`** in the working directory when **`--out`** is omitted).
 
+The pipeline reviews **`.py`** and **`.pyi`** only. The **`--focus docs`** facet selects Python files whose path contains a **`docs/`** directory segment (for example tooling beside the Jekyll site), not Markdown documentation pages. For published-site link, front matter, and command-example checks on the modules docs tree, run **`python scripts/check-docs-commands.py`** in this repository (see CI and contributing docs).
+
 ## Command
 
 - `specfact code review run [FILES...]`
@@ -55,12 +57,63 @@ The Typer entrypoint validates **review flags** first: it raises **`typer.BadPar
 
 ## Examples
 
+### Auto-discovered scope (omit positional files)
+
 ```bash
+# Tracked + untracked changes; tests excluded by default for auto-scope
 specfact code review run --scope changed
+
+# Same, with bug-hunt heuristics on the discovered file set
+specfact code review run --scope changed --bug-hunt
+
+# Full index, limited to one package (repeat --path for more repo-relative prefixes)
 specfact code review run --scope full --path packages/specfact-code-review
+
+# Package sources plus that package’s unit tests
+specfact code review run --scope full --path packages/specfact-code-review --path tests/unit/specfact_code_review
+
+# Warnings dropped before scoring (affects JSON, verdict text, and ci_exit_code)
+specfact code review run --scope changed --level warning
+
+# Longer CrossHair budgets for exploratory bug-hunt pass (with explicit files)
+specfact code review run --bug-hunt --json --out /tmp/review-bughunt.json packages/specfact-code-review/src/specfact_code_review/run/commands.py
+```
+
+### Shadow mode and JSON to a file
+
+**`--mode shadow`** runs the full toolchain but forces process exit code **`0`** and JSON **`ci_exit_code`** **`0`** so callers can ingest reports without failing a step; **`overall_verdict`** still reflects the real outcome.
+
+```bash
+specfact code review run --scope changed --mode shadow --json --out /tmp/review-report.json
+```
+
+### `--focus` facets (repeatable)
+
+Use **`--focus`** with **`source`**, **`tests`**, and/or **`docs`** (union of facets, then intersect with scope). Do not combine **`--focus`** with **`--include-tests`** or **`--exclude-tests`**.
+
+```bash
+specfact code review run --scope changed --focus tests
+specfact code review run --scope full --path packages/specfact-code-review --focus source
+specfact code review run --scope full --focus docs
+```
+
+### Positional files (explicit Python paths)
+
+Do not pass **`--scope`** or **`--path`** when **`FILES...`** are present.
+
+```bash
 specfact code review run --json --out /tmp/review-report.json packages/specfact-code-review/src/specfact_code_review/run/commands.py
 specfact code review run --score-only packages/specfact-code-review/src/specfact_code_review/run/commands.py
 specfact code review run --fix packages/specfact-code-review/src/specfact_code_review/run/commands.py
+specfact code review run --no-tests packages/specfact-code-review/src/specfact_code_review/run/commands.py
+```
+
+### Noise and interactive test inclusion
+
+```bash
+specfact code review run --scope changed --include-noise
+specfact code review run --scope changed --suppress-noise
+specfact code review run --scope changed --interactive
 ```
 
 ## Bundle-owned resources

--- a/docs/bundles/code-review/run.md
+++ b/docs/bundles/code-review/run.md
@@ -31,7 +31,7 @@ The pipeline reviews **`.py`** and **`.pyi`** only. The **`--focus docs`** facet
 | `--include-tests`, `--exclude-tests` | Control whether changed test files participate in auto-scope review |
 | `--focus <facet>` | Limit auto-discovered scope to **`source`**, **`tests`**, and/or **`docs`** (repeatable); mutually exclusive with `--include-tests` / `--exclude-tests` |
 | `--mode shadow\|enforce` | **`shadow`** surfaces findings without failing the exit code for policy violations; **`enforce`** applies normal gating (default **`enforce`**) |
-| `--level error\|warning` | Optional reporting level override for the review run |
+| `--level error\|warning` | Optional reporting level override before scoring: **`error`** keeps errors only (drops warnings and info); **`warning`** keeps errors and warnings (drops info only); omit to keep all severities (JSON, verdict, and `ci_exit_code` use the filtered list) |
 | `--bug-hunt` | Enable exploratory / bug-hunt style heuristics in the review pipeline |
 | `--include-noise`, `--suppress-noise` | Keep or suppress known low-signal findings |
 | `--json` | Emit a `ReviewReport` JSON file |
@@ -72,8 +72,8 @@ specfact code review run --scope full --path packages/specfact-code-review
 # Package sources plus that package’s unit tests
 specfact code review run --scope full --path packages/specfact-code-review --path tests/unit/specfact_code_review
 
-# Warnings dropped before scoring (affects JSON, verdict text, and ci_exit_code)
-specfact code review run --scope changed --level warning
+# Errors only before scoring — warnings and info omitted from JSON, verdict, and ci_exit_code
+specfact code review run --scope changed --level error
 
 # Longer CrossHair budgets for exploratory bug-hunt pass (with explicit files)
 specfact code review run --bug-hunt --json --out /tmp/review-bughunt.json packages/specfact-code-review/src/specfact_code_review/run/commands.py

--- a/docs/bundles/code-review/run.md
+++ b/docs/bundles/code-review/run.md
@@ -71,4 +71,4 @@ The review pipeline uses rules, skills, and policy payloads shipped with the ins
 
 - [Code review ledger](/bundles/code-review/ledger/)
 - [Code review rules](/bundles/code-review/rules/)
-- [Code review module guide](../../modules/code-review/)
+- [Code review module guide](/modules/code-review/)

--- a/docs/bundles/codebase/overview.md
+++ b/docs/bundles/codebase/overview.md
@@ -12,7 +12,7 @@ expertise_level: [beginner, intermediate]
 
 The **Codebase** bundle (`nold-ai/specfact-codebase`) mounts under `specfact code` alongside the Code Review bundle. It focuses on **brownfield import**, **contract coverage analysis**, **drift detection**, **sidecar validation**, and **reproducible validation suites**.
 
-For automated review runs (Ruff, Semgrep, ledger, rules), see [Code Review](../code-review/overview/) — also on the `code` command group.
+For automated review runs (Ruff, Semgrep, ledger, rules), see [Code Review](/bundles/code-review/overview/) — also on the `code` command group.
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ For automated review runs (Ruff, Semgrep, ledger, rules), see [Code Review](../c
 | `specfact code import` (default) | Import a repository into a project bundle (`from-code` behavior; see `--help`) |
 | `specfact code import from-bridge` | Import from an external bridge/export flow |
 
-Advanced import topics: [Project import command features](../project/import-migration/) (cross-bundle).
+Advanced import topics: [Project import command features](/bundles/project/import-migration/) (cross-bundle).
 
 ### `analyze` — structure and contracts
 

--- a/docs/bundles/govern/overview.md
+++ b/docs/bundles/govern/overview.md
@@ -47,4 +47,4 @@ specfact govern patch apply --help
 
 - [Govern enforce](../enforce/)
 - [Govern patch](../patch/)
-- [Command reference](../../reference/commands/) — nested `govern` commands
+- [Command reference](/reference/commands/) — nested `govern` commands

--- a/docs/bundles/project/overview.md
+++ b/docs/bundles/project/overview.md
@@ -16,7 +16,7 @@ The **Project** bundle (`nold-ai/specfact-project`) manages SpecFact **project b
 
 - SpecFact CLI and a repository with `.specfact/` layout
 - Bundle installed: `specfact module install nold-ai/specfact-project`
-- For backlog-linked flows: install [Backlog](../backlog/overview/) and link a provider
+- For backlog-linked flows: install [Backlog](/bundles/backlog/overview/) and link a provider
 
 ## Command families
 
@@ -76,7 +76,7 @@ Use the top-level group (`specfact sync --help`).
 
 ## Related: codebase import
 
-Brownfield **code import** (`specfact code import`, `specfact import …`) lives in the [Codebase](../codebase/overview/) bundle; it often feeds project bundles. See [Import command features](../import-migration/) for behavior that spans both bundles.
+Brownfield **code import** (`specfact code import`, `specfact import …`) lives in the [Codebase](/bundles/codebase/overview/) bundle; it often feeds project bundles. See [Import command features](../import-migration/) for behavior that spans both bundles.
 
 ## Bundle-owned prompts and plan templates
 

--- a/docs/bundles/spec/overview.md
+++ b/docs/bundles/spec/overview.md
@@ -71,8 +71,8 @@ specfact spec generate contracts --help
 
 ## See also
 
-- [Command reference](../../reference/commands/) — bundle-to-command mapping
+- [Command reference](/reference/commands/) — bundle-to-command mapping
 - [Spec validate and backward compatibility](/bundles/spec/validate/)
 - [Generate Specmatic tests](/bundles/spec/generate-tests/)
 - [Run a mock server](/bundles/spec/mock/)
-- [Contract testing workflow](../../guides/contract-testing-workflow/)
+- [Contract testing workflow](/contract-testing-workflow/)

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -44,9 +44,10 @@ Options (aligned with `specfact code review run --help`):
   full toolchain and preserves `overall_verdict` in JSON, but forces
   `ci_exit_code` and the process exit code to `0` so CI or hooks can log signal
   without blocking
-- `--level error|warning`: drop findings below the chosen severity **before**
-  scoring and report construction so JSON, tables, score, verdict, and
-  `ci_exit_code` all match the filtered list. Omit to keep all severities
+- `--level error|warning`: filter findings **before** scoring so JSON, tables,
+  score, verdict, and `ci_exit_code` match the filtered list: **`error`**
+  keeps errors only (warnings and info dropped); **`warning`** keeps errors and
+  warnings (info dropped). Omit to keep all severities
 - `--bug-hunt`: enable the bug-hunt pass (CrossHair uses longer budgets: per-path
   timeout **10s**, subprocess budget **120s**; other tools keep normal speed)
 - `--include-noise` / `--suppress-noise`: include or suppress known low-signal

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -101,6 +101,11 @@ specfact code review run --scope full --path packages/specfact-code-review
 specfact code review run --scope changed --path packages/specfact-code-review --path tests/unit/specfact_code_review
 ```
 
+Copy-pastable recipes for **shadow mode**, **JSON `--out`**, **`--focus`**
+(`source` / `tests` / `docs` Python only), **noise flags**, and **interactive**
+test prompts live in the [Code review run](/bundles/code-review/run/) bundle
+guide (same Typer surface as this section).
+
 Positional `FILES...` cannot be mixed with **`--scope`** or **`--path`** (see
 **Invalid combinations** above).
 

--- a/openspec/changes/docs-15-code-review-validation-guardrails/TDD_EVIDENCE.md
+++ b/openspec/changes/docs-15-code-review-validation-guardrails/TDD_EVIDENCE.md
@@ -19,6 +19,11 @@
 
 - `hatch run specfact code review run --json --out .specfact/code-review.json --scope changed` — passing (2026-04-15); evidence at `.specfact/code-review.json`.
 
+## Code Review run guide examples (2026-04-16)
+
+- Expanded `docs/bundles/code-review/run.md` with worked examples (auto-scope, `--path`, shadow + `--json` + `--out`, `--focus`, positional files, `--level`, `--bug-hunt`, noise/interactive); clarified Python-only scope vs Markdown docs validation (`scripts/check-docs-commands.py`). Cross-links on bundle overview fixed to root-absolute routes. `docs/modules/code-review.md` points readers to the bundle guide for recipes.
+- `hatch run pytest tests/unit/docs/test_code_review_docs_parity.py …` and `python scripts/check-docs-commands.py` — passing.
+
 ## Follow-up: bundle permalink vs. `..` links (2026-04-16)
 
 - `hatch run pytest tests/unit/scripts/test_docs_site_validation_link_agreement.py tests/unit/docs/test_docs_review.py::test_authored_internal_docs_links_resolve_to_published_docs_targets -q` — passing.

--- a/openspec/changes/docs-15-code-review-validation-guardrails/TDD_EVIDENCE.md
+++ b/openspec/changes/docs-15-code-review-validation-guardrails/TDD_EVIDENCE.md
@@ -9,6 +9,7 @@
 ## OpenSpec
 
 - `openspec validate docs-15-code-review-validation-guardrails --strict` — passing.
+- 2026-04-16: Spec delta headers normalized (`## MODIFIED Requirements`, `### Requirement:`, `#### Scenario:`) under `openspec/changes/docs-15-code-review-validation-guardrails/specs/**/spec.md` so strict validation and future `openspec archive` succeed; `openspec validate docs-15-code-review-validation-guardrails --strict` — passing.
 
 ## Format / lint
 

--- a/openspec/changes/docs-15-code-review-validation-guardrails/TDD_EVIDENCE.md
+++ b/openspec/changes/docs-15-code-review-validation-guardrails/TDD_EVIDENCE.md
@@ -17,3 +17,11 @@
 ## SpecFact code review
 
 - `hatch run specfact code review run --json --out .specfact/code-review.json --scope changed` — passing (2026-04-15); evidence at `.specfact/code-review.json`.
+
+## Follow-up: bundle permalink vs. `..` links (2026-04-16)
+
+- `hatch run pytest tests/unit/scripts/test_docs_site_validation_link_agreement.py tests/unit/docs/test_docs_review.py::test_authored_internal_docs_links_resolve_to_published_docs_targets -q` — passing.
+- `python scripts/check-docs-commands.py` — passing (no findings).
+- `hatch run format`, `hatch run lint`, `hatch run type-check` — passing.
+- `hatch run contract-test` — passing (624 tests).
+- `hatch run specfact code review run --json --out /tmp/code-review-docs15.json scripts/docs_site_validation.py tests/unit/scripts/test_docs_site_validation_link_agreement.py` — **PASS** (`overall_verdict` PASS, `ci_exit_code` 0; report outside gitignored `.specfact/` for inspection).

--- a/openspec/changes/docs-15-code-review-validation-guardrails/specs/bundle-overview-pages/spec.md
+++ b/openspec/changes/docs-15-code-review-validation-guardrails/specs/bundle-overview-pages/spec.md
@@ -1,26 +1,28 @@
-# ADDED Requirements
+# Bundle overview pages
 
-## Requirement: Bundle overview links SHALL resolve as published URLs
+## MODIFIED Requirements
+
+### Requirement: Bundle overview links SHALL resolve as published URLs
 
 Bundle overview pages SHALL use links that resolve correctly from the published overview permalink route, including "See also", prerequisite, deep-dive, and related-bundle links.
 
-### Scenario: Code Review overview links to run page
+#### Scenario: Code Review overview links to run page
 
 - **WHEN** the Code Review overview page is published at `/bundles/code-review/overview/`
 - **THEN** its "Code review run" link resolves to `/bundles/code-review/run/`
 - **AND** the link does not resolve to `/bundles/code-review/overview/run/`
 
-### Scenario: Cross-bundle overview link resolves
+#### Scenario: Cross-bundle overview link resolves
 
 - **WHEN** a bundle overview page links to another bundle overview page
 - **THEN** the link resolves to the target bundle's canonical published overview route
 - **AND** docs validation fails if the link resolves to a route nested under the source overview page
 
-## Requirement: Bundle overview-related links SHALL be covered by docs validation tests
+### Requirement: Bundle overview-related links SHALL be covered by docs validation tests
 
 The bundle overview docs test suite SHALL include coverage that fails when any overview page contains a body link that is valid by source-file path but broken under published permalink semantics.
 
-### Scenario: Source-valid but published-broken link is rejected
+#### Scenario: Source-valid but published-broken link is rejected
 
 - **WHEN** an overview page links to a sibling page using a source-file-relative shorthand that would publish below the overview permalink
 - **THEN** the overview link test reports the generated public route mismatch

--- a/openspec/changes/docs-15-code-review-validation-guardrails/specs/modules-docs-command-validation/spec.md
+++ b/openspec/changes/docs-15-code-review-validation-guardrails/specs/modules-docs-command-validation/spec.md
@@ -1,54 +1,67 @@
-# ADDED Requirements
+# Modules docs command validation
 
-## Requirement: Docs validation SHALL validate published-route body links
+## MODIFIED Requirements
+
+### Requirement: Docs validation SHALL validate published-route body links
 
 The modules docs validation command SHALL validate internal links in authored page bodies using the page's published permalink route as the URL base, and SHALL fail when a link resolves to a route that is not backed by a published page or an accepted redirect route.
 
-### Scenario: Overview relative link fails under published route semantics
+#### Scenario: Overview relative link fails under published route semantics
 
 - **WHEN** a page with permalink `/bundles/code-review/overview/` contains a body link `run/`
 - **THEN** docs validation resolves the link as `/bundles/code-review/overview/run/`
 - **AND** docs validation reports a `published-link` finding when that route is not published or redirected
 - **AND** the validation command exits non-zero
 
-### Scenario: Published-route-safe link passes
+#### Scenario: Published-route-safe link passes
 
 - **WHEN** a page with permalink `/bundles/code-review/overview/` links to `/bundles/code-review/run/`
 - **THEN** docs validation resolves the link to the published Code Review run page
 - **AND** no `published-link` finding is emitted for that link
 
-## Requirement: Docs validation SHALL reject incomplete published page front matter
+### Requirement: Docs validation SHALL reject incomplete published page front matter
 
 The modules docs validation command SHALL reject published Markdown pages whose front matter is missing required route and display metadata, including `layout`, `title`, and `permalink`, unless the page has an explicit documented exemption recognized by the validator.
 
-### Scenario: Redirect page missing title fails
+#### Scenario: Redirect page missing title fails
 
 - **WHEN** a published Markdown redirect page has `layout` and `permalink` but no `title`
 - **THEN** docs validation reports a `frontmatter` finding for the missing `title`
 - **AND** the validation command exits non-zero
 
-### Scenario: Complete published page passes front matter validation
+#### Scenario: Complete published page passes front matter validation
 
 - **WHEN** a published Markdown page defines `layout`, `title`, and `permalink`
 - **THEN** docs validation accepts the page front matter
 - **AND** no `frontmatter` finding is emitted for that page
 
-## Requirement: Docs validation SHALL expose stable finding categories
+### Requirement: Docs validation SHALL expose stable finding categories
 
 The modules docs validation command SHALL emit stable category names for each class of documentation defect so CI logs, pre-commit output, and tests can assert category coverage without matching brittle prose.
 
-### Scenario: Multiple docs defect categories are reported together
+#### Scenario: Multiple docs defect categories are reported together
 
 - **WHEN** docs validation finds an unknown command example, a broken published route link, and incomplete front matter
 - **THEN** the output includes `command`, `published-link`, and `frontmatter` categories
 - **AND** the validation command exits non-zero after reporting all discovered docs findings
 
-## Requirement: Docs validation SHALL detect docs build dependency drift
+### Requirement: Docs validation SHALL detect docs build dependency drift
 
 The modules docs validation workflow SHALL include a docs build dependency health check that fails when the checked-in Jekyll dependency lock cannot be installed for the docs site.
 
-### Scenario: Stale Gemfile lock fails docs dependency validation
+#### Scenario: Stale Gemfile lock fails docs dependency validation
 
 - **WHEN** the docs dependency install command cannot resolve a locked gem version from the configured sources
 - **THEN** the docs workflow reports a `docs-build-dependency` failure
 - **AND** Pages publication does not proceed as healthy
+
+### Requirement: Bundle permalink pages SHALL validate parent-segment links against browser routes
+
+For pages whose canonical published route is under `/bundles/`, docs validation SHALL treat Markdown links whose path contains parent-directory segments (`..`) as unsafe unless the filesystem-resolved target file matches the target resolved from the page permalink using browser URL rules.
+
+#### Scenario: Deep bundle overview rejects filesystem-only match for `../../` links
+
+- **WHEN** a bundle overview page is published under `/bundles/<bundle>/overview/` (or another deep `/bundles/` permalink)
+- **AND** its body uses a `../` or `../../` link that reaches a markdown file on disk but resolves to a different or missing public route
+- **THEN** docs validation reports a `published-link` finding (missing route or route mismatch)
+- **AND** the validation command exits non-zero

--- a/openspec/changes/docs-15-code-review-validation-guardrails/specs/modules-docs-publishing/spec.md
+++ b/openspec/changes/docs-15-code-review-validation-guardrails/specs/modules-docs-publishing/spec.md
@@ -1,26 +1,28 @@
-# ADDED Requirements
+# Modules docs publishing
 
-## Requirement: Docs publishing SHALL validate generated-site readiness before deploy
+## MODIFIED Requirements
+
+### Requirement: Docs publishing SHALL validate generated-site readiness before deploy
 
 The docs publishing workflow SHALL run docs dependency installation, Jekyll build, and generated-site validation before uploading or deploying the Pages artifact.
 
-### Scenario: Dependency install failure blocks Pages artifact
+#### Scenario: Dependency install failure blocks Pages artifact
 
 - **WHEN** `bundle install` fails for the docs site
 - **THEN** the docs publishing workflow fails before `jekyll build`
 - **AND** no Pages artifact is uploaded from that run
 
-### Scenario: Generated site contains broken internal link
+#### Scenario: Generated site contains broken internal link
 
 - **WHEN** the generated `_site` HTML contains an internal `modules.specfact.io` link whose route is not present in the generated site or redirect set
 - **THEN** generated-site validation reports the broken route
 - **AND** the docs publishing workflow fails before deployment
 
-## Requirement: Docs review CI SHALL run the same deterministic docs validators as local checks
+### Requirement: Docs review CI SHALL run the same deterministic docs validators as local checks
 
 The docs review workflow SHALL run the deterministic docs validators used by local pre-commit, plus the docs unit tests, so PR and local validation enforce the same defect categories.
 
-### Scenario: Docs-only pull request has broken published link
+#### Scenario: Docs-only pull request has broken published link
 
 - **WHEN** a pull request changes only Markdown files under `docs/`
 - **THEN** the docs review workflow runs published-route link validation

--- a/openspec/changes/docs-15-code-review-validation-guardrails/specs/modules-pre-commit-quality-parity/spec.md
+++ b/openspec/changes/docs-15-code-review-validation-guardrails/specs/modules-pre-commit-quality-parity/spec.md
@@ -1,26 +1,28 @@
-# ADDED Requirements
+# Modules pre-commit quality parity
 
-## Requirement: Docs-only pre-commit changes SHALL run docs validation before safe bypass
+## MODIFIED Requirements
+
+### Requirement: Docs-only pre-commit changes SHALL run docs validation before safe bypass
 
 The modules repo pre-commit helper SHALL run deterministic docs validation for staged docs-only changes before skipping code-specific review and contract-test stages.
 
-### Scenario: Docs-only commit with broken link fails pre-commit
+#### Scenario: Docs-only commit with broken link fails pre-commit
 
 - **WHEN** only docs files are staged and one staged docs page introduces a broken published-route link
 - **THEN** pre-commit runs docs validation
 - **AND** pre-commit fails before reporting the change as safe
 
-### Scenario: Docs-only commit with valid docs skips code-specific checks
+#### Scenario: Docs-only commit with valid docs skips code-specific checks
 
 - **WHEN** only docs files are staged and docs validation passes
 - **THEN** pre-commit may skip code review and contract-test stages
 - **AND** pre-commit reports that docs validation passed before applying the safe-change bypass
 
-## Requirement: Pre-commit and CI docs gates SHALL share validation categories
+### Requirement: Pre-commit and CI docs gates SHALL share validation categories
 
 The local pre-commit docs gate and CI docs review workflow SHALL report the same docs validation categories for matching defects.
 
-### Scenario: Same broken docs route reports same category locally and in CI
+#### Scenario: Same broken docs route reports same category locally and in CI
 
 - **WHEN** a docs change introduces a broken generated public route
 - **THEN** local pre-commit reports a `published-link` finding

--- a/openspec/changes/docs-15-code-review-validation-guardrails/specs/review-run-command/spec.md
+++ b/openspec/changes/docs-15-code-review-validation-guardrails/specs/review-run-command/spec.md
@@ -1,26 +1,28 @@
-# ADDED Requirements
+# Review run command (docs)
 
-## Requirement: Code Review run docs SHALL cover the public option surface
+## MODIFIED Requirements
+
+### Requirement: Code Review run docs SHALL cover the public option surface
 
 The Code Review run documentation SHALL describe every supported public `specfact code review run` option that affects targeting, output, exit behavior, analysis depth, or filtering.
 
-### Scenario: Newly added review options are documented
+#### Scenario: Newly added review options are documented
 
 - **WHEN** the `specfact code review run` Typer command exposes `--bug-hunt`, `--mode`, `--focus`, and `--level`
 - **THEN** the Code Review run guide documents those options in its key option table or equivalent option section
 - **AND** docs validation fails if any of those public options are missing from the run guide
 
-### Scenario: Invalid option combinations are documented
+#### Scenario: Invalid option combinations are documented
 
 - **WHEN** the command rejects combinations such as positional files with `--scope` or `--path`, or `--focus` with `--include-tests`
 - **THEN** the Code Review docs describe the invalid combination behavior
 - **AND** the docs include a user-facing alternative for the supported targeting style aligned with the public **`run`** signature (**`files: list[Path]`**): pass explicit **positional files** (file paths) for a fixed review set, or use **`--scope`** / **`--path`** (without positional files) to auto-discover targets from the repo
 
-## Requirement: Code Review docs SHALL stay aligned with review behavior
+### Requirement: Code Review docs SHALL stay aligned with review behavior
 
 The Code Review docs SHALL describe current review run behavior for JSON output, shadow/enforce mode, progress output, focus filtering, severity filtering, bug-hunt budgets, and test inclusion semantics.
 
-### Scenario: Docs parity check detects missing behavior section
+#### Scenario: Docs parity check detects missing behavior section
 
 - **WHEN** the command implementation includes a public behavior that affects output, exit code, target selection, or analysis cost
 - **THEN** docs parity validation checks that the behavior is represented in the Code Review run docs

--- a/scripts/docs_site_validation.py
+++ b/scripts/docs_site_validation.py
@@ -3,6 +3,11 @@
 Used by ``scripts/check-docs-commands.py``, unit tests, and CI. Resolves
 Markdown links relative to each page's *published* permalink (browser
 semantics), not the repository source path.
+
+For pages whose ``permalink`` is under ``/bundles/``, links whose path
+contains parent segments (``..``) are validated against both filesystem
+resolution and browser URL resolution, because bundle permalinks do not
+mirror the ``docs/bundles/<name>/`` directory depth.
 """
 
 from __future__ import annotations
@@ -345,6 +350,30 @@ def _resolve_http_or_opaque(parsed, ctx: DocsLinkResolutionContext) -> tuple[Pat
     return None
 
 
+def _published_route_label(ctx: DocsLinkResolutionContext, doc_path: Path) -> str:
+    """Human-readable route or path for mismatch diagnostics."""
+    resolved = doc_path.resolve()
+    route = ctx.path_to_route.get(resolved)
+    if route is not None:
+        return route
+    try:
+        return str(resolved.relative_to(ctx.docs_root))
+    except ValueError:
+        return str(resolved)
+
+
+def _link_path_has_parent_traversal(raw_link: str) -> bool:
+    """True when the link path walks up with ``..`` (repo vs browser divergence risk)."""
+    stripped = _normalize_jekyll_relative_url(raw_link.strip())
+    path_only = urlparse(stripped).path
+    return ".." in Path(unquote(path_only)).parts
+
+
+def _published_route_is_under_bundles(published_page_route: str) -> bool:
+    """Bundle overview pages use ``permalink`` paths that diverge from the ``docs/`` tree."""
+    return normalize_route(published_page_route).startswith("/bundles/")
+
+
 @beartype
 @require(
     lambda source, ctx, published_page_route, raw_link: (
@@ -381,6 +410,20 @@ def resolve_internal_link_hybrid(
     if fs_first:
         fs_target, fs_err = _resolve_filesystem_relative(source, ctx, raw_link)
         if fs_target is not None and fs_err is None:
+            if _link_path_has_parent_traversal(raw_link) and _published_route_is_under_bundles(published_page_route):
+                pub_target, pub_err = _resolve_published_relative_url(published_page_route, target_path, fragment, ctx)
+                if pub_err is not None:
+                    return None, pub_err
+                if pub_target is None:
+                    return fs_target, None
+                if pub_target.resolve() != fs_target.resolve():
+                    want = _published_route_label(ctx, fs_target)
+                    got = _published_route_label(ctx, pub_target)
+                    return None, (
+                        "repository-relative link matches a markdown file on disk, but browsers "
+                        f"resolve it to a different site route than `{want}` (permalink-relative "
+                        f"navigation targets `{got}`); use a root-absolute path such as `{want}`"
+                    )
             return fs_target, None
 
     pub_target, pub_err = _resolve_published_relative_url(published_page_route, target_path, fragment, ctx)

--- a/tests/unit/scripts/test_docs_site_validation_link_agreement.py
+++ b/tests/unit/scripts/test_docs_site_validation_link_agreement.py
@@ -1,0 +1,162 @@
+"""Tests for published vs filesystem agreement in ``docs_site_validation``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import docs_site_validation as dsv  # noqa: E402
+
+
+def _ctx_for(docs: Path) -> dsv.DocsLinkResolutionContext:
+    route_to_path, path_to_route = dsv.build_route_mappings(docs)
+    return dsv.DocsLinkResolutionContext(docs, route_to_path, path_to_route, dsv.MODULES_DOCS_HOST)
+
+
+def test_hybrid_rejects_repo_relative_when_disk_and_browser_targets_diverge(tmp_path: Path) -> None:
+    """``../..`` from a deep ``/bundles/.../`` permalink must not pass on filesystem match alone."""
+    docs = tmp_path / "docs"
+    (docs / "bundles" / "deep").mkdir(parents=True)
+    (docs / "guides").mkdir(parents=True)
+    (docs / "bundles" / "deep" / "page.md").write_text(
+        """---
+layout: default
+title: Deep page
+permalink: /bundles/deep/here/
+---
+[bad](../../guides/target/)
+""",
+        encoding="utf-8",
+    )
+    (docs / "guides" / "target.md").write_text(
+        """---
+layout: default
+title: Target
+permalink: /guides/target/
+---
+""",
+        encoding="utf-8",
+    )
+    ctx = _ctx_for(docs)
+    source = docs / "bundles" / "deep" / "page.md"
+    target, err = dsv.resolve_internal_link_hybrid(
+        source=source,
+        ctx=ctx,
+        published_page_route="/bundles/deep/here/",
+        raw_link="../../guides/target/",
+    )
+    assert target is None
+    assert err is not None
+    assert "missing published route" in err or "root-absolute" in err
+
+
+def test_hybrid_accepts_root_absolute_when_target_exists(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    (docs / "bundles" / "deep").mkdir(parents=True)
+    (docs / "guides").mkdir(parents=True)
+    (docs / "bundles" / "deep" / "page.md").write_text(
+        """---
+layout: default
+title: Deep page
+permalink: /bundles/deep/here/
+---
+[ok](/guides/target/)
+""",
+        encoding="utf-8",
+    )
+    (docs / "guides" / "target.md").write_text(
+        """---
+layout: default
+title: Target
+permalink: /guides/target/
+---
+""",
+        encoding="utf-8",
+    )
+    ctx = _ctx_for(docs)
+    source = docs / "bundles" / "deep" / "page.md"
+    target, err = dsv.resolve_internal_link_hybrid(
+        source=source,
+        ctx=ctx,
+        published_page_route="/bundles/deep/here/",
+        raw_link="/guides/target/",
+    )
+    assert err is None
+    assert target == (docs / "guides" / "target.md").resolve()
+
+
+def test_parent_traversal_outside_bundles_keeps_filesystem_first_semantics(tmp_path: Path) -> None:
+    """``../`` from non-``/bundles/`` permalinks must not require published agreement (legacy)."""
+    docs = tmp_path / "docs"
+    (docs / "adapters").mkdir(parents=True)
+    (docs / "guides").mkdir(parents=True)
+    (docs / "adapters" / "page.md").write_text(
+        """---
+layout: default
+title: Adapter page
+permalink: /adapters/page/
+---
+[guide](../guides/target.md)
+""",
+        encoding="utf-8",
+    )
+    (docs / "guides" / "target.md").write_text(
+        """---
+layout: default
+title: Guide
+permalink: /guides/target/
+---
+""",
+        encoding="utf-8",
+    )
+    ctx = _ctx_for(docs)
+    source = docs / "adapters" / "page.md"
+    target, err = dsv.resolve_internal_link_hybrid(
+        source=source,
+        ctx=ctx,
+        published_page_route="/adapters/page/",
+        raw_link="../guides/target.md",
+    )
+    assert err is None
+    assert target == (docs / "guides" / "target.md").resolve()
+
+
+def test_hybrid_uses_published_semantics_when_filesystem_misses(tmp_path: Path) -> None:
+    """Sibling ``../run/`` style links often miss on disk but are valid on the site URL."""
+    docs = tmp_path / "docs"
+    (docs / "bundles" / "cr").mkdir(parents=True)
+    (docs / "bundles" / "cr" / "overview.md").write_text(
+        """---
+layout: default
+title: Overview
+permalink: /bundles/cr/here/
+---
+[run](../run/)
+""",
+        encoding="utf-8",
+    )
+    (docs / "bundles" / "cr" / "run.md").write_text(
+        """---
+layout: default
+title: Run
+permalink: /bundles/cr/run/
+---
+""",
+        encoding="utf-8",
+    )
+    ctx = _ctx_for(docs)
+    source = docs / "bundles" / "cr" / "overview.md"
+    target, err = dsv.resolve_internal_link_hybrid(
+        source=source,
+        ctx=ctx,
+        published_page_route="/bundles/cr/here/",
+        raw_link="../run/",
+    )
+    assert err is None
+    assert target == (docs / "bundles" / "cr" / "run.md").resolve()


### PR DESCRIPTION
## Summary

This PR continues **docs-15-code-review-validation-guardrails** (issue [#202](https://github.com/nold-ai/specfact-cli-modules/issues/202)) with follow-up work already reviewed locally.

### Changes

- **Published-route vs filesystem links for `/bundles/`**: When a page permalink is under `/bundles/` and a link path contains `..`, validation now requires browser URL resolution to match the resolved markdown target (or report a missing route). Fixes wrong `../../` links that passed filesystem checks but 404ed on the site; updates cross-bundle overview links to root-absolute URLs.
- **OpenSpec**: Normalized delta spec headings (`## MODIFIED Requirements`, `### Requirement:`, `#### Scenario:`) so `openspec validate docs-15-code-review-validation-guardrails --strict` passes for future archive.
- **Code Review docs**: Expanded `docs/bundles/code-review/run.md` with worked examples (shadow + JSON, `--focus`, `--path`, `--level`, `--bug-hunt`, noise/interactive); clarified that `run` reviews `.py`/`.pyi` only and points Markdown site checks to `scripts/check-docs-commands.py`. Module notes link to the bundle run guide for recipes.

### Verification

- `python scripts/check-docs-commands.py`
- `hatch run pytest` (docs parity, authored link scan, link-agreement unit tests)
- `hatch run contract-test` (during earlier commits)
- `openspec validate docs-15-code-review-validation-guardrails --strict`


Made with [Cursor](https://cursor.com)