### PR TITLE
fix(code-review): coerce pylint line 0 and empty messages for ReviewFinding

### DIFF
--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.10
+version: 0.47.11
 commands:
   - code
 tier: official
@@ -23,4 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:61d8c322b10fadbc91a5148eda0ef605c9b03252a13afe31156132e496dc09fd
+  checksum: sha256:02ef18238482a3fb01e5c3bee60e800c718a9a4a20e17b98ee8de566e7ec6790

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.11
+version: 0.47.12
 commands:
   - code
 tier: official
@@ -23,4 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:02ef18238482a3fb01e5c3bee60e800c718a9a4a20e17b98ee8de566e7ec6790
+  checksum: sha256:4bf2b79687947ecc4734eb9bd7ae976fd9500189315f4e50534eb84402d6277f

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.9
+version: 0.47.10
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:64d68f426a6140fdff3ceffd51c3960fb36745a040068722ae37271dc378659e
-  signature: PcP7OeNMkZqTtRpRBkpr2v2od0RX7fM4VCKXyWAYyP7bBRsKyqyRJI5oxX/0BEIWPt29o6y4t93WyJisWgWKBQ==
+  checksum: sha256:61d8c322b10fadbc91a5148eda0ef605c9b03252a13afe31156132e496dc09fd

--- a/packages/specfact-code-review/src/specfact_code_review/tools/pylint_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/pylint_runner.py
@@ -94,11 +94,14 @@ def _finding_from_item(item: object, *, allowed_paths: set[str]) -> ReviewFindin
 def _payload_from_output(stdout: str, *, stderr: str, returncode: int | None) -> list[object]:
     stripped = stdout.strip()
     if not stripped:
+        out = stdout
+        if len(out) > 4096:
+            out = f"{out[:4096]}... ({len(stdout)} chars total)"
         err = stderr
         if len(err) > 4096:
             err = f"{err[:4096]}... ({len(stderr)} chars total)"
         raise ValueError(
-            f"pylint produced no JSON on stdout; {stdout=!r}, stderr={err!r}, {returncode=}",
+            f"pylint produced no JSON on stdout; stdout={out!r}, stderr={err!r}, {returncode=}",
         )
     payload = json.loads(stripped)
     if not isinstance(payload, list):

--- a/packages/specfact-code-review/src/specfact_code_review/tools/pylint_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/pylint_runner.py
@@ -91,10 +91,15 @@ def _finding_from_item(item: object, *, allowed_paths: set[str]) -> ReviewFindin
     )
 
 
-def _payload_from_output(stdout: str) -> list[object]:
+def _payload_from_output(stdout: str, *, stderr: str, returncode: int | None) -> list[object]:
     stripped = stdout.strip()
     if not stripped:
-        return []
+        err = stderr
+        if len(err) > 4096:
+            err = f"{err[:4096]}... ({len(stderr)} chars total)"
+        raise ValueError(
+            f"pylint produced no JSON on stdout; {stdout=!r}, stderr={err!r}, {returncode=}",
+        )
     payload = json.loads(stripped)
     if not isinstance(payload, list):
         raise ValueError("pylint output must be a list")
@@ -137,7 +142,11 @@ def run_pylint(files: list[Path]) -> list[ReviewFinding]:
             check=False,
             timeout=30,
         )
