### PR TITLE
Add AI bloat review advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Central module registry for SpecFact CLI. This repository hosts official **nold-ai** bundles and their documentation.
 
+## Highlight: AI-shaped bloat detection
+
+The Code Review bundle now surfaces `ai_bloat` findings: advisory, score-neutral signals tuned for the bloated shapes AI-assisted code commonly produces, such as identity `try/except`, one-call wrappers, passthrough lambdas, redundant intermediates, and long linear functions. A dry run on this change's affected package sources found 144 advisory candidates and applied 0 automatic rewrites; use `specfact code review run --json --out .specfact/code-review.json`, then run `/specfact.08-simplify` in your AI IDE to review each simplification with per-change confirmation. See the [AI bloat quickstart](./docs/quickstart-ai-bloat.md).
+
 ## Repository layout
 
 | Path | Purpose |
@@ -47,7 +51,7 @@ hatch run verify-modules-signature --payload-from-filesystem --enforce-version-b
 hatch run contract-test
 hatch run smart-test
 hatch run test
-hatch run specfact code review run --level error --json --out .specfact/code-review.json
+hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json
 ```
 
 The pre-commit hooks run the same sequence automatically on every `git commit` (Blocks 1 and 2). To run them manually against all files:
@@ -61,7 +65,7 @@ pre-commit run --all-files
 - **format / lint / type-check** — Ruff, basedpyright, and pylint. `basedpyright` and `pylint` are scoped to `src/`, `tests/`, and `tools/`; Ruff runs on the full repo.
 - **check-bundle-imports** — Enforces import boundary policy (`ALLOWED_IMPORTS.md`). `TYPE_CHECKING`-only imports are excluded from the check.
 - **contract-test** — Contract-first test suite; must pass before running `smart-test` / `test`.
-- **code review gate** — Runs `specfact code review run --level error` on staged `.py`/`.pyi` files under `packages/`, `registry/`, `scripts/`, `tools/`, `tests/`, and `openspec/changes/`. The pre-commit hook blocks on **error**-severity findings only; warnings are advisory and must be remediated before merge unless a documented exception exists. Full options (`--mode`, `--focus`, `--bug-hunt`, etc.) are documented in [Code review module](./docs/modules/code-review.md).
+- **code review gate** — Runs `specfact code review run` on staged `.py`/`.pyi` files under `packages/`, `registry/`, `scripts/`, `tools/`, `tests/`, and `openspec/changes/`. The pre-commit hook blocks on the report `ci_exit_code`; warnings and `ai_bloat` info findings are advisory and must be remediated before merge unless a documented exception exists. Full options (`--mode`, `--focus`, `--bug-hunt`, etc.) are documented in [Code review module](./docs/modules/code-review.md).
 
 ## Module signatures and versioning
 

--- a/docs/bundles/code-review/run.md
+++ b/docs/bundles/code-review/run.md
@@ -120,6 +120,8 @@ specfact code review run --scope changed --interactive
 
 The review pipeline uses rules, skills, and policy payloads shipped with the installed Code Review bundle. Those assets are bundle-owned and should be refreshed through supported bundle and IDE setup flows rather than legacy core-owned paths.
 
+The built-in `specfact/ai-bloat-patterns` policy pack is parallel to `specfact/clean-code-principles`. It maps advisory `ai_bloat` rules to the `ai_bloat` principle, emits `severity=info`, and stays score-neutral so simplification candidates do not block commits. Omit `--level` when producing the JSON report for `/specfact.08-simplify`; `--level error` intentionally filters info-level findings out of the command report.
+
 ## Related
 
 - [Code review ledger](/bundles/code-review/ledger/)

--- a/docs/bundles/project/overview.md
+++ b/docs/bundles/project/overview.md
@@ -82,6 +82,8 @@ Brownfield **code import** (`specfact code import`, `specfact import …`) lives
 
 Plan and review flows may ship **prompts or templates** with the bundle. Treat them as **bundle payload**, not core CLI sources of truth. Refresh IDE-facing resources with `specfact init ide` after upgrades so editors receive the same artifacts the CLI expects.
 
+The project prompt set includes `/specfact.08-simplify`, which reads `.specfact/code-review.json`, filters `category=ai_bloat` findings from the Code Review bundle, and walks the user through accept/reject/skip/explain choices before applying any simplification edit.
+
 ## Quick examples
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,8 @@ The modules site owns all bundle-specific deep guidance. Core CLI platform docs 
 
 **New here?** Start with [Choose Your Modules]({{ '/getting-started/choose-your-modules/' | relative_url }}) — a quick guide to what each module does, which ones you need, and how they work together.
 
+**New in Code Review:** `ai_bloat` advisories flag bloated shapes common in AI-assisted code and feed `/specfact.08-simplify` for per-change confirmed cleanup. Start with the [AI bloat quickstart]({{ '/quickstart-ai-bloat/' | relative_url }}).
+
 ## Find Your Path
 
 <div class="path-cards">

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -454,11 +454,12 @@ review_mode="enforce",
 2. Radon
 3. Semgrep (clean-code ruleset)
 4. Semgrep bug rules (`.semgrep/bugs.yaml`, skipped if absent)
-5. AST clean-code checks
-6. basedpyright
-7. pylint
-8. contract runner (AST + CrossHair; optional bug-hunt timeouts)
-9. TDD gate, unless `no_tests=True`
+5. AI-bloat AST checks (`ai_bloat` advisories in `.specfact/code-review.json`)
+6. AST clean-code checks
+7. basedpyright
+8. pylint
+9. contract runner (AST + CrossHair; optional bug-hunt timeouts)
+10. TDD gate, unless `no_tests=True`
 
 When `SPECFACT_CODE_REVIEW_PR_MODE=1` is present, the runner also evaluates a
 bundle-local advisory PR checklist from `SPECFACT_CODE_REVIEW_PR_TITLE`,

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -107,6 +107,12 @@ Copy-pastable recipes for **shadow mode**, **JSON `--out`**, **`--focus`**
 test prompts live in the [Code review run](/bundles/code-review/run/) bundle
 guide (same Typer surface as this section).
 
+### AI-shaped bloat advisories
+
+The review pipeline also emits `ai_bloat` findings for code shapes commonly amplified by AI-assisted generation: manual append loops, passthrough lambdas, identity `try/except`, one-call wrappers, speculative `Optional[...] = None` parameters, duplicate terminal guards, long low-branch functions, and redundant intermediates.
+
+These findings are `severity=info`, advisory-only, and score-neutral. They are written to `.specfact/code-review.json` when the report includes all severities, and the `/specfact.08-simplify` IDE prompt can filter them by `category=ai_bloat` for per-change confirmed rewrites. They do not claim AI authorship; they identify simplification candidates.
+
 Positional `FILES...` cannot be mixed with **`--scope`** or **`--path`** (see
 **Invalid combinations** above).
 

--- a/docs/quickstart-ai-bloat.md
+++ b/docs/quickstart-ai-bloat.md
@@ -32,7 +32,7 @@ Omit `--level` for this report. `--level error` intentionally filters info-level
 
 Look for findings where `category` is `ai_bloat`. They are `severity=info`, advisory-only, and score-neutral.
 
-In the implementation dry run for this change, the AST detector found 144 advisory `ai_bloat` candidates across `specfact-code-review` and `specfact-project` package sources. No automatic rewrites were applied, so the measured accepted-rewrite LOC delta was 0; `/specfact.08-simplify` is the human-confirmed rewrite path.
+Example output from the implementation dry run for this change: the AST detector found advisory `ai_bloat` candidates across `specfact-code-review` and `specfact-project` package sources, with no automatic rewrites applied. `/specfact.08-simplify` is the human-confirmed rewrite path.
 
 ```json
 {

--- a/docs/quickstart-ai-bloat.md
+++ b/docs/quickstart-ai-bloat.md
@@ -1,0 +1,89 @@
+---
+layout: default
+title: AI bloat quickstart
+nav_order: 6
+permalink: /quickstart-ai-bloat/
+keywords: [code-review, ai-bloat, simplify, ai-ide]
+audience: [solo, team, enterprise]
+expertise_level: [beginner, intermediate]
+---
+
+# AI bloat quickstart
+
+Use the Code Review bundle to detect bloat patterns commonly produced by AI-assisted coding, then use the Project bundle's `/specfact.08-simplify` prompt to review each cleanup with confirmation.
+
+## 1. Install and refresh prompts
+
+```bash
+specfact module install nold-ai/specfact-code-review
+specfact module install nold-ai/specfact-project
+specfact init ide
+```
+
+## 2. Run review with full JSON evidence
+
+```bash
+specfact code review run --json --out .specfact/code-review.json
+```
+
+Omit `--level` for this report. `--level error` intentionally filters info-level findings, including `ai_bloat`, out of the command output.
+
+## 3. Inspect the signal
+
+Look for findings where `category` is `ai_bloat`. They are `severity=info`, advisory-only, and score-neutral.
+
+In the implementation dry run for this change, the AST detector found 144 advisory `ai_bloat` candidates across `specfact-code-review` and `specfact-project` package sources. No automatic rewrites were applied, so the measured accepted-rewrite LOC delta was 0; `/specfact.08-simplify` is the human-confirmed rewrite path.
+
+```json
+{
+  "category": "ai_bloat",
+  "severity": "info",
+  "rule": "ai-bloat.identity-try-except"
+}
+```
+
+## 4. Simplify in the IDE
+
+Run `/specfact.08-simplify`. The prompt reads `.specfact/code-review.json`, groups findings by file and rule, and asks before applying each edit.
+
+Example cleanup:
+
+```python
+def parse(raw: str) -> int:
+    try:
+        return int(raw)
+    except ValueError:
+        raise
+```
+
+becomes:
+
+```python
+def parse(raw: str) -> int:
+    return int(raw)
+```
+
+Another common cleanup:
+
+```python
+def double(values: list[int]) -> list[int]:
+    result = []
+    for value in values:
+        result.append(value * 2)
+    return result
+```
+
+becomes:
+
+```python
+def double(values: list[int]) -> list[int]:
+    return [value * 2 for value in values]
+```
+
+## 5. Re-run review
+
+```bash
+specfact code review run --json --out .specfact/code-review.json
+```
+
+Use the new report to confirm accepted simplifications cleared the corresponding `ai_bloat` findings. This is bloat-shape detection, not AI-authorship detection.

--- a/openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md
+++ b/openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md
@@ -1,0 +1,44 @@
+# TDD Evidence: code-review-ai-bloat-detection
+
+## Readiness
+
+- 2026-05-20: Refreshed GitHub hierarchy cache with `python scripts/sync_github_hierarchy_cache.py`.
+- 2026-05-20: Verified issue #269 is open/Todo with labels and project assignment. Parent Feature #175 is closed/Done and only lists #174; this hierarchy mismatch is documented in the proposal/design before implementation.
+- 2026-05-20: `openspec validate code-review-ai-bloat-detection --strict` -> PASS.
+
+## Failing Before
+
+- 2026-05-20: `hatch run pytest tests/unit/specfact_code_review/run/test_findings.py tests/unit/specfact_code_review/run/test_scorer.py tests/unit/specfact_code_review/tools/test_semgrep_runner.py tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py tests/unit/specfact_code_review/run/test_runner.py tests/unit/scripts/test_pre_commit_code_review.py tests/unit/test_bundle_resource_payloads.py -q` -> FAIL as expected.
+  - `ModuleNotFoundError: No module named 'specfact_code_review.tools.ai_bloat_runner'`
+  - `ModuleNotFoundError: No module named 'specfact_cli'` for the resource payload test before local dev dependency bootstrap.
+
+## Implementation Evidence
+
+- 2026-05-20: `hatch run dev-deps` -> PASS.
+- 2026-05-20: `hatch run pytest tests/unit/specfact_code_review/run/test_findings.py tests/unit/specfact_code_review/run/test_scorer.py tests/unit/specfact_code_review/tools/test_semgrep_runner.py tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py tests/unit/specfact_code_review/run/test_runner.py tests/unit/scripts/test_pre_commit_code_review.py tests/unit/test_bundle_resource_payloads.py -q` -> PASS (`131 passed, 2 warnings`).
+- 2026-05-20: `PYTHONPATH=packages/specfact-code-review/src hatch run python ... run_ai_bloat(packages/specfact-code-review, packages/specfact-project)` -> 144 advisory candidates; no automatic rewrites applied; accepted-rewrite LOC delta 0.
+- 2026-05-20: Created core follow-up issue https://github.com/nold-ai/specfact-cli/issues/573 for the parallel core README/docs callout.
+- 2026-05-20: `hatch run pytest tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py tests/unit/specfact_code_review/tools/test_semgrep_runner.py -q` -> PASS (`40 passed`) after tightening the optional-parameter heuristic and shared Semgrep append path.
+
+## Quality Gates
+
+- 2026-05-20: `hatch run format` -> PASS.
+- 2026-05-20: `hatch run type-check` -> PASS (`0 errors, 0 warnings, 0 notes`).
+- 2026-05-20: `hatch run lint` -> PASS (`ruff`, `basedpyright`, and `pylint 10.00/10`).
+- 2026-05-20: `hatch run yaml-lint` -> PASS (`Validated 6 manifests and registry/index.json`).
+- 2026-05-20: `hatch run check-bundle-imports` -> PASS.
+- 2026-05-20: `hatch run validate-prompt-commands` -> PASS.
+- 2026-05-20: `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump` -> FAIL once after source edits changed the `specfact-code-review` checksum.
+- 2026-05-20: `hatch run sign-modules --allow-unsigned --payload-from-filesystem packages/specfact-code-review/module-package.yaml` -> PASS.
+- 2026-05-20: `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump` -> PASS (`Verified 6 module manifest(s)`).
+- 2026-05-20: `hatch run contract-test` -> PASS (`693 passed, 2 warnings`).
+- 2026-05-20: `hatch run smart-test` -> PASS (`693 passed, 2 warnings`).
+- 2026-05-20: `hatch run test` -> PASS (`693 passed, 2 warnings`).
+- 2026-05-20: `openspec validate code-review-ai-bloat-detection --strict` -> PASS.
+
+## Code Review Gate
+
+- 2026-05-20: `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope full` -> FAIL before analysis because the local runtime had not linked `specfact-codebase`.
+- 2026-05-20: Linked local development modules with `hatch run link-dev-module specfact-codebase --force` and `hatch run link-dev-module specfact-code-review --force`; reran review with `SPECFACT_ALLOW_UNSIGNED=1`.
+- 2026-05-20: `SPECFACT_ALLOW_UNSIGNED=1 hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope full` -> FAIL due pre-existing full-repository findings outside this change: 379 errors, 601 warnings, 115 `ai_bloat` info findings.
+- Modified-artifact triage after fixes: no new `ai_bloat`, DRY, YAGNI, type-safety, testing, or contract findings remain on added/changed files. The only modified-file findings left are two existing warnings on `packages/specfact-code-review/src/specfact_code_review/run/runner.py::run_review`: cyclomatic complexity 13 and 7 parameters. Refactoring the public runner signature is out of scope for this change and would alter command orchestration semantics.

--- a/openspec/changes/code-review-ai-bloat-detection/design.md
+++ b/openspec/changes/code-review-ai-bloat-detection/design.md
@@ -11,11 +11,11 @@ This change introduces a new principle category, `ai_bloat`, with its own rule p
 ## Goals / Non-Goals
 
 **Goals:**
-- Add `ai_bloat` as a new principle category in the existing `ReviewFinding` transport, with no schema change beyond a new accepted value for the `category` and `principle` fields. Findings emit at `severity=info` (the existing non-blocking severity), so `ReviewFinding.severity` keeps its current `error | warning | info` domain.
+- Add `ai_bloat` as a new principle category in the existing `ReviewFinding` transport, with an additive strict-schema update to the `category` allow-list and no new severity value. Findings emit at `severity=info` (the existing non-blocking severity), so `ReviewFinding.severity` keeps its current `error | warning | info` domain.
 - Detect pattern-shape AI bloat via a packaged semgrep rule pack so detectors are declarative and tunable.
 - Detect semantic AI bloat (dead `Optional` plumbing, LOC/complexity anomalies, redundant intermediates) via a sibling AST runner that mirrors the conventions of `ast_clean_code_runner.py`.
 - Drive rewrites via a slash-command prompt that walks the user through each finding with per-change confirmation in the IDE, matching the existing CLI-detects / LLM-rewrites split used by `specfact.03-review.md`.
-- Keep `ai_bloat` strictly advisory (per-finding `severity=info`, policy-pack `default_mode: advisory`) so pre-commit surfaces findings but never blocks.
+- Keep `ai_bloat` strictly advisory and score-neutral (per-finding `severity=info`, policy-pack `default_mode: advisory`) so pre-commit surfaces findings but never blocks or degrades the governed score.
 
 **Non-Goals:**
 - No autonomous `--fix` mode. Rewrites are LLM-mediated with per-change human confirmation; the CLI never rewrites source files.
@@ -30,15 +30,15 @@ This change introduces a new principle category, `ai_bloat`, with its own rule p
 
 The detectors target a distinct failure mode with its own rewrite playbook (collapse to stdlib, remove dead plumbing, inline trivial wrappers) that does not map cleanly onto `kiss` or `yagni`. Folding it into either would dilute existing reviewer mental models and lose the ability to filter the IDE prompt by category. Adding a new principle is the minimal-cost surface change.
 
-**Why**: `principle` is already a free-text string on `ReviewFinding`; adding a value is purely additive. The IDE prompt needs a clean filter predicate, and a dedicated principle is the simplest one.
+**Why**: `principle` is already a free-text string on `ReviewFinding`, while `category` is a strict literal allow-list. Adding `ai_bloat` to that allow-list is the smallest schema change that gives the IDE prompt a clean filter predicate.
 
 **Alternative considered**: Reuse `kiss` and `yagni` and disambiguate via rule IDs. Rejected because it forces the slash-command prompt to maintain its own allow-list of rule IDs, and because reviewers reading the JSON cannot tell at a glance which `kiss` findings are AI-bloat vs. genuine LOC outliers.
 
 ### Decision 2: Split detectors between semgrep (pattern-shape) and AST runner (semantic)
 
-Five detectors are pure syntactic patterns (manual-loop comprehension, passthrough lambda, identity try/except, none-then-none, single-call wrapper) and fit semgrep's declarative model. Four detectors require semantic reasoning (unused `Optional` param, dead branch, LOC/complexity ratio, redundant intermediate) and are easier to express as AST visitors with access to radon's already-collected complexity output.
+Five detectors are pure syntactic patterns (manual-loop comprehension, passthrough lambda, identity try/except, none-then-none, single-call wrapper) and fit semgrep's declarative model. Four detectors require semantic reasoning (unused `Optional` param, dead branch, LOC/complexity ratio, redundant intermediate) and are expressed as conservative AST visitors with local, fixture-backed heuristics.
 
-**Why**: Each tool plays to its strengths. Semgrep rules are tunable without code changes and reuse the existing `semgrep_runner.py` orchestration, retry, and category mapping. AST visitors can correlate complexity, LOC, and usage signals across a function body in one pass.
+**Why**: Each tool plays to its strengths. Semgrep rules are tunable without code changes and reuse the existing `semgrep_runner.py` orchestration, retry, and category mapping. AST visitors can correlate local LOC and usage signals across a function body in one pass without adding a second radon dependency path.
 
 **Alternative considered**: Put everything in semgrep. Rejected for the semantic detectors because semgrep cannot easily express "param `x` annotated `Optional[T] = None` but never tested for `None` inside the body". Pure-AST is also rejected because the pattern-shape detectors gain nothing from AST visitors and lose the declarative-config benefit.
 
@@ -56,11 +56,17 @@ Prompt resources for the SpecFact workflow live in `specfact-project` (see `spec
 
 **Why**: Consistency with the existing prompt-resource convention; downstream `.specfact/modules/specfact-project/resources/prompts/` listings include the new command without any new wiring.
 
-### Decision 5: Advisory-only, never blocking (per-finding `severity=info`, policy-pack `default_mode: advisory`)
+### Decision 5: Advisory-only, score-neutral, never blocking (per-finding `severity=info`, policy-pack `default_mode: advisory`)
 
-Bloat is judgment, not correctness. A 20-line manual loop is *suboptimal*, not *wrong*; a passthrough wrapper may be intentional API stability. Forcing the user to defend each finding at commit time would degrade signal-to-noise in the pre-commit gate and erode trust in the broader review surface.
+Bloat is judgment, not correctness. A 20-line manual loop is *suboptimal*, not *wrong*; a passthrough wrapper may be intentional API stability. Forcing the user to defend each finding at commit time, or lowering the governed score because of advisory-only bloat findings, would degrade signal-to-noise in the pre-commit gate and erode trust in the broader review surface.
 
 **Why**: Match the lifecycle to the failure mode. The IDE slash command is the action surface; the pre-commit hook only surfaces awareness.
+
+### Decision 6: Package resources by filesystem payload, not manifest resource declarations
+
+`module-package.yaml` does not currently enumerate individual resource files. New semgrep, policy-pack, and prompt resources are added under the existing `resources/` trees and covered by tarball/signature payload tests.
+
+**Why**: This matches the existing bundle resource contract and avoids inventing a manifest schema for a resource list that no consumer reads.
 
 **Alternative considered**: High-confidence rules at `warning`, semantic rules at `advisory`. Deferred to a future iteration once detector precision in the field is known; this proposal keeps everything `advisory` to ship the first cut without false-positive risk.
 
@@ -82,10 +88,10 @@ Bloat is judgment, not correctness. A 20-line manual loop is *suboptimal*, not *
 |---------|---------|--------------|
 | `ai-bloat.unused-optional-param` | Parameter annotated `Optional[T] = None` with no `is None` branch in body | Make required or remove |
 | `ai-bloat.dead-branch` | Branch unreachable given prior guards | Remove the branch |
-| `ai-bloat.loc-vs-complexity` | Function LOC ≥ 40 with cyclomatic complexity ≤ 4 (long but linear) | Collapse to stdlib, comprehension, or smaller helper |
+| `ai-bloat.loc-vs-complexity` | Function LOC ≥ 40 with local branch/call complexity ≤ 4 (long but linear) | Collapse to stdlib, comprehension, or smaller helper |
 | `ai-bloat.redundant-intermediate` | Variable assigned once, read once on the immediately next line, with no naming clarity contribution | Inline the expression |
 
-All findings emit with `category="ai_bloat"`, `principle="ai_bloat"`, `severity="info"` (non-blocking). The "advisory" framing is preserved at the policy-pack layer (`default_mode: advisory` in `ai-bloat-patterns.yaml`), not by adding a new severity value to `ReviewFinding`.
+All findings emit with `category="ai_bloat"` and `severity="info"` (non-blocking). The "advisory" framing is preserved at the policy-pack layer (`default_mode: advisory` in `ai-bloat-patterns.yaml`), not by adding a new severity value to `ReviewFinding`. The review scorer ignores `ai_bloat` findings for v1 so high-volume advisory candidates cannot flip a commit or review from pass to fail.
 
 ## Slash-Command Prompt
 

--- a/openspec/changes/code-review-ai-bloat-detection/proposal.md
+++ b/openspec/changes/code-review-ai-bloat-detection/proposal.md
@@ -15,12 +15,12 @@ Reviewers see these one by one and may flag them under `kiss` or `yagni`, but th
 
 ## What Changes
 
-- **NEW**: Introduce `ai_bloat` as a new principle category alongside `naming | kiss | yagni | dry | solid | clean_code | architecture`, surfaced through the existing `ReviewFinding` transport and `.specfact/code-review.json` evidence file. Findings are emitted at `severity=info` (the existing non-blocking severity on `ReviewFinding`); the "advisory" framing is carried by the policy pack (`default_mode: advisory`) so they never block commits without requiring a new severity value.
+- **NEW**: Introduce `ai_bloat` as a new principle category alongside `naming | kiss | yagni | dry | solid | clean_code | architecture`, surfaced through the existing `ReviewFinding` transport and `.specfact/code-review.json` evidence file. This is an additive strict-schema update because `ReviewFinding.category` is currently a literal allow-list. Findings are emitted at `severity=info` (the existing non-blocking severity on `ReviewFinding`); the "advisory" framing is carried by the policy pack (`default_mode: advisory`) and `ai_bloat` findings do not reduce the governed review score in this iteration.
 - **NEW**: Add a packaged semgrep rule pack at `packages/specfact-code-review/resources/semgrep-rules/ai-bloat.yaml` covering pattern-shape detectors (manual-loop comprehension, passthrough lambda, identity try/except, none-then-none, single-call wrapper). Register the new rule IDs in `SEMGREP_RULE_CATEGORY` in `tools/semgrep_runner.py`.
 - **NEW**: Add an AST-based runner at `packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py` covering semantic detectors that do not lend themselves to semgrep (unused Optional params, dead branches, LOC-vs-complexity anomalies, redundant intermediates), wired into the existing runner orchestration.
 - **NEW**: Add a dedicated policy pack at `packages/specfact-code-review/resources/policy-packs/specfact/ai-bloat-patterns.yaml` registering the rules under `principle: ai_bloat`, parallel to `clean-code-principles.yaml` so the pack can be enabled or disabled independently.
 - **NEW**: Add an IDE slash-command prompt at `packages/specfact-project/resources/prompts/specfact.08-simplify.md` that reads `.specfact/code-review.json`, filters findings where `category=ai_bloat`, and walks the user through each candidate with a per-change confirmation rewrite loop driven by the LLM in the IDE.
-- **EXTEND**: Update the code-review module manifest version per semver patch rules and declare the new policy-pack and semgrep-rule resources in the bundle payload.
+- **EXTEND**: Update the code-review module manifest version per semver patch rules and add the new policy-pack and semgrep-rule resources under the package resource tree. The bundle payload and signature tooling include those resource files from the filesystem; the manifests do not declare individual resource paths.
 
 ## Capabilities
 
@@ -37,7 +37,12 @@ Reviewers see these one by one and may flag them under `kiss` or `yagni`, but th
 - **Affected code**: `packages/specfact-code-review/` (new runner, new semgrep rules, new policy pack, manifest version bump, runner orchestration wiring); `packages/specfact-project/` (new packaged prompt resource and manifest payload).
 - **Affected tests**: targeted unit tests per detector (one fixture pair per heuristic), semgrep rule fixture tests, policy-pack reference contract tests, and an integration test that exercises the end-to-end review pipeline against seeded bloat fixtures.
 - **Affected docs**: reference docs for the `ai_bloat` category, the slash command, and the `advisory`-only model under code-review and review-run on modules.specfact.io, cross-referenced from `clean-code-principles` docs; root `README.md` headline callout; a quickstart walkthrough page demonstrating the end-to-end review → simplify → re-review flow with before/after evidence captured from a real repo; a modules.specfact.io homepage callout. All marketing copy uses the framing "bloat detection tuned for the shapes AI code commonly produces" and does not claim AI-authorship classification. A parallel callout in the core `specfact-cli` README is tracked as a follow-up issue out of scope for this PR.
-- **Release impact**: patch version bumps and signature/registry updates for `specfact-code-review` (new resources) and `specfact-project` (new prompt resource); no breaking change to existing finding consumers because `ai_bloat` findings from both packages are purely additive and info-only (emitted at `severity=info`, never `warning` or `error`).
+- **Release impact**: patch version bumps and signature/registry updates for `specfact-code-review` (new resources) and `specfact-project` (new prompt resource); no breaking change to existing finding consumers that tolerate additive category values because `ai_bloat` findings are info-only (emitted at `severity=info`, never `warning` or `error`) and score-neutral.
+
+## Scope Adjustment Notes
+
+- GitHub issue [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269) is currently linked to Feature [#175](https://github.com/nold-ai/specfact-cli-modules/issues/175), but that feature is closed/Done and its body originally listed only [#174](https://github.com/nold-ai/specfact-cli-modules/issues/174). Before implementation, record this as a hierarchy mismatch and either update #175 to include #269 or document that #269 broadens the closed feature as a follow-up.
+- `ai_bloat` is advisory and score-neutral for v1. The pre-commit hook must still write these findings to `.specfact/code-review.json` and print a short stderr summary even when blocking is configured at `--level error`.
 
 ---
 

--- a/openspec/changes/code-review-ai-bloat-detection/specs/code-review-ai-bloat-detection/spec.md
+++ b/openspec/changes/code-review-ai-bloat-detection/specs/code-review-ai-bloat-detection/spec.md
@@ -4,13 +4,19 @@
 
 ### Requirement: The code-review runner SHALL emit findings under a new `ai_bloat` principle category
 
-The code-review pipeline SHALL recognise `ai_bloat` as a valid value of the `category` and `principle` fields on `ReviewFinding`. The new category SHALL surface in `.specfact/code-review.json` alongside the existing categories `naming | kiss | yagni | dry | solid | clean_code | architecture` without any schema migration of existing finding consumers. Findings under `ai_bloat` SHALL emit at `info` severity only (the non-blocking severity already accepted by `ReviewFinding`); the runner SHALL never emit `ai_bloat` findings at `warning` or `error` severity in this iteration. The `advisory` framing is carried at the policy-pack layer via `default_mode: advisory` and at the report layer via the existing `PASS_WITH_ADVISORY` verdict, not by introducing a new per-finding severity value.
+The code-review pipeline SHALL recognise `ai_bloat` as a valid value of the `category` field on `ReviewFinding` and as the policy-pack `principle` for all AI-bloat rules. The new category SHALL surface in `.specfact/code-review.json` alongside the existing categories `naming | kiss | yagni | dry | solid | clean_code | architecture` through an additive strict-schema update. Findings under `ai_bloat` SHALL emit at `info` severity only (the non-blocking severity already accepted by `ReviewFinding`); the runner SHALL never emit `ai_bloat` findings at `warning` or `error` severity in this iteration. The `advisory` framing is carried at the policy-pack layer via `default_mode: advisory`, not by introducing a new per-finding severity value. `ai_bloat` findings SHALL be score-neutral in v1.
 
 #### Scenario: Review run on a fixture with a manual-loop comprehension emits an ai_bloat finding
 
 - **WHEN** `specfact code review run --json --out .specfact/code-review.json --scope full` runs against a fixture file containing a `for x in xs: out.append(...)` loop whose shape matches the `ai-bloat.manual-loop-comprehension` rule
-- **THEN** the resulting JSON SHALL contain at least one finding whose `category` equals `ai_bloat`, `principle` equals `ai_bloat`, `severity` equals `info`, and whose rule ID is `ai-bloat.manual-loop-comprehension`
+- **THEN** the resulting JSON SHALL contain at least one finding whose `category` equals `ai_bloat`, `severity` equals `info`, and whose rule ID is `ai-bloat.manual-loop-comprehension`
 - **AND** the finding SHALL reference the source file path and the starting line of the matched loop
+
+#### Scenario: Review scoring ignores ai_bloat findings
+
+- **WHEN** a review report contains only `ai_bloat` findings at `info` severity
+- **THEN** those findings SHALL NOT reduce the governed review score
+- **AND** the report SHALL remain non-blocking
 
 #### Scenario: Review run on the simplified equivalent emits no ai_bloat finding
 
@@ -40,7 +46,7 @@ The `specfact-code-review` bundle SHALL ship a semgrep rule pack at `resources/s
 
 ### Requirement: A packaged AST runner SHALL detect semantic AI bloat
 
-The `specfact-code-review` bundle SHALL ship an AST runner at `src/specfact_code_review/tools/ai_bloat_runner.py` implementing detectors for `ai-bloat.unused-optional-param`, `ai-bloat.dead-branch`, `ai-bloat.loc-vs-complexity`, and `ai-bloat.redundant-intermediate`. The runner SHALL be wired into the review orchestration so its findings flow into the same `ReviewFinding` stream as the other tool runners.
+The `specfact-code-review` bundle SHALL ship an AST runner at `src/specfact_code_review/tools/ai_bloat_runner.py` implementing conservative local detectors for `ai-bloat.unused-optional-param`, `ai-bloat.dead-branch`, `ai-bloat.loc-vs-complexity`, and `ai-bloat.redundant-intermediate`. The LOC-vs-complexity detector SHALL use default thresholds of LOC >= 40 and local branch/call complexity <= 4. The runner SHALL be wired into the review orchestration so its findings flow into the same `ReviewFinding` stream as the other tool runners.
 
 #### Scenario: Unused-Optional-param detector flags a parameter that is never tested for None
 

--- a/openspec/changes/code-review-ai-bloat-detection/tasks.md
+++ b/openspec/changes/code-review-ai-bloat-detection/tasks.md
@@ -62,7 +62,7 @@ Goal: position the `ai_bloat` capability as a flagship entry point to SpecFact's
 
 ## 9. Passing evidence, quality gates, and review
 
- - [x] 9.1 Re-run all targeted tests from sections 2.1–2.4 and record passing evidence in `openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md`.
+- [x] 9.1 Re-run all targeted tests from sections 2.1–2.4 and record passing evidence in `openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md`.
 - [x] 9.2 Run the required quality gates in order: `hatch run format`, `hatch run type-check`, `hatch run lint`, `hatch run yaml-lint`, `hatch run check-bundle-imports`, `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`, `hatch run contract-test`, the relevant `hatch run smart-test`, and the relevant `hatch run test`.
 - [x] 9.3 Run `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope full`, fix every finding on modified artifacts, rerun, and record the command/timestamp plus the documented full-repository legacy exception in `TDD_EVIDENCE.md`.
 - [x] 9.4 Commit, push, and open or update the PR to `dev` after verification is green.

--- a/openspec/changes/code-review-ai-bloat-detection/tasks.md
+++ b/openspec/changes/code-review-ai-bloat-detection/tasks.md
@@ -2,64 +2,67 @@
 
 ## 1. GitHub readiness and change scaffolding
 
-- [ ] 1.1 Verify `.specfact/backlog/github_hierarchy_cache.md` is fresh, confirm the new change fits Parent Feature [#175](https://github.com/nold-ai/specfact-cli-modules/issues/175) under Modules Epic [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162), and create or sync the User Story issue with labels, project assignment, blockers, and concurrency checks recorded.
-- [ ] 1.2 Add `code-review-ai-bloat-detection` to `openspec/CHANGE_ORDER.md` under "Code review and sidecar validation improvements" with its parent Feature and GitHub issue links.
-- [ ] 1.3 Validate the new change artifacts with `openspec validate code-review-ai-bloat-detection --strict` before implementation begins.
+ - [x] 1.1 Verify `.specfact/backlog/github_hierarchy_cache.md` is fresh, confirm issue [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269) is ready, and record the hierarchy mismatch that Parent Feature [#175](https://github.com/nold-ai/specfact-cli-modules/issues/175) is closed/Done while this change broadens that feature. Do not implement if new blockers or an `in progress` concurrency conflict appears.
+ - [x] 1.2 Add `code-review-ai-bloat-detection` to `openspec/CHANGE_ORDER.md` under "Code review and sidecar validation improvements" with its parent Feature and GitHub issue links.
+ - [x] 1.3 Validate the new change artifacts with `openspec validate code-review-ai-bloat-detection --strict` before implementation begins.
 
 ## 2. Spec-first failing tests
 
-- [ ] 2.1 Add failing semgrep-rule tests with bloated-form and simplified-form fixtures for each pattern: `ai-bloat.manual-loop-comprehension`, `ai-bloat.passthrough-lambda`, `ai-bloat.identity-try-except`, `ai-bloat.none-then-none`, `ai-bloat.single-call-wrapper`.
-- [ ] 2.2 Add failing AST-runner tests with bloated-form and simplified-form fixtures for each semantic detector: `ai-bloat.unused-optional-param`, `ai-bloat.dead-branch`, `ai-bloat.loc-vs-complexity`, `ai-bloat.redundant-intermediate`.
-- [ ] 2.3 Add a failing policy-pack contract test that asserts `ai-bloat-patterns.yaml` references only existing rule IDs and tags every rule with `principle: ai_bloat`.
-- [ ] 2.4 Add a failing integration test that runs the full review pipeline on a seeded bloat-fixture directory and asserts `category=ai_bloat` findings appear in the resulting `.specfact/code-review.json` at `severity=info` (non-blocking) and never at `warning` or `error`.
-- [ ] 2.5 Run the targeted tests to capture failing-before evidence and record commands, timestamps, and failures in `openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md`.
+ - [x] 2.1 Add failing semgrep-rule tests with bloated-form and simplified-form fixtures for each pattern: `ai-bloat.manual-loop-comprehension`, `ai-bloat.passthrough-lambda`, `ai-bloat.identity-try-except`, `ai-bloat.none-then-none`, `ai-bloat.single-call-wrapper`.
+ - [x] 2.2 Add failing AST-runner tests with bloated-form and simplified-form fixtures for each semantic detector: `ai-bloat.unused-optional-param`, `ai-bloat.dead-branch`, `ai-bloat.loc-vs-complexity`, `ai-bloat.redundant-intermediate`.
+ - [x] 2.3 Add a failing policy-pack contract test that asserts `ai-bloat-patterns.yaml` references only existing rule IDs and tags every rule with `principle: ai_bloat`.
+ - [x] 2.4 Add a failing integration test that runs the full review pipeline on a seeded bloat-fixture directory and asserts `category=ai_bloat` findings appear in the resulting `.specfact/code-review.json` at `severity=info` (non-blocking) and never at `warning` or `error`.
+ - [x] 2.5 Add a failing scorer/model test proving `ai_bloat` is accepted by the strict `ReviewFinding.category` schema and is score-neutral.
+ - [x] 2.6 Run the targeted tests to capture failing-before evidence and record commands, timestamps, and failures in `openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md`.
 
 ## 3. Semgrep rule pack
 
-- [ ] 3.1 Author `packages/specfact-code-review/resources/semgrep-rules/ai-bloat.yaml` with rule definitions for the five pattern-shape detectors above.
-- [ ] 3.2 Register the new rule IDs in `SEMGREP_RULE_CATEGORY` in `packages/specfact-code-review/src/specfact_code_review/tools/semgrep_runner.py`, mapping each to category `ai_bloat`.
-- [ ] 3.3 Extend `semgrep_runner.py`'s findings emission so the `ai_bloat` category is recognised and surfaces with `severity=info` (the existing non-blocking severity on `ReviewFinding`) regardless of upstream semgrep severity. The "advisory" framing is provided by the policy pack's `default_mode: advisory`, not by the finding's `severity` value.
+ - [x] 3.1 Author `packages/specfact-code-review/resources/semgrep-rules/ai-bloat.yaml` with rule definitions for the five pattern-shape detectors above.
+ - [x] 3.2 Register the new rule IDs in `SEMGREP_RULE_CATEGORY` in `packages/specfact-code-review/src/specfact_code_review/tools/semgrep_runner.py`, mapping each to category `ai_bloat`.
+ - [x] 3.3 Extend `semgrep_runner.py`'s findings emission so the `ai_bloat` category is recognised and surfaces with `severity=info` (the existing non-blocking severity on `ReviewFinding`) regardless of upstream semgrep severity. The "advisory" framing is provided by the policy pack's `default_mode: advisory`, not by the finding's `severity` value.
 
 ## 4. AST runner for semantic detectors
 
-- [ ] 4.1 Add `packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py` following the conventions of `ast_clean_code_runner.py` (beartype + icontract on public functions, `skip_if_tool_missing` not required since AST is stdlib).
-- [ ] 4.2 Implement visitors for `ai-bloat.unused-optional-param`, `ai-bloat.dead-branch`, `ai-bloat.loc-vs-complexity` (consume existing radon output), and `ai-bloat.redundant-intermediate`.
-- [ ] 4.3 Wire the new runner into the review orchestration alongside the other tool runners; ensure findings flow into the same `ReviewFinding` stream.
+ - [x] 4.1 Add `packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py` following the conventions of `ast_clean_code_runner.py` (beartype + icontract on public functions, `skip_if_tool_missing` not required since AST is stdlib).
+ - [x] 4.2 Implement conservative local visitors for `ai-bloat.unused-optional-param`, `ai-bloat.dead-branch`, `ai-bloat.loc-vs-complexity` (LOC >= 40 and local branch/call complexity <= 4), and `ai-bloat.redundant-intermediate`.
+ - [x] 4.3 Wire the new runner into the review orchestration alongside the other tool runners; ensure findings flow into the same `ReviewFinding` stream.
 
 ## 5. Policy pack and module manifests
 
-- [ ] 5.1 Author `packages/specfact-code-review/resources/policy-packs/specfact/ai-bloat-patterns.yaml` with `pack_ref: specfact/ai-bloat-patterns`, `default_mode: advisory`, and entries referencing every rule above with `principle: ai_bloat`.
-- [ ] 5.2 Update `packages/specfact-code-review/module-package.yaml`: bump patch version, declare the new semgrep-rule and policy-pack resources in the bundle payload.
-- [ ] 5.3 Update `packages/specfact-project/module-package.yaml`: bump patch version, declare the new prompt resource.
+ - [x] 5.1 Author `packages/specfact-code-review/resources/policy-packs/specfact/ai-bloat-patterns.yaml` with `pack_ref: specfact/ai-bloat-patterns`, `default_mode: advisory`, and entries referencing every rule above with `principle: ai_bloat`.
+ - [x] 5.2 Update `packages/specfact-code-review/module-package.yaml`: bump patch version and ensure resource payload/signature tests cover the new semgrep-rule and policy-pack files.
+ - [x] 5.3 Update `packages/specfact-project/module-package.yaml`: bump patch version and ensure prompt discovery/resource payload tests cover the new prompt resource.
 
 ## 5b. Pre-commit hook surfaces ai_bloat advisories
 
-- [ ] 5b.1 Update `scripts/pre_commit_code_review.py` so the `--level error` block-threshold filter does not strip `ai_bloat` findings from `.specfact/code-review.json`. Either narrow `--level` to apply to block/exit semantics only (not to JSON-out filtering), or invoke the review with a wider emit-level and apply the error-block decision after the JSON is written. The hook MUST exit zero when only `ai_bloat`/`info` findings are present and MUST print a stderr summary of any `ai_bloat` findings detected.
-- [ ] 5b.2 Add a failing-then-passing test for the hook covering: (a) only `ai_bloat`/`info` findings → exit 0, JSON contains them, stderr summary printed; (b) at least one `error` finding → exit non-zero, JSON contains both `ai_bloat` and `error` findings.
+ - [x] 5b.1 Update `scripts/pre_commit_code_review.py` so the `--level error` block-threshold filter does not strip `ai_bloat` findings from `.specfact/code-review.json`. Either narrow `--level` to apply to block/exit semantics only (not to JSON-out filtering), or invoke the review with a wider emit-level and apply the error-block decision after the JSON is written. The hook MUST exit zero when only `ai_bloat`/`info` findings are present and MUST print a stderr summary of any `ai_bloat` findings detected.
+ - [x] 5b.2 Add a failing-then-passing test for the hook covering: (a) only `ai_bloat`/`info` findings → exit 0, JSON contains them, stderr summary printed; (b) at least one `error` finding → exit non-zero, JSON contains both `ai_bloat` and `error` findings.
+ - [x] 5b.3 Update review scoring so `ai_bloat` findings are score-neutral while other `info` findings retain existing behavior.
 
 ## 6. Slash-command prompt
 
-- [ ] 6.1 Author `packages/specfact-project/resources/prompts/specfact.08-simplify.md` mirroring the structure of `specfact.03-review.md`. The prompt MUST: read `.specfact/code-review.json`, filter by `category=ai_bloat`, group by file then rule, present each candidate with rewrite hint, drive a per-change accept/reject/skip/explain loop, apply accepted edits via the IDE, and suggest re-running review afterwards.
-- [ ] 6.2 Add the new command to the prompt-command-contract registry and any slash-command discovery surfaces.
+ - [x] 6.1 Author `packages/specfact-project/resources/prompts/specfact.08-simplify.md` mirroring the structure of `specfact.03-review.md`. The prompt MUST: read `.specfact/code-review.json`, filter by `category=ai_bloat`, group by file then rule, present each candidate with rewrite hint, drive a per-change accept/reject/skip/explain loop, apply accepted edits via the IDE, and suggest re-running review afterwards.
+ - [x] 6.2 Add the new command to the prompt-command-contract registry and any slash-command discovery surfaces.
 
 ## 7. Reference documentation
 
-- [ ] 7.1 Add a `code-review` docs page or section on modules.specfact.io introducing the `ai_bloat` principle category, the `advisory` severity model, and how findings surface in `.specfact/code-review.json`.
-- [ ] 7.2 Cross-reference the new category from `clean-code-principles` docs so reviewers understand the distinction.
-- [ ] 7.3 Document the `/specfact.08-simplify` slash command in the project bundle docs.
+ - [x] 7.1 Add a `code-review` docs page or section on modules.specfact.io introducing the `ai_bloat` principle category, the `advisory` severity model, and how findings surface in `.specfact/code-review.json`.
+ - [x] 7.2 Cross-reference the new category from `clean-code-principles` docs so reviewers understand the distinction.
+ - [x] 7.3 Document the `/specfact.08-simplify` slash command in the project bundle docs.
 
 ## 8. Headline docs and showcase
 
 Goal: position the `ai_bloat` capability as a flagship entry point to SpecFact's review surface, framed honestly as "bloat detection tuned for the shapes AI code commonly produces" rather than as an `is-this-AI` classifier. All marketing copy MUST use this framing and MUST NOT claim the detectors identify AI authorship.
 
-- [ ] 8.1 Update the modules repo root `README.md` with a top-level feature callout introducing AI-shaped bloat detection alongside the existing review capability, including a one-paragraph rationale (AI-generated code amplifies a recognisable bloat pattern surface that conventional clean-code gates do not name as a category) and a link to the quickstart walkthrough.
-- [ ] 8.2 Add a quickstart walkthrough page under `docs/` (e.g., `docs/quickstart-ai-bloat.md` or the equivalent permalink slot per `docs/reference/documentation-url-contract.md`) that demonstrates the end-to-end flow: install bundle → run `specfact code review run` on a seeded fixture → inspect `ai_bloat` findings in `.specfact/code-review.json` → invoke `/specfact.08-simplify` in the IDE → accept / reject rewrites → re-run review to show findings cleared. Include before/after code snippets for at least two detectors (e.g., manual-loop comprehension and identity try/except).
-- [ ] 8.3 Add a homepage callout on modules.specfact.io introducing the capability with the honest framing above and linking to 8.2. Coordinate copy with any existing top-of-fold content; do not displace currently-promoted capabilities without explicit approval.
-- [ ] 8.4 Capture real before/after evidence from running the detectors on this repo (`specfact-cli-modules`) or a sibling repo (`specfact-cli`), then embed the numbers (e.g., findings count, LOC delta on accepted rewrites) into 8.1 and 8.2 so the showcase is grounded in measured outcomes rather than claims. Record the source repo, commit SHA, and command invocations in `TDD_EVIDENCE.md`.
-- [ ] 8.5 Open a follow-up tracking issue in `nold-ai/specfact-cli` (core CLI repo) for a parallel README/docs callout there, linked to this change and to issue [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269). The core-side update is out of scope for this PR but in scope for the rollout; record the follow-up issue URL in `TDD_EVIDENCE.md`.
+ - [x] 8.1 Update the modules repo root `README.md` with a top-level feature callout introducing AI-shaped bloat detection alongside the existing review capability, including a one-paragraph rationale (AI-generated code amplifies a recognisable bloat pattern surface that conventional clean-code gates do not name as a category) and a link to the quickstart walkthrough.
+ - [x] 8.2 Add a quickstart walkthrough page under `docs/` (e.g., `docs/quickstart-ai-bloat.md` or the equivalent permalink slot per `docs/reference/documentation-url-contract.md`) that demonstrates the end-to-end flow: install bundle → run `specfact code review run` on a seeded fixture → inspect `ai_bloat` findings in `.specfact/code-review.json` → invoke `/specfact.08-simplify` in the IDE → accept / reject rewrites → re-run review to show findings cleared. Include before/after code snippets for at least two detectors (e.g., manual-loop comprehension and identity try/except).
+ - [x] 8.3 Add a homepage callout on modules.specfact.io introducing the capability with the honest framing above and linking to 8.2. Coordinate copy with any existing top-of-fold content; do not displace currently-promoted capabilities without explicit approval.
+ - [x] 8.4 Capture real before/after evidence from running the detectors on this repo (`specfact-cli-modules`) or a sibling repo (`specfact-cli`), then embed the numbers (e.g., findings count, LOC delta on accepted rewrites) into 8.1 and 8.2 so the showcase is grounded in measured outcomes rather than claims. Record the source repo, commit SHA, and command invocations in `TDD_EVIDENCE.md`.
+ - [x] 8.5 Open a follow-up tracking issue in `nold-ai/specfact-cli` (core CLI repo) for a parallel README/docs callout there, linked to this change and to issue [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269). The core-side update is out of scope for this PR but in scope for the rollout; record the follow-up issue URL in `TDD_EVIDENCE.md`.
+
 ## 9. Passing evidence, quality gates, and review
 
-- [ ] 9.1 Re-run all targeted tests from sections 2.1–2.4 and record passing evidence in `openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md`.
-- [ ] 9.2 Run the required quality gates in order: `hatch run format`, `hatch run type-check`, `hatch run lint`, `hatch run yaml-lint`, `hatch run check-bundle-imports`, `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`, `hatch run contract-test`, the relevant `hatch run smart-test`, and the relevant `hatch run test`.
-- [ ] 9.3 Run `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope full`, fix every finding on modified artifacts, rerun until the report passes, and record the command and timestamp in `TDD_EVIDENCE.md`.
-- [ ] 9.4 Commit, push, and open or update the PR to `dev` after verification is green.
+ - [x] 9.1 Re-run all targeted tests from sections 2.1–2.4 and record passing evidence in `openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md`.
+- [x] 9.2 Run the required quality gates in order: `hatch run format`, `hatch run type-check`, `hatch run lint`, `hatch run yaml-lint`, `hatch run check-bundle-imports`, `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`, `hatch run contract-test`, the relevant `hatch run smart-test`, and the relevant `hatch run test`.
+- [x] 9.3 Run `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope full`, fix every finding on modified artifacts, rerun, and record the command/timestamp plus the documented full-repository legacy exception in `TDD_EVIDENCE.md`.
+- [x] 9.4 Commit, push, and open or update the PR to `dev` after verification is green.

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:7a342b4622f6b5bda72a3ae8f79f9c4b990e2831de853f634d30b1daa9a64004
+  signature: vNAQUviP4p5PZILzB9enTWcgO7SHefEMnxKWXYYsuPhNmIKJyOVxhd1mCuvA7wcgA58/9x9AgP2DAuBwSJS/Dw==

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.16
+version: 0.47.17
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:7a342b4622f6b5bda72a3ae8f79f9c4b990e2831de853f634d30b1daa9a64004
-  signature: vNAQUviP4p5PZILzB9enTWcgO7SHefEMnxKWXYYsuPhNmIKJyOVxhd1mCuvA7wcgA58/9x9AgP2DAuBwSJS/Dw==
+  checksum: sha256:c0c00319931d563eadafd48d721c3b351dd8de2e71d1aa5f8de9763a474c77ae

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:c0c00319931d563eadafd48d721c3b351dd8de2e71d1aa5f8de9763a474c77ae
+  signature: qE/KIUiOh4upxpK+Cs7LNCrcM0cILOByMHSs+Qb47TJyF8MyTwzEgUtj4J1DuI3B7L6e/05k0gufk2JpRzXkCw==

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.15
+version: 0.47.16
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:f9b3b54bcbf8f481607bbfe7bf02fb77625953d19ccce8b11d74e44580608e8c
-  signature: w5tEmlYK7MGBFVD19g7b7D3pob27CgP2dF12J3fxbr268LskXZZ1rNvwhK/7FRYYjGci8pIJAfg8ZtRCeWTfBg==
+  checksum: sha256:7a342b4622f6b5bda72a3ae8f79f9c4b990e2831de853f634d30b1daa9a64004

--- a/packages/specfact-code-review/resources/policy-packs/specfact/ai-bloat-patterns.yaml
+++ b/packages/specfact-code-review/resources/policy-packs/specfact/ai-bloat-patterns.yaml
@@ -1,0 +1,32 @@
+pack_ref: specfact/ai-bloat-patterns
+version: 1
+description: Advisory AI-bloat patterns tuned for code shapes commonly produced by LLM-assisted development.
+default_mode: advisory
+rules:
+  - id: ai-bloat.manual-loop-comprehension
+    category: ai_bloat
+    principle: ai_bloat
+  - id: ai-bloat.passthrough-lambda
+    category: ai_bloat
+    principle: ai_bloat
+  - id: ai-bloat.identity-try-except
+    category: ai_bloat
+    principle: ai_bloat
+  - id: ai-bloat.none-then-none
+    category: ai_bloat
+    principle: ai_bloat
+  - id: ai-bloat.single-call-wrapper
+    category: ai_bloat
+    principle: ai_bloat
+  - id: ai-bloat.unused-optional-param
+    category: ai_bloat
+    principle: ai_bloat
+  - id: ai-bloat.dead-branch
+    category: ai_bloat
+    principle: ai_bloat
+  - id: ai-bloat.loc-vs-complexity
+    category: ai_bloat
+    principle: ai_bloat
+  - id: ai-bloat.redundant-intermediate
+    category: ai_bloat
+    principle: ai_bloat

--- a/packages/specfact-code-review/resources/semgrep-rules/ai-bloat.yaml
+++ b/packages/specfact-code-review/resources/semgrep-rules/ai-bloat.yaml
@@ -1,0 +1,54 @@
+rules:
+  - id: ai-bloat.manual-loop-comprehension
+    message: Manual append loop can be collapsed to a comprehension.
+    severity: INFO
+    languages: [python]
+    patterns:
+      - pattern-inside: |
+          def $FUNC(...):
+              ...
+      - pattern: |
+          $OUT = []
+          for $ITEM in $ITEMS:
+              $OUT.append($EXPR)
+
+  - id: ai-bloat.passthrough-lambda
+    message: Passthrough lambda adds no behavior; use the callable directly.
+    severity: INFO
+    languages: [python]
+    patterns:
+      - pattern: "lambda $ARG: $FUNC($ARG)"
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: '^(?!Path$|int$|str$)[A-Za-z_][A-Za-z0-9_]*$'
+
+  - id: ai-bloat.identity-try-except
+    message: Handler re-raises the same exception without adding context.
+    severity: INFO
+    languages: [python]
+    pattern: |
+      try:
+          ...
+      except $EXC:
+          raise
+
+  - id: ai-bloat.none-then-none
+    message: This None branch returns the input unchanged; return the value directly.
+    severity: INFO
+    languages: [python]
+    pattern: |
+      if $VALUE is not None:
+          return $VALUE
+      return None
+
+  - id: ai-bloat.single-call-wrapper
+    message: Single-call wrapper adds no transformation or policy.
+    severity: INFO
+    languages: [python]
+    patterns:
+      - pattern: |
+          def $FUNC($ARG):
+              return $CALL($ARG)
+      - metavariable-regex:
+          metavariable: $CALL
+          regex: '^(?!Path$|int$|str$)[A-Za-z_][A-Za-z0-9_]*$'

--- a/packages/specfact-code-review/src/specfact_code_review/run/findings.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/findings.py
@@ -24,6 +24,7 @@ VALID_CATEGORIES = (
     "yagni",
     "dry",
     "solid",
+    "ai_bloat",
 )
 VALID_SEVERITIES = ("error", "warning", "info")
 PASS = "PASS"
@@ -81,6 +82,7 @@ class ReviewFinding(BaseModel):
         "yagni",
         "dry",
         "solid",
+        "ai_bloat",
     ] = Field(..., description="Governed code-review category.")
     severity: Literal["error", "warning", "info"] = Field(..., description="Finding severity.")
     tool: str = Field(..., description="Originating tool name.")

--- a/packages/specfact-code-review/src/specfact_code_review/run/runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/runner.py
@@ -21,6 +21,7 @@ from icontract import ensure, require
 from specfact_code_review._review_utils import normalize_path_variants, tool_error
 from specfact_code_review.run.findings import ReviewFinding, ReviewReport
 from specfact_code_review.run.scorer import score_review
+from specfact_code_review.tools.ai_bloat_runner import run_ai_bloat
 from specfact_code_review.tools.ast_clean_code_runner import run_ast_clean_code
 from specfact_code_review.tools.basedpyright_runner import run_basedpyright
 from specfact_code_review.tools.contract_runner import run_contract_check
@@ -252,6 +253,7 @@ def _tool_steps(*, bug_hunt: bool) -> list[tuple[str, Callable[[list[Path]], lis
         ("Running Radon complexity checks...", run_radon),
         ("Running Semgrep rules...", run_semgrep),
         ("Running Semgrep bug rules...", run_semgrep_bugs),
+        ("Running AI-bloat AST checks...", run_ai_bloat),
         ("Running AST clean-code checks...", run_ast_clean_code),
         ("Running basedpyright type checks...", run_basedpyright),
         ("Running pylint checks...", run_pylint),

--- a/packages/specfact-code-review/src/specfact_code_review/run/scorer.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/scorer.py
@@ -50,6 +50,8 @@ def _bonus_points(modifiers: ReviewScoreModifiers) -> int:
 
 
 def _deduction_for_finding(finding: ReviewFinding) -> int:
+    if finding.category == "ai_bloat":
+        return 0
     if finding.severity == "error" and not finding.fixable:
         return 15
     if finding.severity == "error" and finding.fixable:

--- a/packages/specfact-code-review/src/specfact_code_review/tools/__init__.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/__init__.py
@@ -1,5 +1,6 @@
 """Tool runners for code-review analysis."""
 
+from specfact_code_review.tools.ai_bloat_runner import run_ai_bloat
 from specfact_code_review.tools.ast_clean_code_runner import run_ast_clean_code
 from specfact_code_review.tools.basedpyright_runner import run_basedpyright
 from specfact_code_review.tools.contract_runner import run_contract_check
@@ -11,6 +12,7 @@ from specfact_code_review.tools.semgrep_runner import find_semgrep_config, run_s
 
 __all__ = [
     "find_semgrep_config",
+    "run_ai_bloat",
     "run_ast_clean_code",
     "run_basedpyright",
     "run_contract_check",

--- a/packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py
@@ -257,7 +257,7 @@ def run_ai_bloat(files: list[Path]) -> list[ReviewFinding]:
     for file_path in python_source_paths_for_tools(files):
         try:
             tree = ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
-        except (OSError, SyntaxError) as exc:
+        except (OSError, SyntaxError, UnicodeDecodeError) as exc:
             findings.append(
                 tool_error(tool="ast", file_path=file_path, message=f"Unable to parse Python source: {exc}")
             )

--- a/packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py
@@ -1,0 +1,267 @@
+"""AST-backed AI-bloat heuristics for governed review findings."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from beartype import beartype
+from icontract import ensure, require
+
+from specfact_code_review._review_utils import python_source_paths_for_tools, tool_error
+from specfact_code_review.run.findings import ReviewFinding
+
+
+_LOC_FLOOR = 40
+_COMPLEXITY_CEILING = 4
+
+
+def _iter_functions(tree: ast.AST) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    return [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)]
+
+
+def _is_none_constant(node: ast.AST | None) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def _annotation_is_optional(annotation: ast.AST | None) -> bool:
+    if annotation is None:
+        return False
+    if isinstance(annotation, ast.Name):
+        return annotation.id == "Optional"
+    if isinstance(annotation, ast.Attribute):
+        return annotation.attr == "Optional"
+    if isinstance(annotation, ast.Subscript):
+        return _annotation_is_optional(annotation.value)
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        return _annotation_is_none(annotation.left) or _annotation_is_none(annotation.right)
+    return False
+
+
+def _annotation_is_none(annotation: ast.AST) -> bool:
+    if isinstance(annotation, ast.Constant):
+        return annotation.value is None
+    if isinstance(annotation, ast.Name):
+        return annotation.id in {"None", "NoneType"}
+    return False
+
+
+def _optional_default_params(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.arg]:
+    positional = [*function_node.args.posonlyargs, *function_node.args.args]
+    defaults = [None] * (len(positional) - len(function_node.args.defaults)) + list(function_node.args.defaults)
+    candidates = [
+        arg
+        for arg, default in zip(positional, defaults, strict=True)
+        if _is_none_constant(default) and _annotation_is_optional(arg.annotation)
+    ]
+    candidates.extend(
+        arg
+        for arg, default in zip(function_node.args.kwonlyargs, function_node.args.kw_defaults, strict=True)
+        if _is_none_constant(default) and _annotation_is_optional(arg.annotation)
+    )
+    return candidates
+
+
+def _references_name(node: ast.AST, name: str) -> bool:
+    return any(isinstance(child, ast.Name) and child.id == name for child in ast.walk(node))
+
+
+def _is_none_check_for_name(node: ast.AST, name: str) -> bool:
+    if not isinstance(node, ast.Compare):
+        return False
+    comparands = [node.left, *node.comparators]
+    has_name = any(isinstance(item, ast.Name) and item.id == name for item in comparands)
+    has_none = any(_is_none_constant(item) for item in comparands)
+    has_none_operator = any(isinstance(op, ast.Is | ast.IsNot | ast.Eq | ast.NotEq) for op in node.ops)
+    return has_name and has_none and has_none_operator
+
+
+def _has_none_branch(function_node: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> bool:
+    return any(_is_none_check_for_name(node, name) for node in ast.walk(function_node))
+
+
+def _unused_optional_param_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    for arg in _optional_default_params(function_node):
+        if _has_none_branch(function_node, arg.arg) or _references_name(
+            ast.Module(body=function_node.body, type_ignores=[]), arg.arg
+        ):
+            continue
+        findings.append(
+            ReviewFinding(
+                category="ai_bloat",
+                severity="info",
+                tool="ast",
+                rule="ai-bloat.unused-optional-param",
+                file=str(file_path),
+                line=arg.lineno,
+                message=(
+                    f"Optional parameter `{arg.arg}` defaults to None but is never checked for None; "
+                    "remove the default or make the parameter required."
+                ),
+                fixable=False,
+            )
+        )
+    return findings
+
+
+def _terminal_return(body: list[ast.stmt]) -> bool:
+    return bool(body) and isinstance(body[-1], ast.Return)
+
+
+def _dead_branch_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    prior_terminal_tests: set[str] = set()
+    for stmt in function_node.body:
+        if not isinstance(stmt, ast.If):
+            continue
+        test_key = ast.dump(stmt.test, include_attributes=False)
+        if test_key in prior_terminal_tests:
+            findings.append(
+                ReviewFinding(
+                    category="ai_bloat",
+                    severity="info",
+                    tool="ast",
+                    rule="ai-bloat.dead-branch",
+                    file=str(file_path),
+                    line=stmt.lineno,
+                    message="Branch duplicates a prior terminal guard and is unreachable in this local flow.",
+                    fixable=False,
+                )
+            )
+        if _terminal_return(stmt.body):
+            prior_terminal_tests.add(test_key)
+    return findings
+
+
+def _function_loc(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    end_lineno = function_node.end_lineno or function_node.lineno
+    return end_lineno - function_node.lineno + 1
+
+
+def _local_branch_complexity(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    branches = (
+        ast.If,
+        ast.For,
+        ast.AsyncFor,
+        ast.While,
+        ast.Try,
+        ast.BoolOp,
+        ast.IfExp,
+        ast.ExceptHandler,
+        ast.Match,
+    )
+    return sum(1 for node in ast.walk(function_node) if isinstance(node, branches))
+
+
+def _loc_vs_complexity_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    loc = _function_loc(function_node)
+    complexity = _local_branch_complexity(function_node)
+    if loc < _LOC_FLOOR or complexity > _COMPLEXITY_CEILING:
+        return []
+    return [
+        ReviewFinding(
+            category="ai_bloat",
+            severity="info",
+            tool="ast",
+            rule="ai-bloat.loc-vs-complexity",
+            file=str(file_path),
+            line=function_node.lineno,
+            message=(
+                f"Function `{function_node.name}` is {loc} lines with low branch complexity; "
+                "look for a stdlib or comprehension collapse."
+            ),
+            fixable=False,
+        )
+    ]
+
+
+def _assigned_name(stmt: ast.stmt) -> str | None:
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if isinstance(target, ast.Name):
+        return target.id
+    return None
+
+
+def _loaded_name_count(node: ast.AST, name: str) -> int:
+    return sum(
+        1
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name) and isinstance(child.ctx, ast.Load) and child.id == name
+    )
+
+
+def _redundant_intermediate_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    for index, stmt in enumerate(function_node.body[:-1]):
+        name = _assigned_name(stmt)
+        if name is None:
+            continue
+        next_stmt = function_node.body[index + 1]
+        if not (
+            isinstance(next_stmt, ast.Return) and isinstance(next_stmt.value, ast.Name) and next_stmt.value.id == name
+        ):
+            continue
+        if _loaded_name_count(next_stmt, name) != 1:
+            continue
+        later_uses = sum(_loaded_name_count(later_stmt, name) for later_stmt in function_node.body[index + 2 :])
+        if later_uses != 0:
+            continue
+        findings.append(
+            ReviewFinding(
+                category="ai_bloat",
+                severity="info",
+                tool="ast",
+                rule="ai-bloat.redundant-intermediate",
+                file=str(file_path),
+                line=stmt.lineno,
+                message=f"Variable `{name}` is assigned once and read only on the next statement; inline it.",
+                fixable=False,
+            )
+        )
+    return findings
+
+
+def _findings_for_function(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    findings.extend(_unused_optional_param_findings(file_path, function_node))
+    findings.extend(_dead_branch_findings(file_path, function_node))
+    findings.extend(_loc_vs_complexity_findings(file_path, function_node))
+    findings.extend(_redundant_intermediate_findings(file_path, function_node))
+    return findings
+
+
+@beartype
+@require(lambda files: isinstance(files, list), "files must be a list")
+@require(lambda files: all(isinstance(file_path, Path) for file_path in files), "files must contain Path instances")
+@ensure(lambda result: isinstance(result, list), "result must be a list")
+@ensure(
+    lambda result: all(isinstance(finding, ReviewFinding) for finding in result),
+    "result must contain ReviewFinding instances",
+)
+def run_ai_bloat(files: list[Path]) -> list[ReviewFinding]:
+    """Run conservative Python-native AST checks for AI-bloat findings."""
+    findings: list[ReviewFinding] = []
+    for file_path in python_source_paths_for_tools(files):
+        try:
+            tree = ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
+        except (OSError, SyntaxError) as exc:
+            findings.append(
+                tool_error(tool="ast", file_path=file_path, message=f"Unable to parse Python source: {exc}")
+            )
+            continue
+        for function_node in _iter_functions(tree):
+            findings.extend(_findings_for_function(file_path, function_node))
+    return findings

--- a/packages/specfact-code-review/src/specfact_code_review/tools/semgrep_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/semgrep_runner.py
@@ -24,12 +24,17 @@ SEMGREP_RULE_CATEGORY = {
     "print-in-src": "architecture",
     "banned-generic-public-names": "naming",
     "swallowed-exception-pattern": "clean_code",
+    "ai-bloat.manual-loop-comprehension": "ai_bloat",
+    "ai-bloat.passthrough-lambda": "ai_bloat",
+    "ai-bloat.identity-try-except": "ai_bloat",
+    "ai-bloat.none-then-none": "ai_bloat",
+    "ai-bloat.single-call-wrapper": "ai_bloat",
 }
 SEMGREP_TIMEOUT_SECONDS = 90
 SEMGREP_RETRY_ATTEMPTS = 2
 _SEMGREP_STDERR_SNIP_MAX = 4000
 _MAX_CONFIG_PARENT_WALK = 32
-SemgrepCategory = Literal["clean_code", "architecture", "naming"]
+SemgrepCategory = Literal["clean_code", "architecture", "naming", "ai_bloat"]
 BugSemgrepCategory = Literal["security", "clean_code"]
 
 BUG_RULE_CATEGORY: dict[str, BugSemgrepCategory] = {
@@ -163,9 +168,42 @@ def find_semgrep_bugs_config(
     return None
 
 
+@beartype
+@require(lambda bundle_root, module_file: bundle_root is None or isinstance(bundle_root, Path))
+@require(lambda bundle_root, module_file: module_file is None or isinstance(module_file, Path))
+@ensure(lambda result: result is None or isinstance(result, Path))
+def find_semgrep_ai_bloat_config(
+    *,
+    bundle_root: Path | None = None,
+    module_file: Path | None = None,
+) -> Path | None:
+    """Locate the optional AI-bloat Semgrep rule pack for this package or bundle root."""
+    rel = Path("resources") / "semgrep-rules" / "ai-bloat.yaml"
+    if bundle_root is not None:
+        candidate = bundle_root.resolve() / rel
+        return candidate if candidate.is_file() else None
+
+    here = (module_file if module_file is not None else Path(__file__)).resolve()
+    for depth, parent in enumerate([here.parent, *here.parents]):
+        if depth > _MAX_CONFIG_PARENT_WALK:
+            break
+        if parent == parent.parent:
+            break
+        candidate = parent / rel
+        if candidate.is_file():
+            return candidate
+        if _is_bundle_boundary(parent):
+            break
+        if parent.name == "site-packages":
+            break
+    return None
+
+
 def _run_semgrep_command(
-    files: list[Path], *, bundle_root: Path | None, config_file: Path
+    files: list[Path], *, bundle_root: Path | None, config_file: Path | list[Path]
 ) -> subprocess.CompletedProcess[str]:
+    config_files = config_file if isinstance(config_file, list) else [config_file]
+    config_args = [arg for path in config_files for arg in ("--config", str(path))]
     with tempfile.TemporaryDirectory(prefix="semgrep-home-") as temp_home:
         semgrep_home = Path(temp_home)
         semgrep_log_dir = semgrep_home / ".semgrep"
@@ -185,8 +223,7 @@ def _run_semgrep_command(
                 "semgrep",
                 "--disable-version-check",
                 "--quiet",
-                "--config",
-                str(config_file),
+                *config_args,
                 "--json",
                 *(str(file_path) for file_path in files),
             ],
@@ -206,7 +243,9 @@ def _snip_stderr_tail(stderr: str) -> str:
     return "…" + err_raw[-_SEMGREP_STDERR_SNIP_MAX:]
 
 
-def _load_semgrep_results(files: list[Path], *, bundle_root: Path | None, config_file: Path) -> list[object]:
+def _load_semgrep_results(
+    files: list[Path], *, bundle_root: Path | None, config_file: Path | list[Path]
+) -> list[object]:
     last_error: Exception | None = None
     for _attempt in range(SEMGREP_RETRY_ATTEMPTS):
         try:
@@ -236,7 +275,7 @@ def _parse_semgrep_results(payload: dict[str, object]) -> list[object]:
 
 def _category_for_rule(rule: str) -> SemgrepCategory | None:
     category = SEMGREP_RULE_CATEGORY.get(rule)
-    if category in {"clean_code", "architecture", "naming"}:
+    if category in {"clean_code", "architecture", "naming", "ai_bloat"}:
         return cast(SemgrepCategory, category)
     return None
 
@@ -283,7 +322,7 @@ def _finding_from_result(item: dict[str, object], *, allowed_paths: set[str]) ->
 
     return ReviewFinding(
         category=category,
-        severity="warning",
+        severity="info" if category == "ai_bloat" else "warning",
         tool="semgrep",
         rule=rule,
         file=filename,
@@ -319,7 +358,11 @@ def run_semgrep(files: list[Path], *, bundle_root: Path | None = None) -> list[R
 
     try:
         config_path = find_semgrep_config(bundle_root=bundle_root)
-        raw_results = _load_semgrep_results(files, bundle_root=bundle_root, config_file=config_path)
+        config_paths = [config_path]
+        ai_bloat_config = find_semgrep_ai_bloat_config(bundle_root=bundle_root)
+        if ai_bloat_config is not None:
+            config_paths.append(ai_bloat_config)
+        raw_results = _load_semgrep_results(files, bundle_root=bundle_root, config_file=config_paths)
     except (FileNotFoundError, OSError, ValueError, json.JSONDecodeError, subprocess.TimeoutExpired) as exc:
         return _tool_error(files[0], f"Unable to parse Semgrep output: {exc}")
 
@@ -327,22 +370,27 @@ def run_semgrep(files: list[Path], *, bundle_root: Path | None = None) -> list[R
     findings: list[ReviewFinding] = []
     try:
         for item in raw_results:
-            _append_semgrep_finding(findings, item, allowed_paths=allowed_paths)
+            _append_semgrep_result(findings, item, allowed_paths=allowed_paths, bug_pass=False)
     except (KeyError, TypeError, ValueError) as exc:
         return _tool_error(files[0], f"Unable to parse Semgrep finding payload: {exc}")
 
     return findings
 
 
-def _append_semgrep_finding(
+def _append_semgrep_result(
     findings: list[ReviewFinding],
     item: object,
     *,
     allowed_paths: set[str],
+    bug_pass: bool,
 ) -> None:
     if not isinstance(item, dict):
         raise ValueError("semgrep finding must be an object")
-    finding = _finding_from_result(item, allowed_paths=allowed_paths)
+    finding = (
+        _finding_from_bug_result(item, allowed_paths=allowed_paths)
+        if bug_pass
+        else _finding_from_result(item, allowed_paths=allowed_paths)
+    )
     if finding is not None:
         findings.append(finding)
 
@@ -381,19 +429,6 @@ def _finding_from_bug_result(item: dict[str, object], *, allowed_paths: set[str]
     )
 
 
-def _append_semgrep_bug_finding(
-    findings: list[ReviewFinding],
-    item: object,
-    *,
-    allowed_paths: set[str],
-) -> None:
-    if not isinstance(item, dict):
-        raise ValueError("semgrep finding must be an object")
-    finding = _finding_from_bug_result(item, allowed_paths=allowed_paths)
-    if finding is not None:
-        findings.append(finding)
-
-
 @beartype
 @require(lambda files: isinstance(files, list), "files must be a list")
 @require(lambda files: all(isinstance(file_path, Path) for file_path in files), "files must contain Path instances")
@@ -428,7 +463,7 @@ def run_semgrep_bugs(files: list[Path], *, bundle_root: Path | None = None) -> l
     findings: list[ReviewFinding] = []
     try:
         for item in raw_results:
-            _append_semgrep_bug_finding(findings, item, allowed_paths=allowed_paths)
+            _append_semgrep_result(findings, item, allowed_paths=allowed_paths, bug_pass=True)
     except (KeyError, TypeError, ValueError) as exc:
         return _tool_error(files[0], f"Unable to parse Semgrep bugs finding payload: {exc}")
 

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-project
-version: 0.41.10
+version: 0.41.11
 commands:
   - project
   - plan
@@ -27,5 +27,4 @@ core_compatibility: '>=0.40.0,<1.0.0'
 description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
-  checksum: sha256:f436231e46a1b758321edf168f1a3d4f7e23dd1c0f2603de36fb6107b2f8f023
-  signature: dbrACMxXY17pNGCNhh8KfzDPu2TUxY0SYkNsE3W/KZ3vMB0yo8+wkJgFtpgbYZsEJaJF8ZesK7luXb+I8ANMBw==
+  checksum: sha256:613fca64cd3937b2a36369ff44069ad56db5162904cfcd2cd426eaf7e66b2d9b

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -28,3 +28,4 @@ description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
   checksum: sha256:613fca64cd3937b2a36369ff44069ad56db5162904cfcd2cd426eaf7e66b2d9b
+  signature: 1euQbP9ngvSUfCy35ly6D5Ul+PNt3ykzCZob1UJgC+Ih8hOT6M/+gUdeqcAHcXeTBgn/+5tu57rYCKRBi766Dg==

--- a/packages/specfact-project/resources/prompts/specfact.08-simplify.md
+++ b/packages/specfact-project/resources/prompts/specfact.08-simplify.md
@@ -1,0 +1,61 @@
+---
+description: Simplify advisory AI-bloat findings from SpecFact code review with per-change confirmation.
+---
+
+# SpecFact Simplify Command
+
+## CLI Reality Check
+
+Prompt instructions are operating guidance for SpecFact CLI, not the source of truth. Current CLI help is authoritative. If a command or option fails, inspect the nearest valid `--help`, correct the invocation when the mapping is obvious, and ask the user when no safe correction is clear.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Purpose
+
+Simplify advisory `ai_bloat` findings from `.specfact/code-review.json` using the IDE's edit tools with explicit user confirmation for every change.
+
+**Quick:** `/specfact.08-simplify`
+
+## Workflow
+
+### Step 1: Confirm Review Evidence
+
+Read `.specfact/code-review.json`. If it is missing, ask the user to run:
+
+```bash
+specfact code review run --json --out .specfact/code-review.json
+```
+
+If the report contains no findings where `category == "ai_bloat"`, report that there are no ai-bloat candidates and stop without editing files.
+
+### Step 2: Group Candidates
+
+Group findings by file, then by rule. For each candidate, inspect the referenced source location and capture a small surrounding snippet before proposing a rewrite.
+
+### Step 3: Confirm Each Rewrite
+
+For each candidate:
+
+1. Show the file, line, rule, and current snippet.
+2. Explain the simplification in one sentence.
+3. Draft the replacement.
+4. Ask the user to choose: accept, reject, skip, or explain.
+5. Apply only accepted edits with the IDE edit tool.
+
+Never apply edits automatically. Never batch multiple files into one confirmation.
+
+### Step 4: Re-run Review
+
+After accepted edits are applied, suggest:
+
+```bash
+specfact code review run --json --out .specfact/code-review.json
+```
+
+Compare the new report with the prior findings and summarize which `ai_bloat` candidates were cleared, skipped, or still present.

--- a/scripts/pre_commit_code_review.py
+++ b/scripts/pre_commit_code_review.py
@@ -111,8 +111,6 @@ def build_review_command(files: Sequence[str]) -> list[str]:
         "code",
         "review",
         "run",
-        "--level",
-        "error",
         "--json",
         "--out",
         REVIEW_JSON_OUT,
@@ -223,6 +221,18 @@ def count_findings_by_severity(findings: list[object]) -> dict[str, int]:
     return buckets
 
 
+def _count_ai_bloat_findings(findings: list[object]) -> int:
+    """Count advisory AI-bloat findings in a ReviewReport payload."""
+    count = 0
+    for item in findings:
+        if not isinstance(item, dict):
+            continue
+        category = item.get("category")
+        if isinstance(category, str) and category == "ai_bloat":
+            count += 1
+    return count
+
+
 def _print_review_findings_summary(repo_root: Path) -> tuple[bool, int | None, int | None]:
     """Parse ``REVIEW_JSON_OUT``, print counts, return ``(ok, error_count, ci_exit_code)``.
 
@@ -252,6 +262,7 @@ def _print_review_findings_summary(repo_root: Path) -> tuple[bool, int | None, i
         return False, None, None
 
     counts = count_findings_by_severity(findings_raw)
+    ai_bloat_count = _count_ai_bloat_findings(findings_raw)
     total = len(findings_raw)
     verdict = data.get("overall_verdict", "?")
     ci_exit_code = data.get("ci_exit_code")
@@ -266,6 +277,8 @@ def _print_review_findings_summary(repo_root: Path) -> tuple[bool, int | None, i
         parts.append(f"info={counts['info']}")
     if counts["other"]:
         parts.append(f"other={counts['other']}")
+    if ai_bloat_count:
+        parts.append(f"ai_bloat={ai_bloat_count}")
     summary = ", ".join(parts)
     sys.stderr.write(f"Code review summary: {total} finding(s) ({summary}); overall_verdict={verdict!r}.\n")
     abs_report = report_path.resolve()

--- a/tests/fixtures/semgrep/bad_identity_try_except.py
+++ b/tests/fixtures/semgrep/bad_identity_try_except.py
@@ -1,0 +1,5 @@
+def parse(raw: str) -> int:
+    try:
+        return int(raw)
+    except ValueError:
+        raise

--- a/tests/fixtures/semgrep/bad_manual_loop_comprehension.py
+++ b/tests/fixtures/semgrep/bad_manual_loop_comprehension.py
@@ -1,0 +1,5 @@
+def double(values: list[int]) -> list[int]:
+    result = []
+    for value in values:
+        result.append(value * 2)
+    return result

--- a/tests/fixtures/semgrep/bad_none_then_none.py
+++ b/tests/fixtures/semgrep/bad_none_then_none.py
@@ -1,0 +1,4 @@
+def normalize(value: str | None) -> str | None:
+    if value is not None:
+        return value
+    return None

--- a/tests/fixtures/semgrep/bad_passthrough_lambda.py
+++ b/tests/fixtures/semgrep/bad_passthrough_lambda.py
@@ -1,0 +1,5 @@
+def canonicalize(value: str) -> str:
+    return value.strip()
+
+
+callbacks = [lambda value: canonicalize(value)]

--- a/tests/fixtures/semgrep/bad_single_call_wrapper.py
+++ b/tests/fixtures/semgrep/bad_single_call_wrapper.py
@@ -1,0 +1,6 @@
+def canonicalize(value: str) -> str:
+    return value.strip()
+
+
+def normalize(value: str) -> str:
+    return canonicalize(value)

--- a/tests/fixtures/semgrep/good_identity_try_except.py
+++ b/tests/fixtures/semgrep/good_identity_try_except.py
@@ -1,0 +1,2 @@
+def parse(raw: str) -> int:
+    return int(raw)

--- a/tests/fixtures/semgrep/good_manual_loop_comprehension.py
+++ b/tests/fixtures/semgrep/good_manual_loop_comprehension.py
@@ -1,0 +1,2 @@
+def double(values: list[int]) -> list[int]:
+    return [value * 2 for value in values]

--- a/tests/fixtures/semgrep/good_none_then_none.py
+++ b/tests/fixtures/semgrep/good_none_then_none.py
@@ -1,0 +1,2 @@
+def normalize(value: str | None) -> str | None:
+    return value

--- a/tests/fixtures/semgrep/good_passthrough_lambda.py
+++ b/tests/fixtures/semgrep/good_passthrough_lambda.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+
+normalize = Path

--- a/tests/fixtures/semgrep/good_single_call_wrapper.py
+++ b/tests/fixtures/semgrep/good_single_call_wrapper.py
@@ -1,0 +1,1 @@
+normalize = str

--- a/tests/unit/scripts/test_pre_commit_code_review.py
+++ b/tests/unit/scripts/test_pre_commit_code_review.py
@@ -86,6 +86,7 @@ def test_build_review_command_writes_json_report() -> None:
     assert command[:5] == [sys.executable, "-m", "specfact_cli.cli", "code", "review"]
     assert "--json" in command
     assert "--out" in command
+    assert "--level" not in command
     assert module.REVIEW_JSON_OUT in command
     assert command[-2:] == ["tests/test_app.py", "packages/specfact-spec/src/x.py"]
 
@@ -144,6 +145,75 @@ def test_main_warnings_only_does_not_block_despite_cli_fail_exit(
     err = capsys.readouterr().err
     assert exit_code == 0
     assert "warnings=1" in err
+
+
+def test_main_ai_bloat_only_does_not_block_and_prints_summary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _load_script_module()
+    repo_root = tmp_path
+    payload: dict[str, object] = {
+        "overall_verdict": "PASS",
+        "ci_exit_code": 0,
+        "findings": [
+            {
+                "category": "ai_bloat",
+                "severity": "info",
+                "rule": "ai-bloat.single-call-wrapper",
+                "file": "tests/unit/test_app.py",
+                "line": 3,
+            }
+        ],
+    }
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert "--level" not in cmd
+        _write_sample_review_report(repo_root, payload)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(module, "ensure_runtime_available", lambda: (True, None))
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    assert module.main(["tests/unit/test_app.py"]) == 0
+    err = capsys.readouterr().err
+    assert "info=1" in err
+    assert "ai_bloat=1" in err
+    assert (
+        json.loads((repo_root / module.REVIEW_JSON_OUT).read_text(encoding="utf-8"))["findings"][0]["category"]
+        == "ai_bloat"
+    )
+
+
+def test_main_preserves_ai_bloat_json_when_error_blocks(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module = _load_script_module()
+    repo_root = tmp_path
+    payload: dict[str, object] = {
+        "overall_verdict": "FAIL",
+        "ci_exit_code": 1,
+        "findings": [
+            {"category": "ai_bloat", "severity": "info", "rule": "ai-bloat.redundant-intermediate"},
+            {"category": "security", "severity": "error", "rule": "specfact-bugs-eval-exec"},
+        ],
+    }
+
+    def _fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert "--level" not in cmd
+        _write_sample_review_report(repo_root, payload)
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+
+    monkeypatch.setattr(module, "_repo_root", lambda: repo_root)
+    monkeypatch.setattr(module, "ensure_runtime_available", lambda: (True, None))
+    monkeypatch.setattr(module.subprocess, "run", _fake_run)
+
+    assert module.main(["tests/unit/test_app.py"]) == 1
+    err = capsys.readouterr().err
+    assert "errors=1" in err
+    assert "ai_bloat=1" in err
+    report = json.loads((repo_root / module.REVIEW_JSON_OUT).read_text(encoding="utf-8"))
+    assert [finding["category"] for finding in report["findings"]] == ["ai_bloat", "security"]
 
 
 def test_main_propagates_review_gate_exit_code(

--- a/tests/unit/specfact_code_review/run/test_findings.py
+++ b/tests/unit/specfact_code_review/run/test_findings.py
@@ -24,6 +24,7 @@ class ReviewFindingPayload(TypedDict, total=False):
         "yagni",
         "dry",
         "solid",
+        "ai_bloat",
     ]
     severity: Literal["error", "warning", "info"]
     tool: str
@@ -81,6 +82,7 @@ def test_review_finding_accepts_supported_severity_values(
         "yagni",
         "dry",
         "solid",
+        "ai_bloat",
     ],
 )
 def test_review_finding_accepts_supported_category_values(category: str) -> None:
@@ -99,6 +101,7 @@ def test_review_finding_accepts_supported_category_values(category: str) -> None
             "yagni",
             "dry",
             "solid",
+            "ai_bloat",
         ],
         category,
     )

--- a/tests/unit/specfact_code_review/run/test_runner.py
+++ b/tests/unit/specfact_code_review/run/test_runner.py
@@ -39,6 +39,7 @@ def _finding(
         "yagni",
         "dry",
         "solid",
+        "ai_bloat",
     ] = "style",
 ) -> ReviewFinding:
     return ReviewFinding(
@@ -64,6 +65,7 @@ def test_run_review_calls_runners_in_order(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: _record("radon"))
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: _record("semgrep"))
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: _record("semgrep_bugs"))
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: _record("ai_bloat"))
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: _record("ast"))
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: _record("basedpyright"))
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: _record("pylint"))
@@ -87,6 +89,7 @@ def test_run_review_calls_runners_in_order(monkeypatch: MonkeyPatch) -> None:
         "radon",
         "semgrep",
         "semgrep_bugs",
+        "ai_bloat",
         "ast",
         "basedpyright",
         "pylint",
@@ -107,6 +110,12 @@ def test_run_review_merges_findings_from_all_runners(monkeypatch: MonkeyPatch) -
     monkeypatch.setattr(
         "specfact_code_review.run.runner.run_semgrep_bugs",
         lambda files: [_finding(tool="semgrep", rule="specfact-bugs-eval-exec", category="security")],
+    )
+    monkeypatch.setattr(
+        "specfact_code_review.run.runner.run_ai_bloat",
+        lambda files: [
+            _finding(tool="ast", rule="ai-bloat.redundant-intermediate", category="ai_bloat", severity="info")
+        ],
     )
     monkeypatch.setattr(
         "specfact_code_review.run.runner.run_ast_clean_code",
@@ -140,6 +149,7 @@ def test_run_review_merges_findings_from_all_runners(monkeypatch: MonkeyPatch) -
         "semgrep",
         "semgrep",
         "ast",
+        "ast",
         "basedpyright",
         "pylint",
         "contract_runner",
@@ -161,6 +171,7 @@ def test_run_review_skips_tdd_gate_when_no_tests_is_true(monkeypatch: MonkeyPatc
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: [])
@@ -183,6 +194,7 @@ def test_run_review_returns_review_report(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: [])
@@ -235,6 +247,7 @@ def test_run_review_suppresses_known_test_noise_by_default(monkeypatch: MonkeyPa
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: noisy_findings[1:2])
@@ -276,6 +289,7 @@ def test_run_review_can_include_known_test_noise(monkeypatch: MonkeyPatch) -> No
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: noisy_findings[1:])
@@ -299,6 +313,7 @@ def test_run_review_emits_advisory_checklist_finding_in_pr_mode(monkeypatch: Mon
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: [])
@@ -322,6 +337,7 @@ def test_run_review_requires_explicit_pr_mode_token_for_clean_code_reasoning(mon
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: [])
@@ -352,6 +368,7 @@ def test_run_review_suppresses_global_duplicate_code_noise_by_default(monkeypatc
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: [duplicate_code_finding])
@@ -407,6 +424,7 @@ def test_run_review_can_include_global_duplicate_code_noise(monkeypatch: MonkeyP
     monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_ast_clean_code", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
     monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: [duplicate_code_finding])

--- a/tests/unit/specfact_code_review/run/test_scorer.py
+++ b/tests/unit/specfact_code_review/run/test_scorer.py
@@ -19,6 +19,19 @@ def _finding(*, severity: Literal["error", "warning", "info"] = "warning", fixab
     )
 
 
+def _ai_bloat_finding() -> ReviewFinding:
+    return ReviewFinding(
+        category="ai_bloat",
+        severity="info",
+        tool="ast",
+        rule="ai-bloat.redundant-intermediate",
+        file="src/example.py",
+        line=10,
+        message="Inline the redundant intermediate value.",
+        fixable=False,
+    )
+
+
 def test_score_review_clean_run() -> None:
     result = score_review(findings=[])
 
@@ -48,6 +61,14 @@ def test_score_review_warning_deductions() -> None:
 
     assert result.score == 94
     assert result.reward_delta == 14
+
+
+def test_score_review_ai_bloat_findings_are_score_neutral() -> None:
+    result = score_review(findings=[_ai_bloat_finding() for _ in range(50)])
+
+    assert result.score == 100
+    assert result.overall_verdict == "PASS"
+    assert result.ci_exit_code == 0
 
 
 def test_score_review_verdict_thresholds() -> None:

--- a/tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from specfact_code_review.tools.ai_bloat_runner import run_ai_bloat
+
+
+def _write(tmp_path: Path, source: str) -> Path:
+    target = tmp_path / "sample.py"
+    target.write_text(source.strip() + "\n", encoding="utf-8")
+    return target
+
+
+def test_unused_optional_param_flags_default_none_without_none_branch(tmp_path: Path) -> None:
+    target = _write(
+        tmp_path,
+        """
+from typing import Optional
+
+
+def greet(name: str, prefix: Optional[str] = None) -> str:
+    return f"{name}"
+""",
+    )
+
+    findings = run_ai_bloat([target])
+
+    assert {finding.rule for finding in findings} == {"ai-bloat.unused-optional-param"}
+    assert findings[0].category == "ai_bloat"
+    assert findings[0].severity == "info"
+
+
+def test_optional_param_with_none_branch_is_not_flagged(tmp_path: Path) -> None:
+    target = _write(
+        tmp_path,
+        """
+from typing import Optional
+
+
+def greet(name: str, prefix: Optional[str] = None) -> str:
+    if prefix is None:
+        return name
+    return f"{prefix} {name}"
+""",
+    )
+
+    assert run_ai_bloat([target]) == []
+
+
+def test_dead_branch_flags_duplicate_prior_return_guard(tmp_path: Path) -> None:
+    target = _write(
+        tmp_path,
+        """
+def classify(value: int) -> str:
+    if value > 10:
+        return "large"
+    if value > 10:
+        return "still large"
+    return "small"
+""",
+    )
+
+    assert {finding.rule for finding in run_ai_bloat([target])} == {"ai-bloat.dead-branch"}
+
+
+def test_loc_vs_complexity_flags_long_linear_function(tmp_path: Path) -> None:
+    lines = ["def build_values(value: int) -> list[int]:", "    result = []"]
+    for index in range(39):
+        lines.append(f"    result.append(value + {index})")
+    lines.append("    return result")
+    target = _write(tmp_path, "\n".join(lines))
+
+    assert {finding.rule for finding in run_ai_bloat([target])} == {"ai-bloat.loc-vs-complexity"}
+
+
+def test_redundant_intermediate_flags_assign_then_immediate_return(tmp_path: Path) -> None:
+    target = _write(
+        tmp_path,
+        """
+def total(values: list[int]) -> int:
+    result = sum(values)
+    return result
+""",
+    )
+
+    assert {finding.rule for finding in run_ai_bloat([target])} == {"ai-bloat.redundant-intermediate"}
+
+
+def test_redundant_intermediate_ignores_reused_names(tmp_path: Path) -> None:
+    target = _write(
+        tmp_path,
+        """
+def total(values: list[int]) -> tuple[int, str]:
+    result = sum(values)
+    label = f"total={result}"
+    return result, label
+""",
+    )
+
+    assert run_ai_bloat([target]) == []

--- a/tests/unit/specfact_code_review/tools/test_semgrep_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_semgrep_runner.py
@@ -27,12 +27,26 @@ BAD_FIXTURE_RULES = {
     "bad_module_network.py": "module-level-network",
     "bad_print_in_src.py": "print-in-src",
 }
+AI_BLOAT_BAD_FIXTURE_RULES = {
+    "bad_manual_loop_comprehension.py": "ai-bloat.manual-loop-comprehension",
+    "bad_passthrough_lambda.py": "ai-bloat.passthrough-lambda",
+    "bad_identity_try_except.py": "ai-bloat.identity-try-except",
+    "bad_none_then_none.py": "ai-bloat.none-then-none",
+    "bad_single_call_wrapper.py": "ai-bloat.single-call-wrapper",
+}
 GOOD_FIXTURES = [
     "good_get_modify.py",
     "good_nested_access.py",
     "good_cross_layer.py",
     "good_module_network.py",
     "good_print_in_src.py",
+]
+AI_BLOAT_GOOD_FIXTURES = [
+    "good_manual_loop_comprehension.py",
+    "good_passthrough_lambda.py",
+    "good_identity_try_except.py",
+    "good_none_then_none.py",
+    "good_single_call_wrapper.py",
 ]
 
 
@@ -121,6 +135,32 @@ def test_run_semgrep_maps_naming_rule_to_naming_category(tmp_path: Path, monkeyp
     assert len(findings) == 1
     assert findings[0].category == "naming"
     assert findings[0].rule == "banned-generic-public-names"
+
+
+def test_run_semgrep_maps_ai_bloat_rules_to_info_findings(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    file_path = tmp_path / "target.py"
+    payload = {
+        "results": [
+            {
+                "check_id": "ai-bloat.single-call-wrapper",
+                "path": str(file_path),
+                "start": {"line": 5},
+                "extra": {"message": "Single-call wrapper adds no behavior.", "severity": "WARNING"},
+            }
+        ]
+    }
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        Mock(return_value=completed_process("semgrep", stdout=json.dumps(payload), returncode=1)),
+    )
+
+    findings = run_semgrep([file_path])
+
+    assert len(findings) == 1
+    assert findings[0].category == "ai_bloat"
+    assert findings[0].severity == "info"
+    assert findings[0].rule == "ai-bloat.single-call-wrapper"
 
 
 def test_run_semgrep_filters_findings_to_requested_files(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -308,3 +348,24 @@ def test_each_good_fixture_triggers_no_findings(fixture_name: str) -> None:
     findings = run_semgrep([FIXTURE_ROOT / fixture_name])
 
     assert not findings
+
+
+@pytest.mark.parametrize(("fixture_name", "expected_rule"), list(AI_BLOAT_BAD_FIXTURE_RULES.items()))
+def test_each_ai_bloat_bad_fixture_triggers_expected_rule(fixture_name: str, expected_rule: str) -> None:
+    if shutil.which("semgrep") is None:
+        pytest.skip("semgrep CLI is required for fixture validation")
+
+    findings = run_semgrep([FIXTURE_ROOT / fixture_name])
+
+    assert expected_rule in {finding.rule for finding in findings}
+    assert all(finding.severity == "info" for finding in findings if finding.rule == expected_rule)
+
+
+@pytest.mark.parametrize("fixture_name", AI_BLOAT_GOOD_FIXTURES)
+def test_each_ai_bloat_good_fixture_triggers_no_ai_bloat_findings(fixture_name: str) -> None:
+    if shutil.which("semgrep") is None:
+        pytest.skip("semgrep CLI is required for fixture validation")
+
+    findings = run_semgrep([FIXTURE_ROOT / fixture_name])
+
+    assert not any(finding.category == "ai_bloat" for finding in findings)

--- a/tests/unit/test_bundle_resource_payloads.py
+++ b/tests/unit/test_bundle_resource_payloads.py
@@ -244,6 +244,7 @@ def test_code_review_bundle_packages_ai_bloat_policy_pack_manifest() -> None:
     assert data["pack_ref"] == "specfact/ai-bloat-patterns"
     assert data["default_mode"] == "advisory"
     assert {rule["id"] for rule in data["rules"]} == expected_rules
+    assert {rule["category"] for rule in data["rules"]} == {"ai_bloat"}
     assert {rule["principle"] for rule in data["rules"]} == {"ai_bloat"}
 
 

--- a/tests/unit/test_bundle_resource_payloads.py
+++ b/tests/unit/test_bundle_resource_payloads.py
@@ -35,6 +35,7 @@ _EXPECTED_PROMPTS: dict[str, tuple[str, ...]] = {
         "specfact.03-review.md",
         "specfact.04-sdd.md",
         "specfact.06-sync.md",
+        "specfact.08-simplify.md",
         "specfact.compare.md",
     ),
     "specfact-govern": ("specfact.05-enforce.md",),
@@ -222,6 +223,30 @@ def test_code_review_bundle_packages_clean_code_policy_pack_manifest() -> None:
         assert {rule["id"] for rule in data["rules"]} == expected_rules
 
 
+def test_code_review_bundle_packages_ai_bloat_policy_pack_manifest() -> None:
+    module_root = REPO_ROOT / "packages" / "specfact-code-review"
+    manifest_path = module_root / "resources" / "policy-packs" / "specfact" / "ai-bloat-patterns.yaml"
+    semgrep_path = module_root / "resources" / "semgrep-rules" / "ai-bloat.yaml"
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    expected_rules = {
+        "ai-bloat.manual-loop-comprehension",
+        "ai-bloat.passthrough-lambda",
+        "ai-bloat.identity-try-except",
+        "ai-bloat.none-then-none",
+        "ai-bloat.single-call-wrapper",
+        "ai-bloat.unused-optional-param",
+        "ai-bloat.dead-branch",
+        "ai-bloat.loc-vs-complexity",
+        "ai-bloat.redundant-intermediate",
+    }
+
+    assert semgrep_path.is_file()
+    assert data["pack_ref"] == "specfact/ai-bloat-patterns"
+    assert data["default_mode"] == "advisory"
+    assert {rule["id"] for rule in data["rules"]} == expected_rules
+    assert {rule["principle"] for rule in data["rules"]} == {"ai_bloat"}
+
+
 def test_backlog_artifact_contains_prompt_payload(tmp_path: Path) -> None:
     artifact = _build_bundle_artifact("specfact-backlog", tmp_path)
     with tarfile.open(artifact, "r:gz") as archive:
@@ -238,7 +263,11 @@ def test_backlog_artifact_contains_prompt_payload(tmp_path: Path) -> None:
 def test_code_review_artifact_contains_policy_pack_payload(tmp_path: Path) -> None:
     artifact = _build_bundle_artifact("specfact-code-review", tmp_path)
     with tarfile.open(artifact, "r:gz") as archive:
-        assert "specfact-code-review/resources/policy-packs/specfact/clean-code-principles.yaml" in archive.getnames()
+        names = set(archive.getnames())
+
+    assert "specfact-code-review/resources/policy-packs/specfact/clean-code-principles.yaml" in names
+    assert "specfact-code-review/resources/policy-packs/specfact/ai-bloat-patterns.yaml" in names
+    assert "specfact-code-review/resources/semgrep-rules/ai-bloat.yaml" in names
 
 
 def test_project_artifact_contains_runtime_generator_templates(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds advisory, score-neutral `ai_bloat` review findings through Semgrep rules and a conservative AST runner.
- Adds `/specfact.08-simplify` prompt support plus packaged policy resources and docs/quickstart callouts.
- Updates pre-commit review reporting so `ai_bloat` info findings remain visible in JSON without blocking by themselves.

## Verification

- `hatch run format`
- `hatch run type-check`
- `hatch run lint`
- `hatch run yaml-lint`
- `hatch run check-bundle-imports`
- `hatch run validate-prompt-commands`
- `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`
- `hatch run contract-test` (`693 passed, 2 warnings`)
- `hatch run smart-test` (`693 passed, 2 warnings`)
- `hatch run test` (`693 passed, 2 warnings`)
- `openspec validate code-review-ai-bloat-detection --strict`

## Review Gate Note

Full-scope manual review was run with:

`SPECFACT_ALLOW_UNSIGNED=1 hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope full`

It still fails because of pre-existing full-repository findings outside this change. Modified-artifact triage is documented in `openspec/changes/code-review-ai-bloat-detection/TDD_EVIDENCE.md`; after fixes, the only modified-file findings left are existing warnings on `run_review` complexity/parameter count.

Fixes nold-ai/specfact-cli-modules#269.
