### PR TITLE
Add simplification feedback loop OpenSpec change

### DIFF
--- a/openspec/CHANGE_ORDER.md
+++ b/openspec/CHANGE_ORDER.md
@@ -101,6 +101,7 @@ The architecture pillar remains active because `architecture-02-well-architected
 | code-review + codebase | 01 | code-review-bug-finding-and-sidecar-venv-fix | [#174](https://github.com/nold-ai/specfact-cli-modules/issues/174) | Parent Feature: [#175](https://github.com/nold-ai/specfact-cli-modules/issues/175); Epic: [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162) |
 | codebase + project-runtime | 02 | codebase-import-runtime-hardening | [#235](https://github.com/nold-ai/specfact-cli-modules/issues/235) | Parent Feature: [#234](https://github.com/nold-ai/specfact-cli-modules/issues/234); Epic: [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162); no known blockers |
 | code-review + project | 03 | code-review-ai-bloat-detection | [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269) | Parent Feature: [#175](https://github.com/nold-ai/specfact-cli-modules/issues/175); Epic: [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162); no known blockers |
+| code-review + project | 04 | code-review-11-simplification-feedback-loop | [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) | Parent Feature: [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275); Epic: [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162); blocked by `code-review-ai-bloat-detection` / [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269) |
 
 ### Documentation restructure
 

--- a/openspec/changes/code-review-11-simplification-feedback-loop/.openspec.yaml
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/code-review-11-simplification-feedback-loop/design.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/design.md
@@ -1,0 +1,78 @@
+## Context
+
+`code-review-ai-bloat-detection` added the first advisory `ai_bloat` layer: semgrep rules for syntactic shapes, an AST runner for local semantic patterns, a policy pack, and `/specfact.08-simplify`. The current output is useful but still shallow for an IDE loop because most findings carry only category, rule, file, line, and message.
+
+The next step is to make the CLI output richer while keeping the responsibility split clear:
+
+- the CLI deterministically detects and groups simplification opportunities;
+- the IDE LLM proposes rewrites from that evidence;
+- the user approves each edit.
+
+This change is owned by `specfact-cli-modules`, primarily `packages/specfact-code-review` and `packages/specfact-project`. No core CLI schema dependency is required for v1 because the JSON extension is additive.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add optional simplification metadata to `ReviewFinding` without breaking existing JSON consumers.
+- Add deterministic static signals for common overengineering patterns that are safe to present as cleanup candidates.
+- Group duplicate-intent code in the same business/domain area so users see consolidation opportunities instead of unrelated one-line warnings.
+- Add `--focus simplify` as a review command convenience for feeding `/specfact.08-simplify`.
+- Update the simplify prompt to use grouped evidence while preserving per-change confirmation.
+
+**Non-Goals:**
+
+- No LLM, embeddings, or authorship classification inside the CLI.
+- No autonomous `--fix` behavior for simplification findings.
+- No blocking or score penalty for simplification findings in v1.
+- No cross-language implementation in v1; Python remains the supported analysis target.
+- No breaking removal or rename of existing `ReviewFinding` fields.
+
+## Decisions
+
+### Decision 1: Add optional metadata on findings instead of a second report artifact
+
+Simplification metadata belongs beside each finding because the IDE prompt already reads `.specfact/code-review.json` and filters findings by category/rule. A second file would create synchronization and stale-data risk.
+
+The metadata fields are optional:
+
+- `confidence`: deterministic confidence bucket or score for prioritization;
+- `rewrite_hint`: concise standard-pattern guidance;
+- `canonical_pattern`: normalized pattern label such as `manual-accumulator-loop` or `verbose-bool-return`;
+- `intent_key`: stable grouping key for related domain intent;
+- `estimated_deletion_lines`: non-binding estimate used for triage;
+- `related_locations`: same-shape or same-intent locations that should be reviewed together.
+
+Existing consumers can ignore unknown fields.
+
+### Decision 2: Use static-first duplicate-intent grouping
+
+The duplicate-intent detector should compute a grouping key from deterministic ingredients:
+
+- normalized AST shape with local names/literals erased;
+- call roots and imported APIs;
+- function name tokens after stop-word removal;
+- path/domain tokens from package and module path;
+- docstring/comment vocabulary only as weak evidence.
+
+This catches “same business operation written twice with different names” without requiring external services or an LLM. The detector should emit only when multiple signals agree; ambiguous groups stay silent.
+
+### Decision 3: Keep policy advisory and score-neutral
+
+Overengineering signals often require human context: wrappers may preserve API compatibility, verbose branches may aid debugging, and duplicate-looking code may intentionally diverge. Therefore every new signal stays advisory and score-neutral in v1. The action surface is the IDE prompt, not pre-commit blocking.
+
+### Decision 4: Reuse `--focus` rather than adding a separate command
+
+`review-run-command` already supports repeatable `--focus` facets. Extending that option with `simplify` avoids a new top-level command while giving users and prompts a stable way to request the simplification queue. `--focus simplify` filters findings after normal analysis to the set intended for simplification review.
+
+### Decision 5: Prompt groups before edits
+
+`/specfact.08-simplify` should first group by `intent_key`, then by file/domain and rule. This lets the IDE explain consolidation opportunities before suggesting a rewrite, but it must continue to apply only one accepted edit at a time.
+
+## Risks / Trade-offs
+
+- **False positives on intentional wrappers** -> Use high-confidence thresholds, advisory severity, and explicit accept/reject/skip confirmation.
+- **Metadata churn in JSON consumers** -> Keep fields optional and bump schema version additively to `1.1`.
+- **Duplicate-intent grouping overreach** -> Require agreement across AST shape plus domain/call evidence; never group solely by similar names.
+- **Prompt overwhelms users on large repos** -> Use `--focus simplify` and grouped ranking by confidence and estimated deletion.
+- **Project board assignment gap** -> GitHub token could not add issues to the project; record as a setup follow-up before implementation readiness.

--- a/openspec/changes/code-review-11-simplification-feedback-loop/proposal.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The first `ai_bloat` pass identifies common AI-shaped bloat, but its findings are still mostly local line-level hints. SpecFact needs a deterministic simplification feedback loop that can tell an IDE LLM what pattern to collapse, what related duplicate-intent code exists, and how much noise can likely be removed without turning advisory cleanup into a blocking gate.
+
+## What Changes
+
+- Add structured simplification metadata to code-review findings so `.specfact/code-review.json` can carry rewrite hints, confidence, estimated deletion impact, canonical patterns, intent keys, and related locations.
+- Add deterministic simplification analyzers in `specfact-code-review` for expanded overengineering patterns: accumulator loops, verbose boolean returns, redundant `None` branches, wrapper chains, pass-through defensive `try/except`, one-use temporaries, table-lookup candidates, and stdlib replacement candidates.
+- Add duplicate-intent grouping for functions in the same business/domain area using static AST shape, call roots, imports, path domain, and business vocabulary. This is not an LLM authorship classifier and does not use embeddings in v1.
+- Add `--focus simplify` to review runs as a targeted queue for `ai_bloat`, high-confidence `dry`, and high-confidence `kiss` simplification findings.
+- Update `/specfact.08-simplify` so IDE agents group findings by `intent_key -> file/domain -> rule`, show related locations, and still require explicit per-change confirmation before editing.
+- Keep all new simplification findings advisory, score-neutral, and non-blocking.
+
+## Capabilities
+
+### New Capabilities
+
+- `code-review-simplification-feedback`: Deterministic simplification metadata, duplicate-intent grouping, and IDE feedback queue behavior for code review findings.
+
+### Modified Capabilities
+
+- `review-finding-model`: Add optional simplification metadata fields while preserving backward compatibility for existing finding consumers.
+- `review-run-command`: Add `--focus simplify` behavior for targeted simplification review queues.
+- `clean-code-analysis`: Clarify how high-confidence `dry` and `kiss` signals can contribute to the simplification queue without changing their blocking policy.
+
+## Impact
+
+- **Affected bundles:** `packages/specfact-code-review` and `packages/specfact-project`.
+- **Affected interfaces:** `.specfact/code-review.json` receives additive optional metadata and a schema-version bump to `1.1`; existing fields and consumers remain compatible.
+- **Affected prompt resources:** `packages/specfact-project/resources/prompts/specfact.08-simplify.md`.
+- **Affected docs:** code-review and prompt documentation on modules.specfact.io should describe the simplify focus, advisory-only model, and duplicate-intent grouping.
+- **Release impact:** module package version bumps and signature refresh are required when implementation changes packaged resources or manifests.
+
+## Source Tracking
+
+<!-- source_repo: nold-ai/specfact-cli-modules -->
+- **Modules Epic:** [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162)
+- **Parent Feature:** [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275)
+- **GitHub Issue:** [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276)
+- **Repository:** nold-ai/specfact-cli-modules
+- **Prior Baseline:** [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269) / `code-review-ai-bloat-detection`
+- **Last Synced Status:** proposed
+- **Sanitized:** false
+
+## Follow-ups
+
+- Add issues [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275) and [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) to the `SpecFact CLI` project board. The current GitHub token created labels, issue type, and parent/subissue relationships successfully but returned `Resource not accessible by personal access token` for project assignment.

--- a/openspec/changes/code-review-11-simplification-feedback-loop/specs/clean-code-analysis/spec.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/specs/clean-code-analysis/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Clean-code signals can contribute to simplification feedback
+
+The clean-code analysis layer SHALL allow high-confidence `dry` and `kiss` findings to contribute to the simplification feedback queue when they include deterministic rewrite or consolidation evidence. This SHALL NOT change the existing clean-code category semantics or blocking policy.
+
+#### Scenario: High-confidence duplicate shape contributes related locations
+
+- **WHEN** AST clean-code analysis detects duplicate intent with stable related locations
+- **THEN** the finding MAY include simplification metadata such as `intent_key`, `rewrite_hint`, and `related_locations`
+- **AND** the finding SHALL retain its governed category, such as `dry`, when that category is the primary principle
+
+#### Scenario: Clean-code policy remains unchanged
+
+- **WHEN** a clean-code finding contributes to the simplification queue
+- **THEN** its existing category and severity semantics SHALL remain unchanged
+- **AND** inclusion in `--focus simplify` SHALL NOT by itself make the finding more severe

--- a/openspec/changes/code-review-11-simplification-feedback-loop/specs/code-review-simplification-feedback/spec.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/specs/code-review-simplification-feedback/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Review findings carry optional simplification metadata
+
+The code-review report SHALL support optional simplification metadata on each finding so IDE prompts can prioritize and explain advisory cleanup without inferring intent from free-form messages. The metadata SHALL be additive and SHALL NOT remove or rename existing `ReviewFinding` fields.
+
+#### Scenario: Finding includes simplification metadata
+
+- **WHEN** a simplification-capable detector emits a finding
+- **THEN** the finding MAY include `confidence`, `rewrite_hint`, `canonical_pattern`, `intent_key`, `estimated_deletion_lines`, and `related_locations`
+- **AND** each included metadata field SHALL be serializable in `.specfact/code-review.json`
+- **AND** existing required fields such as `category`, `severity`, `tool`, `rule`, `file`, `line`, `message`, and `fixable` SHALL remain present
+
+#### Scenario: Consumer ignores simplification metadata
+
+- **WHEN** an existing consumer reads a report containing simplification metadata
+- **THEN** the existing consumer SHALL be able to rely on the original required finding fields
+- **AND** the metadata SHALL be optional so consumers that do not understand it can ignore it
+
+### Requirement: Simplification analyzers detect deterministic overengineering patterns
+
+The code-review bundle SHALL emit advisory simplification findings for deterministic Python overengineering patterns where a standard language or library pattern is safer and simpler than custom control flow.
+
+#### Scenario: Analyzer flags a verbose pattern with a standard rewrite hint
+
+- **WHEN** the analyzer finds a manual accumulator loop, verbose boolean return, redundant `None` branch, wrapper chain, pass-through defensive `try/except`, one-use temporary, table-lookup candidate, or stdlib replacement candidate
+- **THEN** the report SHALL include an advisory simplification finding
+- **AND** the finding SHALL include a `rewrite_hint` describing the standard pattern to consider
+- **AND** the finding SHALL NOT be emitted at `error` severity
+
+#### Scenario: Analyzer stays silent on ambiguous code
+
+- **WHEN** the analyzer cannot determine a simpler standard pattern with high confidence
+- **THEN** it SHALL NOT emit a simplification finding for that code
+
+### Requirement: Duplicate-intent grouping is deterministic and domain-aware
+
+The code-review bundle SHALL group likely duplicate-intent functions only when deterministic static evidence indicates that the functions serve the same business or domain purpose.
+
+#### Scenario: Same-intent functions are grouped
+
+- **WHEN** two or more reviewed functions have compatible normalized AST shapes, compatible call roots or imported APIs, and matching package/domain vocabulary
+- **THEN** the review report SHALL include a simplification finding with a stable `intent_key`
+- **AND** the finding SHALL include `related_locations` for the other functions in the group
+- **AND** the finding message SHALL describe the group as a consolidation candidate rather than a correctness failure
+
+#### Scenario: Similar names alone do not create a group
+
+- **WHEN** two functions have similar names but incompatible AST shape, call roots, or domain context
+- **THEN** the duplicate-intent detector SHALL NOT group them solely because of name similarity
+
+### Requirement: Simplification feedback remains advisory and score-neutral
+
+Simplification findings SHALL remain advisory, score-neutral, and non-blocking in v1.
+
+#### Scenario: Simplification-only report remains non-blocking
+
+- **WHEN** a review report contains only simplification findings
+- **THEN** those findings SHALL NOT reduce the governed review score
+- **AND** the review SHALL NOT fail because of those findings
+- **AND** the findings SHALL remain available in `.specfact/code-review.json` for IDE feedback
+
+### Requirement: IDE simplify prompt consumes grouped evidence
+
+The `/specfact.08-simplify` prompt SHALL consume simplification metadata from `.specfact/code-review.json` and use it to guide one confirmed rewrite at a time.
+
+#### Scenario: Prompt groups by intent before proposing rewrites
+
+- **WHEN** `.specfact/code-review.json` contains findings with `intent_key` values
+- **THEN** `/specfact.08-simplify` SHALL group candidates by `intent_key`, then by file or domain and rule
+- **AND** it SHALL show related locations before drafting a rewrite for a grouped candidate
+
+#### Scenario: Prompt preserves explicit confirmation
+
+- **WHEN** `/specfact.08-simplify` presents a simplification candidate
+- **THEN** it SHALL ask the user to accept, reject, skip, or request explanation before applying any edit
+- **AND** it SHALL apply only edits the user accepts

--- a/openspec/changes/code-review-11-simplification-feedback-loop/specs/review-finding-model/spec.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/specs/review-finding-model/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: ReviewFinding schema supports additive simplification metadata
+
+The `ReviewFinding` model SHALL accept optional simplification metadata while preserving the existing governed finding fields and category/severity validation. The report schema version SHALL advance additively to `1.1` when simplification metadata is emitted.
+
+#### Scenario: Simplification metadata validates on a finding
+
+- **WHEN** a `ReviewFinding` payload includes `confidence`, `rewrite_hint`, `canonical_pattern`, `intent_key`, `estimated_deletion_lines`, or `related_locations`
+- **THEN** model validation SHALL accept the payload when the original required fields are valid
+- **AND** `related_locations` SHALL use stable file and line references compatible with existing evidence references
+
+#### Scenario: Legacy finding payload remains valid
+
+- **WHEN** a `ReviewFinding` payload contains only the existing required fields and optional `evidence_refs`
+- **THEN** model validation SHALL continue to accept the payload
+- **AND** the absence of simplification metadata SHALL NOT change category, severity, blocking, or scoring behavior

--- a/openspec/changes/code-review-11-simplification-feedback-loop/specs/review-run-command/spec.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/specs/review-run-command/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Review run supports simplify focus
+
+The `specfact code review run` command SHALL accept `--focus simplify` as a targeted review focus for IDE simplification feedback. The focus SHALL retain findings that belong in the simplification queue, including `ai_bloat`, high-confidence duplicate-intent `dry`, and high-confidence simplicity `kiss` findings.
+
+#### Scenario: Simplify focus emits simplification queue
+
+- **WHEN** `specfact code review run --focus simplify --json --out .specfact/code-review.json` completes
+- **THEN** the JSON report SHALL retain simplification-focused findings
+- **AND** retained findings SHALL include enough metadata for `/specfact.08-simplify` to group and explain the candidate
+
+#### Scenario: Simplify focus does not make advisories blocking
+
+- **WHEN** a simplify-focused run contains only advisory simplification findings
+- **THEN** the process SHALL remain non-blocking under enforce mode
+- **AND** the governed score SHALL NOT be reduced by simplification-only findings
+
+#### Scenario: Simplify focus composes with scope controls
+
+- **WHEN** `--focus simplify` is combined with `--scope changed`, `--scope full`, `--path`, or positional files
+- **THEN** the command SHALL first resolve the reviewed file set using the existing scope rules
+- **AND** it SHALL then filter or prioritize findings for the simplification queue

--- a/openspec/changes/code-review-11-simplification-feedback-loop/tasks.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/tasks.md
@@ -1,0 +1,54 @@
+## 1. GitHub readiness and change setup
+
+- [ ] 1.1 Verify issue [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) is linked under parent Feature [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275), which is linked under Epic [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162).
+- [ ] 1.2 Add [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275) and [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) to the `SpecFact CLI` project board once a token with project scope is available.
+- [ ] 1.3 Confirm labels are complete: parent Feature has `enhancement`, `codebase`, `openspec`, `Feature`; change issue has `enhancement`, `codebase`, `openspec`, `change-proposal`.
+- [ ] 1.4 Confirm [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) is not already `in progress` before implementation begins, and record any blocker or blocked-by relationship updates in the issue body.
+- [ ] 1.5 Keep `openspec/CHANGE_ORDER.md` aligned with the new change under "Code review and sidecar validation improvements" as order 04, blocked by [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269).
+- [ ] 1.6 Validate the OpenSpec change with `openspec validate code-review-11-simplification-feedback-loop --strict` before implementation begins.
+
+## 2. Spec-first failing tests
+
+- [ ] 2.1 Add failing model tests proving `ReviewFinding` accepts optional simplification metadata and legacy finding payloads remain valid.
+- [ ] 2.2 Add failing runner tests proving `--focus simplify` retains only simplification-queue findings after existing scope resolution.
+- [ ] 2.3 Add failing analyzer tests for new deterministic overengineering patterns: accumulator loops, verbose boolean returns, redundant `None` branches, wrapper chains, pass-through defensive `try/except`, one-use temporaries, table-lookup candidates, and stdlib replacement candidates.
+- [ ] 2.4 Add failing duplicate-intent tests with same-domain functions that differ in local names but share normalized shape, call roots, and domain vocabulary.
+- [ ] 2.5 Add negative fixtures proving similar names alone, intentional compatibility wrappers, and ambiguous domain matches do not emit simplification findings.
+- [ ] 2.6 Add prompt contract tests proving `/specfact.08-simplify` groups by `intent_key`, shows related locations, and still requires accept/reject/skip/explain before edits.
+- [ ] 2.7 Record failing-before commands and output in `openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md`.
+
+## 3. Review model and report metadata
+
+- [ ] 3.1 Extend the review finding model with optional simplification metadata fields: `confidence`, `rewrite_hint`, `canonical_pattern`, `intent_key`, `estimated_deletion_lines`, and `related_locations`.
+- [ ] 3.2 Bump emitted review report schema version to `1.1` when simplification metadata is present while preserving default compatibility for legacy reports.
+- [ ] 3.3 Ensure simplification metadata does not affect `is_blocking`, governed score, or existing severity validation.
+- [ ] 3.4 Add serialization examples or fixture reports covering both legacy and metadata-bearing findings.
+
+## 4. Deterministic simplification analyzers
+
+- [ ] 4.1 Implement static analyzer helpers for the expanded overengineering patterns in `packages/specfact-code-review`.
+- [ ] 4.2 Implement duplicate-intent grouping from normalized AST shape, call roots, import/API evidence, path-domain tokens, and business vocabulary.
+- [ ] 4.3 Emit stable `intent_key` and `related_locations` only when multiple deterministic signals agree.
+- [ ] 4.4 Add confidence and estimated deletion calculations with conservative defaults suitable for advisory triage.
+- [ ] 4.5 Keep all new simplification findings advisory and score-neutral.
+
+## 5. Review command and prompt integration
+
+- [ ] 5.1 Extend `specfact code review run --focus` to accept `simplify` and apply it after normal file-scope resolution.
+- [ ] 5.2 Update `/specfact.08-simplify` to group candidates by `intent_key`, then file/domain and rule, and to show related locations before drafting rewrites.
+- [ ] 5.3 Preserve the prompt's explicit per-change confirmation loop and prohibit autonomous batch edits.
+- [ ] 5.4 Run prompt validation with `hatch run validate-prompt-commands` if prompt command examples or resources change.
+
+## 6. Docs, packaging, and signatures
+
+- [ ] 6.1 Update code-review documentation to explain simplification metadata, `--focus simplify`, duplicate-intent grouping, and advisory-only behavior.
+- [ ] 6.2 Bump affected `module-package.yaml` versions when packaged code, policy resources, or prompt resources change.
+- [ ] 6.3 Re-sign affected module manifests and update registry/signature artifacts as required by the modules repo signing policy.
+
+## 7. Passing evidence and quality gates
+
+- [ ] 7.1 Re-run all targeted tests from section 2 and record passing evidence in `TDD_EVIDENCE.md`.
+- [ ] 7.2 Run `openspec validate code-review-11-simplification-feedback-loop --strict`.
+- [ ] 7.3 Run required gates in order: `hatch run format`, `hatch run type-check`, `hatch run lint`, `hatch run yaml-lint`, `hatch run check-bundle-imports`, `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`, `hatch run contract-test`, relevant `hatch run smart-test`, and relevant `hatch run test`.
+- [ ] 7.4 Run `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed`, fix all findings or document approved exceptions, and rerun until passing.
+- [ ] 7.5 Commit, push, and open or update the PR to `dev` after verification is green.


### PR DESCRIPTION
## Summary

- Add OpenSpec change code-review-11-simplification-feedback-loop.
- Create proposal, design, delta specs, and implementation tasks for simplification metadata and duplicate-intent feedback.
- Sequence the change in openspec/CHANGE_ORDER.md.

## Tracking

- Parent Feature: #275
- Change issue: #276
- Baseline: #269

## Validation

- openspec validate code-review-11-simplification-feedback-loop --strict
- Pre-commit hooks during commit:
  - verify module signatures and version bumps
  - format
  - yaml-lint
  - check-bundle-imports
  - docs command validation

## Notes

This PR creates planning artifacts only; implementation is intentionally left for a later session.