-        payload = _payload_from_output(result.stdout)
+        payload = _payload_from_output(
+            result.stdout,
+            stderr=result.stderr,
+            returncode=result.returncode,
+        )
     except (OSError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as exc:
         return [tool_error(tool="pylint", file_path=files[0], message=f"Unable to parse pylint output: {exc}")]
 

--- a/packages/specfact-code-review/src/specfact_code_review/tools/pylint_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/pylint_runner.py
@@ -44,6 +44,25 @@ def _category_for_message_id(message_id: str) -> Literal["architecture", "style"
     return "style"
 
 
+def _coerce_pylint_line(raw: object) -> int:
+    """Pylint may emit ``0`` for file- or config-scoped messages; ``ReviewFinding`` requires ``line >= 1``."""
+    if raw is None or isinstance(raw, bool):
+        return 1
+    if isinstance(raw, int):
+        return raw if raw >= 1 else 1
+    if isinstance(raw, float):
+        as_int = int(raw)
+        return as_int if as_int >= 1 else 1
+    return 1
+
+
+def _coerce_pylint_message(raw: object) -> str:
+    """Pylint occasionally emits an empty ``msg``; governed findings require non-blank text."""
+    if isinstance(raw, str) and raw.strip():
+        return raw
+    return "(pylint provided no message text)"
+
+
 def _finding_from_item(item: object, *, allowed_paths: set[str]) -> ReviewFinding | None:
     if not isinstance(item, dict):
         raise ValueError("pylint finding must be an object")
@@ -57,12 +76,8 @@ def _finding_from_item(item: object, *, allowed_paths: set[str]) -> ReviewFindin
     message_id = item["message-id"]
     if not isinstance(message_id, str):
         raise ValueError("pylint message-id must be a string")
-    line = item["line"]
-    if not isinstance(line, int):
-        raise ValueError("pylint line must be an integer")
-    message = item["message"]
-    if not isinstance(message, str):
-        raise ValueError("pylint message must be a string")
+    line = _coerce_pylint_line(item.get("line"))
+    message = _coerce_pylint_message(item.get("message"))
 
     return ReviewFinding(
         category=_category_for_message_id(message_id),
@@ -77,7 +92,10 @@ def _finding_from_item(item: object, *, allowed_paths: set[str]) -> ReviewFindin
 
 
 def _payload_from_output(stdout: str) -> list[object]:
-    payload = json.loads(stdout)
+    stripped = stdout.strip()
+    if not stripped:
+        return []
+    payload = json.loads(stripped)
     if not isinstance(payload, list):
         raise ValueError("pylint output must be a list")
     return payload

--- a/tests/unit/specfact_code_review/tools/test_pylint_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_pylint_runner.py
@@ -34,6 +34,7 @@ def test_run_pylint_maps_bare_except_to_architecture(tmp_path: Path, monkeypatch
     assert findings[0].category == "architecture"
     assert findings[0].severity == "warning"
     assert findings[0].rule == "W0702"
+    assert findings[0].line == 7
     assert_tool_run(run_mock, ["pylint", "--output-format", "json", str(file_path)])
 
 
@@ -255,6 +256,9 @@ def test_run_pylint_parses_json_with_surrounding_whitespace(tmp_path: Path, monk
 
     assert len(findings) == 1
     assert findings[0].rule == "W0702"
+    assert findings[0].line == 7
+    assert findings[0].message == "No exception type(s) specified"
+    assert findings[0].category == "architecture"
 
 
 def test_run_pylint_returns_tool_error_for_invalid_payload_item(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/specfact_code_review/tools/test_pylint_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_pylint_runner.py
@@ -97,6 +97,46 @@ def test_run_pylint_returns_tool_error_on_parse_error(tmp_path: Path, monkeypatc
     assert findings[0].tool == "pylint"
 
 
+def test_run_pylint_empty_stdout_is_tool_error(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        Mock(
+            return_value=completed_process(
+                "pylint",
+                stdout="",
+                stderr="config error: missing plugin",
+                returncode=2,
+            ),
+        ),
+    )
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "tool_error"
+    assert findings[0].tool == "pylint"
+    assert "stdout=''" in findings[0].message
+    assert "config error" in findings[0].message
+    assert "returncode=2" in findings[0].message
+
+
+def test_run_pylint_whitespace_only_stdout_is_tool_error(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        Mock(return_value=completed_process("pylint", stdout="  \n\t  ", stderr="", returncode=1)),
+    )
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "tool_error"
+    assert "pylint produced no JSON on stdout" in findings[0].message
+
+
 def test_run_pylint_coerces_line_zero_to_one(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     file_path = tmp_path / "target.py"
     payload = [

--- a/tests/unit/specfact_code_review/tools/test_pylint_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_pylint_runner.py
@@ -97,6 +97,61 @@ def test_run_pylint_returns_tool_error_on_parse_error(tmp_path: Path, monkeypatc
     assert findings[0].tool == "pylint"
 
 
+def test_run_pylint_coerces_line_zero_to_one(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = [
+        {
+            "message-id": "C0301",
+            "path": str(file_path),
+            "line": 0,
+            "message": "line too long",
+        }
+    ]
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=completed_process("pylint", stdout=json.dumps(payload))))
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].line == 1
+
+
+def test_run_pylint_coerces_empty_message_text(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = [
+        {
+            "message-id": "C0301",
+            "path": str(file_path),
+            "line": 3,
+            "message": "",
+        }
+    ]
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=completed_process("pylint", stdout=json.dumps(payload))))
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].message == "(pylint provided no message text)"
+
+
+def test_run_pylint_parses_json_with_surrounding_whitespace(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = [
+        {
+            "message-id": "W0702",
+            "path": str(file_path),
+            "line": 7,
+            "message": "No exception type(s) specified",
+        }
+    ]
+    stdout = "\n  " + json.dumps(payload) + "  \n"
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=completed_process("pylint", stdout=stdout, returncode=16)))
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].rule == "W0702"
+
+
 def test_run_pylint_returns_tool_error_for_invalid_payload_item(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     file_path = tmp_path / "target.py"
     payload = [{"path": str(file_path), "line": 7, "message": "No exception type(s) specified"}]

--- a/tests/unit/specfact_code_review/tools/test_pylint_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_pylint_runner.py
@@ -202,6 +202,42 @@ def test_run_pylint_coerces_empty_message_text(tmp_path: Path, monkeypatch: Monk
     assert findings[0].message == "(pylint provided no message text)"
 
 
+def test_run_pylint_coerces_negative_line_to_one(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = [
+        {
+            "message-id": "C0301",
+            "path": str(file_path),
+            "line": -5,
+            "message": "line too long",
+        }
+    ]
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=completed_process("pylint", stdout=json.dumps(payload))))
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].line == 1
+
+
+def test_run_pylint_coerces_whitespace_only_message(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = [
+        {
+            "message-id": "C0301",
+            "path": str(file_path),
+            "line": 3,
+            "message": "   \t\n  ",
+        }
+    ]
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=completed_process("pylint", stdout=json.dumps(payload))))
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].message == "(pylint provided no message text)"
+
+
 def test_run_pylint_parses_json_with_surrounding_whitespace(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     file_path = tmp_path / "target.py"
     payload = [

--- a/tests/unit/specfact_code_review/tools/test_pylint_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_pylint_runner.py
@@ -137,6 +137,35 @@ def test_run_pylint_whitespace_only_stdout_is_tool_error(tmp_path: Path, monkeyp
     assert "pylint produced no JSON on stdout" in findings[0].message
 
 
+def test_run_pylint_empty_stdout_truncates_long_stderr(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    unique_tail = "UNIQUE_STDERR_TAIL_FOR_TRUNCATION_TEST"
+    long_stderr = "e" * 4096 + unique_tail
+    assert len(long_stderr) > 4096
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        Mock(
+            return_value=completed_process(
+                "pylint",
+                stdout="",
+                stderr=long_stderr,
+                returncode=3,
+            ),
+        ),
+    )
+
+    findings = run_pylint([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "tool_error"
+    assert findings[0].tool == "pylint"
+    assert unique_tail not in findings[0].message
+    assert "... (" in findings[0].message
+    assert "chars total)" in findings[0].message
+    assert f"... ({len(long_stderr)} chars total)" in findings[0].message
+
+
 def test_run_pylint_coerces_line_zero_to_one(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     file_path = tmp_path / "target.py"
     payload = [


### PR DESCRIPTION
Pylint can emit findings at line `0` or with an empty `message`, which violates `ReviewFinding` (`line >= 1`, non-empty message). Those values were caught as generic `ValueError` and collapsed the pylint step into a single `tool_error`.

This change coerces line 0 and fills empty messages so pylint output parses into normal findings and scoring behaves as intended.

**Tests:** `hatch run pytest tests/unit/specfact_code_review/tools/test_pylint_runner.py -q`