### PR TITLE
fix code review semgrep runtime dirs

### DIFF
--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:f9b3b54bcbf8f481607bbfe7bf02fb77625953d19ccce8b11d74e44580608e8c
+  signature: w5tEmlYK7MGBFVD19g7b7D3pob27CgP2dF12J3fxbr268LskXZZ1rNvwhK/7FRYYjGci8pIJAfg8ZtRCeWTfBg==

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.14
+version: 0.47.15
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:9feec110298126ea77f58789dc4c7ba61ff9bfdcaee91b580afd57b9178903ae
-  signature: kIHPg05QU/PSTuGYnn1a2JtXooCCWx1gGZ4bmjoJqOjRQpso/tD2xaApAjYOwCEpXXpRceaBMa+PC3DrniKrCA==
+  checksum: sha256:f9b3b54bcbf8f481607bbfe7bf02fb77625953d19ccce8b11d74e44580608e8c

--- a/packages/specfact-code-review/src/specfact_code_review/tools/semgrep_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/semgrep_runner.py
@@ -169,11 +169,15 @@ def _run_semgrep_command(
     with tempfile.TemporaryDirectory(prefix="semgrep-home-") as temp_home:
         semgrep_home = Path(temp_home)
         semgrep_log_dir = semgrep_home / ".semgrep"
+        semgrep_config_dir = semgrep_home / ".config"
+        semgrep_cache_dir = semgrep_home / ".cache"
         semgrep_log_dir.mkdir(parents=True, exist_ok=True)
+        semgrep_config_dir.mkdir(parents=True, exist_ok=True)
+        semgrep_cache_dir.mkdir(parents=True, exist_ok=True)
         env = os.environ.copy()
         env["HOME"] = str(semgrep_home)
-        env["XDG_CONFIG_HOME"] = str(semgrep_home / ".config")
-        env["XDG_CACHE_HOME"] = str(semgrep_home / ".cache")
+        env["XDG_CONFIG_HOME"] = str(semgrep_config_dir)
+        env["XDG_CACHE_HOME"] = str(semgrep_cache_dir)
         env["SEMGREP_SETTINGS_FILE"] = str(semgrep_log_dir / "settings.yml")
         env.setdefault("SEMGREP_SEND_METRICS", "off")
         return subprocess.run(

--- a/tests/unit/specfact_code_review/tools/test_semgrep_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_semgrep_runner.py
@@ -10,6 +10,7 @@ import pytest
 from pytest import MonkeyPatch
 
 from specfact_code_review.tools.semgrep_runner import (
+    _run_semgrep_command,
     _snip_stderr_tail,
     find_semgrep_config,
     run_semgrep,
@@ -33,6 +34,30 @@ GOOD_FIXTURES = [
     "good_module_network.py",
     "good_print_in_src.py",
 ]
+
+
+def test_run_semgrep_command_creates_runtime_dirs(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    target = tmp_path / "target.py"
+    config = tmp_path / "clean_code.yaml"
+    target.write_text("print('x')\n", encoding="utf-8")
+    config.write_text("rules: []\n", encoding="utf-8")
+    captured_env: dict[str, str] = {}
+
+    def _run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del command
+        env = kwargs["env"]
+        assert isinstance(env, dict)
+        captured_env.update({str(key): str(value) for key, value in env.items()})
+        assert Path(captured_env["XDG_CONFIG_HOME"]).is_dir()
+        assert Path(captured_env["XDG_CACHE_HOME"]).is_dir()
+        assert Path(captured_env["SEMGREP_SETTINGS_FILE"]).parent.is_dir()
+        return completed_process("semgrep", stdout='{"results": []}', returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    _run_semgrep_command([target], bundle_root=None, config_file=config)
+
+    assert captured_env["XDG_CONFIG_HOME"].endswith(".config")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Fix the `specfact-code-review` Semgrep runner so its isolated temporary HOME includes the XDG runtime directories Semgrep expects.

- Create `.config` and `.cache` under the temporary Semgrep HOME before invoking `semgrep`.
- Point `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` at those existing directories.
- Add a regression test around `_run_semgrep_command` to assert the runtime dirs exist when `subprocess.run` is called.
- Bump `nold-ai/specfact-code-review` from `0.47.14` to `0.47.15` and update integrity in unsigned/checksum-only mode for CI signing.

## Why

The paired core PR nold-ai/specfact-cli#558 exposed a real module-side failure while running the local code-review gate: Semgrep crashed before JSON output with `Sys_error("/tmp/semgrep-home-.../.config: No such file or directory")`. That failure is separate from the core runtime discovery bug, but it blocks local `specfact code review run` and pre-commit validation.

## Validation

- `hatch run pytest tests/unit/specfact_code_review/tools/test_semgrep_runner.py -q` -> 23 passed
- `hatch run ruff check packages/specfact-code-review/src/specfact_code_review/tools/semgrep_runner.py tests/unit/specfact_code_review/tools/test_semgrep_runner.py` -> passed
- Pre-commit on commit `5c4a3d3`:
  - module signature/version checks passed
  - format/yaml/bundle/lint passed
  - code review: 0 findings, PASS
  - contract-first tests: 656 passed, 2 warnings

## Related

Companion to nold-ai/specfact-cli#558 and source story nold-ai/specfact-cli#557.