### PR TITLE
Implement code review simplification feedback loop

### DIFF
--- a/docs/bundles/code-review/overview.md
+++ b/docs/bundles/code-review/overview.md
@@ -10,7 +10,7 @@ expertise_level: [beginner, intermediate]
 
 # Code Review bundle overview
 
-The **Code Review** bundle (`nold-ai/specfact-code-review`) extends the shared **`specfact code`** command group with **`review`** workflows: governed review runs, **reward ledger** history, and **house-rules** skill management.
+The **Code Review** bundle (`nold-ai/specfact-code-review`) extends the shared **`specfact code`** command group with **`review`** workflows: governed review runs, **reward ledger** history, and bundled code-review skill management through the **`rules`** command.
 
 Use it together with the [Codebase](/bundles/codebase/overview/) bundle (`import`, `analyze`, `drift`, `validate`, `repro`) on the same `code` surface.
 

--- a/docs/bundles/code-review/overview.md
+++ b/docs/bundles/code-review/overview.md
@@ -25,7 +25,7 @@ Use it together with the [Codebase](/bundles/codebase/overview/) bundle (`import
 |--------|---------|
 | `run` | Execute a governed review (scope, JSON output, `--fix`, TDD gate, etc.) |
 | `ledger` | Inspect and update review reward history |
-| `rules` | Manage the house-rules skill (`show`, `init`, `update`) |
+| `rules` | Manage the bundled code-review skill (`show`, `init`, `update`) |
 
 ### `ledger` subcommands
 
@@ -46,9 +46,10 @@ Use it together with the [Codebase](/bundles/codebase/overview/) bundle (`import
 ## Bundle-owned skills and policy packs
 
 House rules and review payloads ship **inside the bundle** (for example Semgrep
-packs, the `specfact/clean-code-principles` policy-pack manifest, and skill
-metadata). They are **not** core CLI-owned resources. Install or refresh
-IDE-side assets with `specfact init ide` after upgrading the bundle.
+packs, the `specfact/clean-code-principles` policy-pack manifest, and the
+`specfact-code-review` skill). They are **not** core CLI-owned resources. Use
+`specfact code review rules init --ide codex` or the matching IDE target to
+install the reusable skill instead of copying prompt templates by hand.
 
 ## Quick examples
 

--- a/docs/bundles/code-review/rules.md
+++ b/docs/bundles/code-review/rules.md
@@ -12,7 +12,11 @@ expertise_level: [intermediate, advanced]
 
 # Code review rules
 
-The rules commands manage the house-rules skill that backs the Code Review bundle’s policy guidance.
+The rules commands manage the bundled `specfact-code-review` skill. Install it
+when Codex CLI, Claude, Vibe, Cursor, or another SKILL.md-compatible AI IDE
+needs the Code Review workflow without copying slash prompt templates by hand.
+The skill includes CLI self-healing guidance, review run commands,
+simplification queue handling, and compact house rules.
 
 ## Commands
 
@@ -38,7 +42,9 @@ specfact code review rules update --ide cursor
 
 ## Bundle-owned resources
 
-The skill content is bundled with `nold-ai/specfact-code-review`. Initialize or refresh it from the installed module version instead of copying legacy core-owned files by hand.
+The skill content is bundled with `nold-ai/specfact-code-review`. Initialize or
+refresh it from the installed module version instead of copying prompt templates
+or legacy core-owned files by hand.
 
 ## Related
 

--- a/docs/bundles/code-review/run.md
+++ b/docs/bundles/code-review/run.md
@@ -122,6 +122,14 @@ The review pipeline uses rules, skills, and policy payloads shipped with the ins
 
 The built-in `specfact/ai-bloat-patterns` policy pack is parallel to `specfact/clean-code-principles`. It maps advisory `ai_bloat` rules to the `ai_bloat` principle, emits `severity=info`, and stays score-neutral so simplification candidates do not block commits. Omit `--level` when producing the JSON report for `/specfact.08-simplify`; `--level error` intentionally filters info-level findings out of the command report.
 
+Use `--focus simplify` when producing the IDE simplification queue:
+
+```bash
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
+```
+
+Simplify-focused reports keep advisory `ai_bloat` findings plus high-confidence `dry` and `kiss` findings that include deterministic simplification metadata. Metadata fields such as `rewrite_hint`, `canonical_pattern`, `intent_key`, `estimated_deletion_lines`, and `related_locations` are additive; legacy consumers can keep reading the original finding fields. Simplification findings remain score-neutral and non-blocking.
+
 ## Related
 
 - [Code review ledger](/bundles/code-review/ledger/)

--- a/docs/bundles/code-review/run.md
+++ b/docs/bundles/code-review/run.md
@@ -29,7 +29,7 @@ The pipeline reviews **`.py`** and **`.pyi`** only. The **`--focus docs`** facet
 | `--scope changed\|full` | Review changed files or the full repository when no positional files are provided |
 | `--path <prefix>` | Narrow auto-discovered review files to one or more repo-relative prefixes |
 | `--include-tests`, `--exclude-tests` | Control whether changed test files participate in auto-scope review |
-| `--focus <facet>` | Limit auto-discovered scope to **`source`**, **`tests`**, and/or **`docs`** (repeatable); mutually exclusive with `--include-tests` / `--exclude-tests` |
+| `--focus <facet>` | Limit auto-discovered scope to **`source`**, **`tests`**, **`docs`**, and/or **`simplify`** (repeatable); mutually exclusive with `--include-tests` / `--exclude-tests` |
 | `--mode shadow\|enforce` | **`shadow`** surfaces findings without failing the exit code for policy violations; **`enforce`** applies normal gating (default **`enforce`**) |
 | `--level error\|warning` | Optional reporting level override before scoring: **`error`** keeps errors only (drops warnings and info); **`warning`** keeps errors and warnings (drops info only); omit to keep all severities (JSON, verdict, and `ci_exit_code` use the filtered list) |
 | `--bug-hunt` | Enable exploratory / bug-hunt style heuristics in the review pipeline |
@@ -89,12 +89,13 @@ specfact code review run --scope changed --mode shadow --json --out /tmp/review-
 
 ### `--focus` facets (repeatable)
 
-Use **`--focus`** with **`source`**, **`tests`**, and/or **`docs`** (union of facets, then intersect with scope). Do not combine **`--focus`** with **`--include-tests`** or **`--exclude-tests`**.
+Use **`--focus`** with **`source`**, **`tests`**, **`docs`**, and/or **`simplify`** (union of facets, then intersect with scope). Do not combine **`--focus`** with **`--include-tests`** or **`--exclude-tests`**. The **`simplify`** facet produces simplification-focused reports: advisory **`ai_bloat`** findings plus high-confidence **`dry`** and **`kiss`** findings that carry deterministic metadata such as **`rewrite_hint`**, **`canonical_pattern`**, **`intent_key`**, **`estimated_deletion_lines`**, and **`related_locations`**. Simplification-focused findings are score-neutral and non-blocking.
 
 ```bash
 specfact code review run --scope changed --focus tests
 specfact code review run --scope full --path packages/specfact-code-review --focus source
 specfact code review run --scope full --focus docs
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review-simplify.json
 ```
 
 ### Positional files (explicit Python paths)
@@ -125,7 +126,7 @@ The built-in `specfact/ai-bloat-patterns` policy pack is parallel to `specfact/c
 Use `--focus simplify` when producing the IDE simplification queue:
 
 ```bash
-specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review-simplify.json
 ```
 
 Simplify-focused reports keep advisory `ai_bloat` findings plus high-confidence `dry` and `kiss` findings that include deterministic simplification metadata. Metadata fields such as `rewrite_hint`, `canonical_pattern`, `intent_key`, `estimated_deletion_lines`, and `related_locations` are additive; legacy consumers can keep reading the original finding fields. Simplification findings remain score-neutral and non-blocking.

--- a/docs/bundles/project/overview.md
+++ b/docs/bundles/project/overview.md
@@ -82,7 +82,7 @@ Brownfield **code import** (`specfact code import`, `specfact import …`) lives
 
 Plan and review flows may ship **prompts or templates** with the bundle. Treat them as **bundle payload**, not core CLI sources of truth. Refresh IDE-facing resources with `specfact init ide` after upgrades so editors receive the same artifacts the CLI expects.
 
-The project prompt set includes `/specfact.08-simplify`, which reads `.specfact/code-review.json`, filters `category=ai_bloat` findings from the Code Review bundle, and walks the user through accept/reject/skip/explain choices before applying any simplification edit.
+The project prompt set includes `/specfact.08-simplify`, which reads `.specfact/code-review.json`, groups `ai_bloat` and metadata-backed simplification findings by `intent_key`, file or domain, and rule, shows related locations, and walks the user through accept/reject/skip/explain choices before applying any simplification edit.
 
 ## Quick examples
 

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -395,11 +395,14 @@ specfact module init --scope project
 
 Then rerun the ledger command from the same repository checkout.
 
-## House rules skill
+## Code review skill
 
-The `specfact-code-review` bundle can derive a compact house-rules skill from the
-reward ledger and keep it small enough for AI session context injection. The
-default charter now encodes the clean-code principles directly:
+The `specfact-code-review` bundle ships a compact `SKILL.md` for Codex CLI,
+Claude, Vibe, and Cursor-compatible IDEs. Use it as the reusable alternative to
+copying prompt templates into every AI IDE: it carries the CLI-grounded review
+workflow, simplification queue guidance, self-healing `--help` behavior, and
+house rules derived from the reward ledger. The default charter encodes the
+clean-code principles directly:
 
 - Naming: use intention-revealing names instead of placeholders.
 - KISS: keep functions small, shallow, and narrow in parameters.
@@ -407,11 +410,14 @@ default charter now encodes the clean-code principles directly:
 - DRY: extract repeated function shapes once duplication appears.
 - SOLID: keep transport and persistence responsibilities separate.
 - TDD + contracts: keep test-first and icontract discipline in the baseline skill.
+- Simplification loop: use `--focus simplify` for advisory cleanup queues and
+  require explicit user approval before edits.
 
 ### Command flow
 
 ```bash
 specfact code review rules init
+specfact code review rules init --ide codex
 specfact code review rules show
 specfact code review rules update
 ```

--- a/openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md
@@ -1,0 +1,55 @@
+## Failing Before
+
+- Timestamp: 2026-05-21T22:48:51+02:00
+- Command: `hatch run pytest tests/unit/specfact_code_review/run/test_findings.py tests/unit/specfact_code_review/run/test_runner.py tests/unit/specfact_code_review/run/test_commands.py tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py tests/unit/specfact_code_review/tools/test_ast_clean_code_runner.py tests/unit/test_check_prompt_commands_script.py -q`
+- Result: failed as expected before production implementation.
+- Summary: 13 failed, 99 passed.
+- Failed coverage:
+  - `ReviewFinding` lacks optional simplification metadata fields.
+  - `ReviewReport` remains at schema version `1.0` when metadata-bearing findings are present.
+  - `run_review(..., focus="simplify")` is unsupported.
+  - CLI `--focus simplify` is rejected before scope resolution reaches the runner.
+  - Expanded AI-bloat simplification patterns are not detected.
+  - Duplicate-intent findings lack `intent_key` and `related_locations`.
+  - `/specfact.08-simplify` does not group by simplification metadata.
+
+## Passing After
+
+- Timestamp: 2026-05-21T23:31:55+02:00
+- Targeted tests:
+  - `hatch run pytest tests/unit/specfact_code_review/run/test_commands.py tests/unit/specfact_code_review/run/test_runner.py tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py tests/unit/specfact_code_review/run/test_findings.py tests/unit/docs/test_code_review_docs_parity.py -q`
+  - Result: 93 passed.
+- Prompt and skill/resource contract tests:
+  - `hatch run pytest tests/unit/specfact_code_review/rules/test_updater.py tests/unit/test_bundle_resource_payloads.py tests/unit/docs/test_code_review_docs_parity.py tests/unit/test_check_prompt_commands_script.py -q`
+  - Result: 53 passed, 2 warnings.
+  - `hatch run validate-prompt-commands`
+  - Result: passed.
+- OpenSpec and static gates:
+  - `openspec validate code-review-11-simplification-feedback-loop --strict`
+  - Result: valid.
+  - `hatch run format`
+  - Result: passed.
+  - `hatch run type-check`
+  - Result: 0 errors, 0 warnings, 0 notes.
+  - `hatch run lint`
+  - Result: passed; pylint rated 10.00/10.
+  - `hatch run yaml-lint`
+  - Result: validated 6 manifests and `registry/index.json`.
+  - `hatch run check-bundle-imports`
+  - Result: import boundary check passed.
+  - `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`
+  - Result: verified 6 module manifests.
+- Full test gates:
+  - `hatch run contract-test`
+  - Result: 709 passed, 2 warnings.
+  - `hatch run smart-test`
+  - Result: 709 passed, 2 warnings.
+  - `hatch run test`
+  - Result: 709 passed, 2 warnings.
+- SpecFact review:
+  - `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed`
+  - Result: exit code 0; report summary `Review completed with 6 findings (0 blocking).`
+  - Remaining advisory items:
+    - `ai-bloat.loc-vs-complexity` info on Typer `run` wrapper and `run_review`; no blocking score impact.
+    - Pylint style warnings for Typer command signature/local variables and a dataclass request carrier; these are framework/data-carrier shape findings and are non-blocking in the generated report.
+    - Targeted review coverage warning for `run/commands.py`; full `contract-test`, `smart-test`, and `test` gates passed.

--- a/openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md
@@ -62,3 +62,36 @@
   - Codex detection verification:
     `codex -C /tmp/specfact-skill-smoke-roots debug prompt-input "Use specfact-code-review"`
   - Result: prompt input listed `specfact-code-review: CLI-grounded SpecFact code review workflow and house rules for AI coding sessions` from `/tmp/specfact-skill-smoke-roots/.codex/skills/specfact-code-review/SKILL.md`.
+
+## Review Finding Follow-up
+
+- Timestamp: 2026-05-21T23:59:29+02:00
+- Failing-before evidence:
+  - `hatch run pytest tests/unit/specfact_code_review/run/test_findings.py tests/unit/specfact_code_review/run/test_scorer.py tests/unit/specfact_code_review/run/test_runner.py -q`
+  - Result: 7 failed, 60 passed before production edits.
+  - Failed coverage: deterministic simplification metadata helper missing, partial metadata admitted to simplify queue, `dry` simplification findings score-neutral outside simplify focus, and invalid `run_review` override kwargs accepted.
+- Passing-after evidence:
+  - `hatch run pytest tests/unit/specfact_code_review/run/test_findings.py tests/unit/specfact_code_review/run/test_scorer.py tests/unit/specfact_code_review/run/test_runner.py tests/unit/specfact_code_review/review/test_commands.py tests/unit/docs/test_code_review_docs_parity.py tests/unit/test_check_prompt_commands_script.py -q`
+  - Result: 94 passed.
+  - `hatch run pytest tests/unit/specfact_code_review/review/test_commands.py --cov=specfact_code_review.review.commands --cov-report=term-missing -q`
+  - Result: 11 passed; command wrapper coverage 95.60%.
+- Validation:
+  - `openspec validate code-review-11-simplification-feedback-loop --strict`
+  - Result: valid.
+  - `hatch run validate-prompt-commands`
+  - Result: passed.
+  - `hatch run format`
+  - Result: passed.
+  - `hatch run type-check`
+  - Result: 0 errors, 0 warnings, 0 notes.
+  - `hatch run lint`
+  - Result: passed; pylint rated 10.00/10.
+  - `hatch run yaml-lint`
+  - Result: validated 6 manifests and `registry/index.json`.
+  - `hatch run check-bundle-imports`
+  - Result: import boundary check passed.
+  - `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`
+  - Result: verified 6 module manifests.
+  - `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed`
+  - Result: exit code 0; report summary `Review completed with 4 findings (0 blocking).`
+  - Remaining non-blocking findings are existing Typer command wrapper shape advisories (`R0917`, `R0914`) and score-neutral `ai-bloat.loc-vs-complexity` hints for command orchestration wrappers; no pasted review finding remains unresolved.

--- a/openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md
@@ -53,3 +53,12 @@
     - `ai-bloat.loc-vs-complexity` info on Typer `run` wrapper and `run_review`; no blocking score impact.
     - Pylint style warnings for Typer command signature/local variables and a dataclass request carrier; these are framework/data-carrier shape findings and are non-blocking in the generated report.
     - Targeted review coverage warning for `run/commands.py`; full `contract-test`, `smart-test`, and `test` gates passed.
+- Real-world Codex skill smoke:
+  - Initial smoke without a local module root installed stale v1 skill content because the CLI resolved the existing user-scoped module at `~/.specfact/modules/specfact-code-review` first.
+  - Command under test with local module source:
+    `SPECFACT_MODULES_ROOTS=/home/dom/git/nold-ai/specfact-cli-modules-worktrees/feature/code-review-11-simplification-feedback-loop/packages SPECFACT_ALLOW_UNSIGNED=1 python -m specfact_cli.cli code review rules init --ide codex`
+  - Result: created `skills/specfact-code-review/SKILL.md` and installed `.codex/skills/specfact-code-review/SKILL.md` in `/tmp/specfact-skill-smoke-roots`.
+  - Content verification: installed skill contains `Updated: 2026-05-21`, `Codex CLI`, `specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json`, and `Don't copy prompt templates`.
+  - Codex detection verification:
+    `codex -C /tmp/specfact-skill-smoke-roots debug prompt-input "Use specfact-code-review"`
+  - Result: prompt input listed `specfact-code-review: CLI-grounded SpecFact code review workflow and house rules for AI coding sessions` from `/tmp/specfact-skill-smoke-roots/.codex/skills/specfact-code-review/SKILL.md`.

--- a/openspec/changes/code-review-11-simplification-feedback-loop/tasks.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/tasks.md
@@ -51,4 +51,4 @@
 - [x] 7.2 Run `openspec validate code-review-11-simplification-feedback-loop --strict`.
 - [x] 7.3 Run required gates in order: `hatch run format`, `hatch run type-check`, `hatch run lint`, `hatch run yaml-lint`, `hatch run check-bundle-imports`, `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`, `hatch run contract-test`, relevant `hatch run smart-test`, and relevant `hatch run test`.
 - [x] 7.4 Run `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed`, fix all findings or document approved exceptions, and rerun until passing.
-- [ ] 7.5 Commit, push, and open or update the PR to `dev` after verification is green.
+- [x] 7.5 Commit, push, and open or update the PR to `dev` after verification is green.

--- a/openspec/changes/code-review-11-simplification-feedback-loop/tasks.md
+++ b/openspec/changes/code-review-11-simplification-feedback-loop/tasks.md
@@ -1,54 +1,54 @@
 ## 1. GitHub readiness and change setup
 
-- [ ] 1.1 Verify issue [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) is linked under parent Feature [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275), which is linked under Epic [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162).
-- [ ] 1.2 Add [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275) and [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) to the `SpecFact CLI` project board once a token with project scope is available.
-- [ ] 1.3 Confirm labels are complete: parent Feature has `enhancement`, `codebase`, `openspec`, `Feature`; change issue has `enhancement`, `codebase`, `openspec`, `change-proposal`.
-- [ ] 1.4 Confirm [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) is not already `in progress` before implementation begins, and record any blocker or blocked-by relationship updates in the issue body.
-- [ ] 1.5 Keep `openspec/CHANGE_ORDER.md` aligned with the new change under "Code review and sidecar validation improvements" as order 04, blocked by [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269).
-- [ ] 1.6 Validate the OpenSpec change with `openspec validate code-review-11-simplification-feedback-loop --strict` before implementation begins.
+- [x] 1.1 Verify issue [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) is linked under parent Feature [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275), which is linked under Epic [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162).
+- [x] 1.2 Add [#275](https://github.com/nold-ai/specfact-cli-modules/issues/275) and [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) to the `SpecFact CLI` project board once a token with project scope is available.
+- [x] 1.3 Confirm labels are complete: parent Feature has `enhancement`, `codebase`, `openspec`, `Feature`; change issue has `enhancement`, `codebase`, `openspec`, `change-proposal`.
+- [x] 1.4 Confirm [#276](https://github.com/nold-ai/specfact-cli-modules/issues/276) is not already `in progress` before implementation begins, and record any blocker or blocked-by relationship updates in the issue body.
+- [x] 1.5 Keep `openspec/CHANGE_ORDER.md` aligned with the new change under "Code review and sidecar validation improvements" as order 04, blocked by [#269](https://github.com/nold-ai/specfact-cli-modules/issues/269).
+- [x] 1.6 Validate the OpenSpec change with `openspec validate code-review-11-simplification-feedback-loop --strict` before implementation begins.
 
 ## 2. Spec-first failing tests
 
-- [ ] 2.1 Add failing model tests proving `ReviewFinding` accepts optional simplification metadata and legacy finding payloads remain valid.
-- [ ] 2.2 Add failing runner tests proving `--focus simplify` retains only simplification-queue findings after existing scope resolution.
-- [ ] 2.3 Add failing analyzer tests for new deterministic overengineering patterns: accumulator loops, verbose boolean returns, redundant `None` branches, wrapper chains, pass-through defensive `try/except`, one-use temporaries, table-lookup candidates, and stdlib replacement candidates.
-- [ ] 2.4 Add failing duplicate-intent tests with same-domain functions that differ in local names but share normalized shape, call roots, and domain vocabulary.
-- [ ] 2.5 Add negative fixtures proving similar names alone, intentional compatibility wrappers, and ambiguous domain matches do not emit simplification findings.
-- [ ] 2.6 Add prompt contract tests proving `/specfact.08-simplify` groups by `intent_key`, shows related locations, and still requires accept/reject/skip/explain before edits.
-- [ ] 2.7 Record failing-before commands and output in `openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md`.
+- [x] 2.1 Add failing model tests proving `ReviewFinding` accepts optional simplification metadata and legacy finding payloads remain valid.
+- [x] 2.2 Add failing runner tests proving `--focus simplify` retains only simplification-queue findings after existing scope resolution.
+- [x] 2.3 Add failing analyzer tests for new deterministic overengineering patterns: accumulator loops, verbose boolean returns, redundant `None` branches, wrapper chains, pass-through defensive `try/except`, one-use temporaries, table-lookup candidates, and stdlib replacement candidates.
+- [x] 2.4 Add failing duplicate-intent tests with same-domain functions that differ in local names but share normalized shape, call roots, and domain vocabulary.
+- [x] 2.5 Add negative fixtures proving similar names alone, intentional compatibility wrappers, and ambiguous domain matches do not emit simplification findings.
+- [x] 2.6 Add prompt contract tests proving `/specfact.08-simplify` groups by `intent_key`, shows related locations, and still requires accept/reject/skip/explain before edits.
+- [x] 2.7 Record failing-before commands and output in `openspec/changes/code-review-11-simplification-feedback-loop/TDD_EVIDENCE.md`.
 
 ## 3. Review model and report metadata
 
-- [ ] 3.1 Extend the review finding model with optional simplification metadata fields: `confidence`, `rewrite_hint`, `canonical_pattern`, `intent_key`, `estimated_deletion_lines`, and `related_locations`.
-- [ ] 3.2 Bump emitted review report schema version to `1.1` when simplification metadata is present while preserving default compatibility for legacy reports.
-- [ ] 3.3 Ensure simplification metadata does not affect `is_blocking`, governed score, or existing severity validation.
-- [ ] 3.4 Add serialization examples or fixture reports covering both legacy and metadata-bearing findings.
+- [x] 3.1 Extend the review finding model with optional simplification metadata fields: `confidence`, `rewrite_hint`, `canonical_pattern`, `intent_key`, `estimated_deletion_lines`, and `related_locations`.
+- [x] 3.2 Bump emitted review report schema version to `1.1` when simplification metadata is present while preserving default compatibility for legacy reports.
+- [x] 3.3 Ensure simplification metadata does not affect `is_blocking`, governed score, or existing severity validation.
+- [x] 3.4 Add serialization examples or fixture reports covering both legacy and metadata-bearing findings.
 
 ## 4. Deterministic simplification analyzers
 
-- [ ] 4.1 Implement static analyzer helpers for the expanded overengineering patterns in `packages/specfact-code-review`.
-- [ ] 4.2 Implement duplicate-intent grouping from normalized AST shape, call roots, import/API evidence, path-domain tokens, and business vocabulary.
-- [ ] 4.3 Emit stable `intent_key` and `related_locations` only when multiple deterministic signals agree.
-- [ ] 4.4 Add confidence and estimated deletion calculations with conservative defaults suitable for advisory triage.
-- [ ] 4.5 Keep all new simplification findings advisory and score-neutral.
+- [x] 4.1 Implement static analyzer helpers for the expanded overengineering patterns in `packages/specfact-code-review`.
+- [x] 4.2 Implement duplicate-intent grouping from normalized AST shape, call roots, import/API evidence, path-domain tokens, and business vocabulary.
+- [x] 4.3 Emit stable `intent_key` and `related_locations` only when multiple deterministic signals agree.
+- [x] 4.4 Add confidence and estimated deletion calculations with conservative defaults suitable for advisory triage.
+- [x] 4.5 Keep all new simplification findings advisory and score-neutral.
 
 ## 5. Review command and prompt integration
 
-- [ ] 5.1 Extend `specfact code review run --focus` to accept `simplify` and apply it after normal file-scope resolution.
-- [ ] 5.2 Update `/specfact.08-simplify` to group candidates by `intent_key`, then file/domain and rule, and to show related locations before drafting rewrites.
-- [ ] 5.3 Preserve the prompt's explicit per-change confirmation loop and prohibit autonomous batch edits.
-- [ ] 5.4 Run prompt validation with `hatch run validate-prompt-commands` if prompt command examples or resources change.
+- [x] 5.1 Extend `specfact code review run --focus` to accept `simplify` and apply it after normal file-scope resolution.
+- [x] 5.2 Update `/specfact.08-simplify` to group candidates by `intent_key`, then file/domain and rule, and to show related locations before drafting rewrites.
+- [x] 5.3 Preserve the prompt's explicit per-change confirmation loop and prohibit autonomous batch edits.
+- [x] 5.4 Run prompt validation with `hatch run validate-prompt-commands` if prompt command examples or resources change.
 
 ## 6. Docs, packaging, and signatures
 
-- [ ] 6.1 Update code-review documentation to explain simplification metadata, `--focus simplify`, duplicate-intent grouping, and advisory-only behavior.
-- [ ] 6.2 Bump affected `module-package.yaml` versions when packaged code, policy resources, or prompt resources change.
-- [ ] 6.3 Re-sign affected module manifests and update registry/signature artifacts as required by the modules repo signing policy.
+- [x] 6.1 Update code-review documentation to explain simplification metadata, `--focus simplify`, duplicate-intent grouping, and advisory-only behavior.
+- [x] 6.2 Bump affected `module-package.yaml` versions when packaged code, policy resources, or prompt resources change.
+- [x] 6.3 Re-sign affected module manifests and update registry/signature artifacts as required by the modules repo signing policy.
 
 ## 7. Passing evidence and quality gates
 
-- [ ] 7.1 Re-run all targeted tests from section 2 and record passing evidence in `TDD_EVIDENCE.md`.
-- [ ] 7.2 Run `openspec validate code-review-11-simplification-feedback-loop --strict`.
-- [ ] 7.3 Run required gates in order: `hatch run format`, `hatch run type-check`, `hatch run lint`, `hatch run yaml-lint`, `hatch run check-bundle-imports`, `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`, `hatch run contract-test`, relevant `hatch run smart-test`, and relevant `hatch run test`.
-- [ ] 7.4 Run `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed`, fix all findings or document approved exceptions, and rerun until passing.
+- [x] 7.1 Re-run all targeted tests from section 2 and record passing evidence in `TDD_EVIDENCE.md`.
+- [x] 7.2 Run `openspec validate code-review-11-simplification-feedback-loop --strict`.
+- [x] 7.3 Run required gates in order: `hatch run format`, `hatch run type-check`, `hatch run lint`, `hatch run yaml-lint`, `hatch run check-bundle-imports`, `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump`, `hatch run contract-test`, relevant `hatch run smart-test`, and relevant `hatch run test`.
+- [x] 7.4 Run `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed`, fix all findings or document approved exceptions, and rerun until passing.
 - [ ] 7.5 Commit, push, and open or update the PR to `dev` after verification is green.

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.17
+version: 0.47.18
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:c0c00319931d563eadafd48d721c3b351dd8de2e71d1aa5f8de9763a474c77ae
-  signature: qE/KIUiOh4upxpK+Cs7LNCrcM0cILOByMHSs+Qb47TJyF8MyTwzEgUtj4J1DuI3B7L6e/05k0gufk2JpRzXkCw==
+  checksum: sha256:7d664a7e117bb73a49d5cfec5ffd20a99fc0e1a2f27651188d8a8c69bfc38f21

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:7d664a7e117bb73a49d5cfec5ffd20a99fc0e1a2f27651188d8a8c69bfc38f21
-  signature: caibanlCKy0NX93qfI66M7RLgoAeg1JKDBmxzOtptjwQq7VrSDeT1avHBjLol7clTVje4B3DzFO/iGJceo1gCg==
+  checksum: sha256:1de363f9286112d5676eee830583c96e5522d40b3c0f4226480fd38b48d0ca92

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:1de363f9286112d5676eee830583c96e5522d40b3c0f4226480fd38b48d0ca92
+  signature: tyq1NGOvWkilYyKuJkQpq/65eRnRsNXmpzgMqwyrNoxNagvk4tYgMAzl1oc1a6757qzG6B+TxPLBj93xM3/XAQ==

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:7d664a7e117bb73a49d5cfec5ffd20a99fc0e1a2f27651188d8a8c69bfc38f21
+  signature: caibanlCKy0NX93qfI66M7RLgoAeg1JKDBmxzOtptjwQq7VrSDeT1avHBjLol7clTVje4B3DzFO/iGJceo1gCg==

--- a/packages/specfact-code-review/src/specfact_code_review/resources/skills/specfact-code-review/SKILL.md
+++ b/packages/specfact-code-review/src/specfact_code_review/resources/skills/specfact-code-review/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: specfact-code-review
-description: House rules for AI coding sessions derived from review findings
+description: CLI-grounded SpecFact code review workflow and house rules for AI coding sessions
 allowed-tools: []
 ---
 
-# House Rules - AI Coding Context (v1)
+# House Rules - AI Coding Context / SpecFact Code Review Skill (v2)
 
-Updated: 2026-03-30 | Module: nold-ai/specfact-code-review
+Updated: 2026-05-21 | Module: nold-ai/specfact-code-review
 
 ## DO
 
+- Use this skill when asked to run, interpret, or act on SpecFact code review in Codex CLI or another AI IDE
+- Treat `specfact code review run --help` as authoritative; self-heal stale options by checking help before changing workflow
+- For simplification queues, run `specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json`
+- For merge-quality review, run `specfact code review run --scope changed --bug-hunt --json --out .specfact/code-review.json`
 - Ask whether tests should be included before repo-wide review; default to excluding tests unless test changes are the target
 - Use intention-revealing names; avoid placeholder public names like data/process/handle
 - Keep functions under 120 LOC, shallow nesting, and <= 5 parameters (KISS)
@@ -19,17 +23,17 @@ Updated: 2026-03-30 | Module: nold-ai/specfact-code-review
 - Add @require/@ensure (icontract) + @beartype to all new public APIs
 - Run hatch run contract-test-contracts before any commit
 - Write the test file BEFORE the feature file (TDD-first)
-- Return typed values from all public methods and guard chained attribute access
 
 ## DON'T
 
+- Don't copy prompt templates into AI IDEs when this installed skill can carry the reusable workflow guidance
+- Don't treat simplification findings as AI-authorship proof or apply batch rewrites without explicit user approval
 - Don't enable known noisy findings unless you explicitly want strict/full review output
 - Don't use bare except: or except Exception: pass
 - Don't add # noqa / # type: ignore without inline justification
 - Don't mix read + write in the same method or call `repository.*` and `http_client.*` together
 - Don't import at module level if it triggers network calls
 - Don't hardcode secrets; use env vars via pydantic.BaseSettings
-- Don't create functions that exceed the KISS thresholds without a documented reason
 
 ## TOP VIOLATIONS (auto-updated by specfact code review rules update)
 

--- a/packages/specfact-code-review/src/specfact_code_review/review/commands.py
+++ b/packages/specfact-code-review/src/specfact_code_review/review/commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -23,6 +24,17 @@ from specfact_code_review.run.commands import (
 
 app = typer.Typer(help="Code command extensions for structured review workflows.", no_args_is_help=True)
 review_app = typer.Typer(help="Governed code review workflows.", no_args_is_help=True)
+
+
+@dataclass(frozen=True)
+class _ReviewRunCliInputs:
+    files: list[Path] | None
+    include_tests: bool | None
+    exclude_tests: bool | None
+    focus: list[str] | None
+    include_noise: bool
+    suppress_noise: bool
+    interactive: bool
 
 
 def _friendly_run_command_error(exc: RunCommandError | ValueError | ViolationError) -> str:
@@ -49,38 +61,32 @@ def _resolve_include_tests(*, files: list[Path], include_tests: bool | None, int
     return typer.confirm("Include changed and untracked test files in this review?", default=False)
 
 
-def _resolve_review_run_flags(
-    *,
-    files: list[Path] | None,
-    include_tests: bool | None,
-    exclude_tests: bool | None,
-    focus: list[str] | None,
-    include_noise: bool,
-    suppress_noise: bool,
-    interactive: bool,
-) -> tuple[list[str], bool, bool]:
-    if include_tests is not None and exclude_tests is not None:
+def _validate_focus_flags(inputs: _ReviewRunCliInputs) -> list[str]:
+    if inputs.include_tests is not None and inputs.exclude_tests is not None:
         raise typer.BadParameter("Cannot use both --include-tests and --exclude-tests")
 
-    focus_list = list(focus) if focus else []
+    focus_list = list(inputs.focus) if inputs.focus else []
     if focus_list:
-        if include_tests is not None or exclude_tests is not None:
+        if inputs.include_tests is not None or inputs.exclude_tests is not None:
             raise typer.BadParameter("Cannot combine --focus with --include-tests or --exclude-tests")
-        unknown = [facet for facet in focus_list if facet not in {"source", "tests", "docs"}]
+        unknown = [facet for facet in focus_list if facet not in {"source", "tests", "docs", "simplify"}]
         if unknown:
-            raise typer.BadParameter(f"Invalid --focus value(s): {unknown!r}; use source, tests, or docs.")
-        resolved_include_tests = "tests" in focus_list
-    else:
-        resolved_include_tests = _resolve_include_tests(
-            files=files or [],
-            include_tests=include_tests,
-            interactive=interactive,
-        )
-        if exclude_tests is True:
-            resolved_include_tests = False
+            raise typer.BadParameter(f"Invalid --focus value(s): {unknown!r}; use source, tests, docs, or simplify.")
+    return focus_list
 
-    resolved_include_noise = include_noise and not suppress_noise
-    return focus_list, resolved_include_tests, resolved_include_noise
+
+def _resolve_review_run_flags(inputs: _ReviewRunCliInputs) -> tuple[list[str], bool, bool]:
+    focus_list = _validate_focus_flags(inputs)
+    if focus_list:
+        return focus_list, "tests" in focus_list, inputs.include_noise and not inputs.suppress_noise
+    resolved_include_tests = _resolve_include_tests(
+        files=inputs.files or [],
+        include_tests=inputs.include_tests,
+        interactive=inputs.interactive,
+    )
+    if inputs.exclude_tests is True:
+        resolved_include_tests = False
+    return focus_list, resolved_include_tests, inputs.include_noise and not inputs.suppress_noise
 
 
 @review_app.command("run")
@@ -107,14 +113,17 @@ def run(
     interactive: bool = typer.Option(False, "--interactive"),
 ) -> None:
     """Run the full code review workflow."""
+    _ = ctx.resilient_parsing
     focus_list, resolved_include_tests, resolved_include_noise = _resolve_review_run_flags(
-        files=files,
-        include_tests=include_tests,
-        exclude_tests=exclude_tests,
-        focus=focus,
-        include_noise=include_noise,
-        suppress_noise=suppress_noise,
-        interactive=interactive,
+        _ReviewRunCliInputs(
+            files=files,
+            include_tests=include_tests,
+            exclude_tests=exclude_tests,
+            focus=focus,
+            include_noise=include_noise,
+            suppress_noise=suppress_noise,
+            interactive=interactive,
+        )
     )
 
     try:

--- a/packages/specfact-code-review/src/specfact_code_review/review/commands.py
+++ b/packages/specfact-code-review/src/specfact_code_review/review/commands.py
@@ -99,7 +99,11 @@ def run(
     path: list[Path] = typer.Option(None, "--path"),
     include_tests: bool | None = typer.Option(None, "--include-tests"),
     exclude_tests: bool | None = typer.Option(None, "--exclude-tests"),
-    focus: list[str] | None = typer.Option(None, "--focus", help="Limit to source, tests, and/or docs (repeatable)."),
+    focus: list[str] | None = typer.Option(
+        None,
+        "--focus",
+        help="Limit to source, tests, docs, and/or simplify (repeatable).",
+    ),
     mode: Literal["shadow", "enforce"] = typer.Option("enforce", "--mode"),
     level: Literal["error", "warning"] | None = typer.Option(None, "--level"),
     bug_hunt: bool = typer.Option(False, "--bug-hunt"),

--- a/packages/specfact-code-review/src/specfact_code_review/rules/updater.py
+++ b/packages/specfact-code-review/src/specfact_code_review/rules/updater.py
@@ -27,9 +27,17 @@ TITLE_PREFIX = "# House Rules - AI Coding Context"
 MODULE_LABEL = "nold-ai/specfact-code-review"
 TOP_VIOLATIONS_HEADER = "## TOP VIOLATIONS (auto-updated by specfact code review rules update)"
 TOP_VIOLATIONS_MARKER = "<!-- auto-managed: do not edit manually -->"
-DEFAULT_DESCRIPTION = "House rules for AI coding sessions derived from review findings"
+DEFAULT_DESCRIPTION = "CLI-grounded SpecFact code review workflow and house rules for AI coding sessions"
 DEFAULT_DO_RULES = (
-    "- Verify an active OpenSpec change covers the requested scope and follow the sequence: spec delta → failing tests → implementation → passing tests → quality gates",
+    "- Use this skill when asked to run, interpret, or act on SpecFact code review in Codex CLI or another AI IDE",
+    "- Treat `specfact code review run --help` as authoritative; self-heal stale options by checking help "
+    "before changing workflow",
+    "- For simplification queues, run `specfact code review run --scope changed --focus simplify --json "
+    "--out .specfact/code-review.json`",
+    "- For merge-quality review, run `specfact code review run --scope changed --bug-hunt --json "
+    "--out .specfact/code-review.json`",
+    "- Verify an active OpenSpec change covers the requested scope and follow the sequence: spec delta "
+    "→ failing tests → implementation → passing tests → quality gates",
     "- Ask whether tests should be included before repo-wide review; "
     "default to excluding tests unless test changes are the target",
     "- Use intention-revealing names; avoid placeholder public names like data/process/handle",
@@ -40,16 +48,17 @@ DEFAULT_DO_RULES = (
     "- Add @require/@ensure (icontract) + @beartype to all new public APIs",
     "- Run hatch run contract-test-contracts before any commit",
     "- Write the test file BEFORE the feature file (TDD-first)",
-    "- Return typed values from all public methods and guard chained attribute access",
 )
 DEFAULT_DONT_RULES = (
+    "- Don't copy prompt templates into AI IDEs when this installed skill can carry the reusable workflow guidance",
+    "- Don't treat simplification findings as AI-authorship proof or apply batch rewrites without explicit "
+    "user approval",
     "- Don't enable known noisy findings unless you explicitly want strict/full review output",
     "- Don't use bare except: or except Exception: pass",
     "- Don't add # noqa / # type: ignore without inline justification",
     "- Don't mix read + write in the same method or call `repository.*` and `http_client.*` together",
     "- Don't import at module level if it triggers network calls",
     "- Don't hardcode secrets; use env vars via pydantic.BaseSettings",
-    "- Don't create functions that exceed the KISS thresholds without a documented reason",
 )
 
 

--- a/packages/specfact-code-review/src/specfact_code_review/run/commands.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/commands.py
@@ -16,7 +16,7 @@ from rich.console import Console
 from rich.table import Table
 
 from specfact_code_review.run.findings import ReviewFinding, ReviewReport
-from specfact_code_review.run.runner import run_review
+from specfact_code_review.run.runner import ReviewFocus, run_review
 
 
 console = Console()
@@ -66,6 +66,7 @@ class ReviewRunRequest:
     review_mode: ReviewRunMode = "enforce"
     review_level: ReviewLevelFilter | None = None
     focus_facets: tuple[str, ...] = ()
+    review_focus: ReviewFocus | None = None
 
 
 @dataclass(frozen=True)
@@ -77,19 +78,17 @@ class _ReviewLoopFlags:
     bug_hunt: bool
     review_mode: ReviewRunMode
     review_level: ReviewLevelFilter | None
+    review_focus: ReviewFocus | None
 
 
 def _is_test_file(file_path: Path) -> bool:
     return "tests" in file_path.parts
 
 
-def _is_docs_tree_file(file_path: Path) -> bool:
-    return "docs" in file_path.parts
-
-
 def _filter_files_by_focus(files: list[Path], facets: tuple[str, ...]) -> list[Path]:
     """Restrict files to the union of facet selections (Python files only)."""
-    if not facets:
+    file_facets = tuple(facet for facet in facets if facet in {"source", "tests", "docs"})
+    if not file_facets:
         return files
 
     def _matches_focus(file_path: Path, facet: str) -> bool:
@@ -98,12 +97,12 @@ def _filter_files_by_focus(files: list[Path], facets: tuple[str, ...]) -> list[P
         if facet == "tests":
             return _is_test_file(file_path)
         if facet == "docs":
-            return _is_docs_tree_file(file_path)
+            return "docs" in file_path.parts
         if facet == "source":
-            return not _is_test_file(file_path) and not _is_docs_tree_file(file_path)
+            return not _is_test_file(file_path) and "docs" not in file_path.parts
         return False
 
-    return [file_path for file_path in files if any(_matches_focus(file_path, f) for f in facets)]
+    return [file_path for file_path in files if any(_matches_focus(file_path, f) for f in file_facets)]
 
 
 def _is_ignored_review_path(file_path: Path) -> bool:
@@ -337,24 +336,10 @@ def _is_interactive_terminal() -> bool:
 
 def _run_review_with_progress(
     files: list[Path],
-    *,
-    no_tests: bool,
-    include_noise: bool,
-    fix: bool,
-    bug_hunt: bool,
-    review_mode: ReviewRunMode,
-    review_level: ReviewLevelFilter | None,
+    flags: _ReviewLoopFlags,
 ) -> ReviewReport:
     if _is_interactive_terminal():
-        return _run_review_with_status(
-            files,
-            no_tests=no_tests,
-            include_noise=include_noise,
-            fix=fix,
-            bug_hunt=bug_hunt,
-            review_mode=review_mode,
-            review_level=review_level,
-        )
+        return _run_review_with_status(files, flags)
 
     def _emit_progress(description: str) -> None:
         progress_console.print(f"[dim]{description}[/dim]")
@@ -362,39 +347,35 @@ def _run_review_with_progress(
     return _run_review_once(
         files,
         _ReviewLoopFlags(
-            no_tests=no_tests,
-            include_noise=include_noise,
-            fix=fix,
+            no_tests=flags.no_tests,
+            include_noise=flags.include_noise,
+            fix=flags.fix,
             progress_callback=_emit_progress,
-            bug_hunt=bug_hunt,
-            review_mode=review_mode,
-            review_level=review_level,
+            bug_hunt=flags.bug_hunt,
+            review_mode=flags.review_mode,
+            review_level=flags.review_level,
+            review_focus=flags.review_focus,
         ),
     )
 
 
 def _run_review_with_status(
     files: list[Path],
-    *,
-    no_tests: bool,
-    include_noise: bool,
-    fix: bool,
-    bug_hunt: bool,
-    review_mode: ReviewRunMode,
-    review_level: ReviewLevelFilter | None,
+    flags: _ReviewLoopFlags,
 ) -> ReviewReport:
     with progress_console.status("Preparing code review...") as status:
         base = _ReviewLoopFlags(
-            no_tests=no_tests,
-            include_noise=include_noise,
+            no_tests=flags.no_tests,
+            include_noise=flags.include_noise,
             fix=False,
             progress_callback=status.update,
-            bug_hunt=bug_hunt,
-            review_mode=review_mode,
-            review_level=review_level,
+            bug_hunt=flags.bug_hunt,
+            review_mode=flags.review_mode,
+            review_level=flags.review_level,
+            review_focus=flags.review_focus,
         )
         report = _run_review_once(files, base)
-        if fix:
+        if flags.fix:
             status.update("Applying Ruff autofixes...")
             _apply_fixes(files)
             status.update("Re-running review after autofixes...")
@@ -411,6 +392,7 @@ def _run_review_once(files: list[Path], flags: _ReviewLoopFlags) -> ReviewReport
         bug_hunt=flags.bug_hunt,
         review_mode=flags.review_mode,
         review_level=flags.review_level,
+        focus=flags.review_focus,
     )
     if flags.fix:
         if flags.progress_callback is not None:
@@ -430,6 +412,7 @@ def _run_review_once(files: list[Path], flags: _ReviewLoopFlags) -> ReviewReport
             bug_hunt=flags.bug_hunt,
             review_mode=flags.review_mode,
             review_level=flags.review_level,
+            focus=flags.review_focus,
         )
     return report
 
@@ -479,10 +462,14 @@ def _as_focus_facets(value: object) -> tuple[str, ...]:
         return ()
     if isinstance(value, (list, tuple)) and all(isinstance(item, str) for item in value):
         for item in value:
-            if item not in ("source", "tests", "docs"):
+            if item not in ("source", "tests", "docs", "simplify"):
                 raise RunCommandError(f"Invalid focus facet: {item!r}")
         return tuple(value)
     raise RunCommandError("focus facets must be a list or tuple of strings")
+
+
+def _review_focus_from_facets(facets: tuple[str, ...]) -> ReviewFocus | None:
+    return "simplify" if "simplify" in facets else None
 
 
 def _build_review_run_request(
@@ -548,6 +535,7 @@ def _build_review_run_request(
         review_mode=_as_review_mode(request_kwargs.pop("review_mode", "enforce")),
         review_level=_as_review_level(request_kwargs.pop("review_level", None)),
         focus_facets=focus_facets,
+        review_focus=_review_focus_from_facets(focus_facets),
     )
 
     # Reject any unexpected keyword arguments
@@ -599,7 +587,8 @@ def run_command(
     )
     _validate_review_request(request)
 
-    include_for_resolve = request.include_tests or bool(request.focus_facets)
+    file_focus_facets = tuple(facet for facet in request.focus_facets if facet in {"source", "tests", "docs"})
+    include_for_resolve = request.include_tests or bool(file_focus_facets)
     resolved_files = _resolve_files(
         request.files,
         include_tests=include_for_resolve,
@@ -616,12 +605,16 @@ def run_command(
 
     report = _run_review_with_progress(
         resolved_files,
-        no_tests=request.no_tests,
-        include_noise=request.include_noise,
-        fix=request.fix,
-        bug_hunt=request.bug_hunt,
-        review_mode=request.review_mode,
-        review_level=request.review_level,
+        _ReviewLoopFlags(
+            no_tests=request.no_tests,
+            include_noise=request.include_noise,
+            fix=request.fix,
+            progress_callback=None,
+            bug_hunt=request.bug_hunt,
+            review_mode=request.review_mode,
+            review_level=request.review_level,
+            review_focus=request.review_focus,
+        ),
     )
     return _render_review_result(report, request)
 

--- a/packages/specfact-code-review/src/specfact_code_review/run/findings.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/findings.py
@@ -136,6 +136,19 @@ class ReviewFinding(BaseModel):
         )
 
     @beartype
+    @ensure(lambda result: isinstance(result, bool))
+    def simplification_metadata_is_deterministic(self) -> bool:
+        """Return whether simplification metadata is concrete enough for queued rewrites."""
+        return all(
+            value is not None
+            for value in (
+                self.rewrite_hint,
+                self.canonical_pattern,
+                self.intent_key,
+            )
+        )
+
+    @beartype
     @ensure(lambda self, result: result == (self.severity == "error" and not self.fixable))
     def is_blocking(self) -> bool:
         """Return whether this finding blocks a passing review verdict."""

--- a/packages/specfact-code-review/src/specfact_code_review/run/findings.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/findings.py
@@ -95,13 +95,45 @@ class ReviewFinding(BaseModel):
         default=None,
         description="Optional supplemental references with stable file paths, line ranges, or artifact identifiers.",
     )
+    confidence: Literal["low", "medium", "high"] | None = Field(
+        default=None,
+        description="Optional deterministic simplification confidence bucket.",
+    )
+    rewrite_hint: str | None = Field(default=None, description="Optional concise simplification guidance.")
+    canonical_pattern: str | None = Field(default=None, description="Optional normalized simplification pattern label.")
+    intent_key: str | None = Field(default=None, description="Optional stable duplicate-intent grouping key.")
+    estimated_deletion_lines: int | None = Field(
+        default=None,
+        ge=0,
+        description="Optional non-binding deletion estimate for simplification triage.",
+    )
+    related_locations: list[EvidenceRef] | None = Field(
+        default=None,
+        description="Optional related source locations for grouped simplification candidates.",
+    )
 
-    @field_validator("tool", "rule", "file", "message")
+    @field_validator("tool", "rule", "file", "message", "rewrite_hint", "canonical_pattern", "intent_key")
     @classmethod
-    def _validate_non_empty_text(cls, value: str) -> str:
-        if not value.strip():
+    def _validate_non_empty_text(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
             raise ValueError("value must not be empty")
         return value
+
+    @beartype
+    @ensure(lambda result: isinstance(result, bool))
+    def has_simplification_metadata(self) -> bool:
+        """Return whether this finding carries additive simplification metadata."""
+        return any(
+            value is not None
+            for value in (
+                self.confidence,
+                self.rewrite_hint,
+                self.canonical_pattern,
+                self.intent_key,
+                self.estimated_deletion_lines,
+                self.related_locations,
+            )
+        )
 
     @beartype
     @ensure(lambda self, result: result == (self.severity == "error" and not self.fixable))
@@ -143,6 +175,8 @@ class ReviewReport(BaseModel):
 
     @model_validator(mode="after")
     def _derive_governance_fields(self) -> ReviewReport:
+        if any(finding.has_simplification_metadata() for finding in self.findings):
+            self.schema_version = "1.1"
         blocking_error_present = any(finding.is_blocking() for finding in self.findings)
         self.reward_delta = self.score - 80
         if blocking_error_present:

--- a/packages/specfact-code-review/src/specfact_code_review/run/runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/runner.py
@@ -10,9 +10,10 @@ import sys
 import tempfile
 from collections.abc import Callable, Iterable
 from contextlib import suppress
+from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 from uuid import uuid4
 
 from beartype import beartype
@@ -45,6 +46,7 @@ _TEST_NOISE_RULES = {
 _GLOBAL_NOISE_RULES = {
     ("pylint", "R0801"),
 }
+_PYLINT_CLI_WRAPPER_NOISE_RULES = {"R0914", "R0917"}
 _NOISE_MESSAGE_PREFIXES = ("ValidationError: 1 validation error for LedgerState",)
 _PR_MODE_ENV = "SPECFACT_CODE_REVIEW_PR_MODE"
 _PR_CONTEXT_ENVS = (
@@ -54,6 +56,20 @@ _PR_CONTEXT_ENVS = (
 )
 _CLEAN_CODE_CONTEXT_HINTS = ("clean code", "naming", "kiss", "yagni", "dry", "solid", "complexity")
 _TARGETED_TEST_TIMEOUT = int(os.environ.get("SPECFACT_CODE_REVIEW_TARGETED_TEST_TIMEOUT", "120"))
+ReviewFocus = Literal["simplify"]
+
+
+@dataclass(frozen=True)
+class ReviewOptions:
+    """Optional controls for a governed review run."""
+
+    no_tests: bool = False
+    include_noise: bool = False
+    progress_callback: Callable[[str], None] | None = None
+    bug_hunt: bool = False
+    review_level: Literal["error", "warning"] | None = None
+    review_mode: Literal["shadow", "enforce"] = "enforce"
+    focus: ReviewFocus | None = None
 
 
 def _source_relative_path(source_file: Path) -> Path | None:
@@ -208,12 +224,33 @@ def _suppress_known_noise(findings: list[ReviewFinding]) -> list[ReviewFinding]:
     for finding in findings:
         if (finding.tool, finding.rule) in _GLOBAL_NOISE_RULES:
             continue
+        if _is_pylint_structural_noise(finding):
+            continue
         if finding.tool == "crosshair" and finding.message.startswith(_NOISE_MESSAGE_PREFIXES):
             continue
         if _is_test_file(finding.file) and (finding.tool, finding.rule) in _TEST_NOISE_RULES:
             continue
         filtered.append(finding)
     return filtered
+
+
+def _is_pylint_structural_noise(finding: ReviewFinding) -> bool:
+    if finding.tool != "pylint":
+        return False
+    if finding.rule in _PYLINT_CLI_WRAPPER_NOISE_RULES and finding.file.endswith("/commands.py"):
+        return "argument" in finding.message or "local variable" in finding.message
+    return (
+        finding.rule == "R0902"
+        and "Too many instance attributes" in finding.message
+        and _file_contains_dataclass(finding.file)
+    )
+
+
+def _file_contains_dataclass(file_path: str) -> bool:
+    try:
+        return "@dataclass" in Path(file_path).read_text(encoding="utf-8")
+    except OSError:
+        return False
 
 
 def _is_truthy_env(name: str) -> bool:
@@ -270,6 +307,22 @@ def _filter_findings_by_review_level(
     if level == "error":
         return [finding for finding in findings if finding.severity == "error"]
     return [finding for finding in findings if finding.severity in {"error", "warning"}]
+
+
+def _belongs_to_simplification_queue(finding: ReviewFinding) -> bool:
+    if finding.category == "ai_bloat":
+        return True
+    return (
+        finding.category in {"dry", "kiss"} and finding.confidence == "high" and finding.has_simplification_metadata()
+    )
+
+
+def _filter_findings_by_focus(findings: list[ReviewFinding], focus: ReviewFocus | None) -> list[ReviewFinding]:
+    if focus is None:
+        return findings
+    if focus == "simplify":
+        return [finding for finding in findings if _belongs_to_simplification_queue(finding)]
+    raise ValueError(f"Unsupported review focus: {focus}")
 
 
 def _collect_tdd_inputs(files: list[Path]) -> tuple[list[Path], list[Path], list[ReviewFinding]]:
@@ -453,41 +506,84 @@ def _has_no_suppressions(files: list[Path]) -> bool:
     return True
 
 
+def _review_options_from_kwargs(options: ReviewOptions | None, overrides: dict[str, object]) -> ReviewOptions:
+    if options is not None and overrides:
+        raise TypeError("pass either options or keyword review overrides, not both")
+    if options is not None:
+        return options
+    progress_callback = overrides.get("progress_callback")
+    if progress_callback is not None and not callable(progress_callback):
+        raise TypeError("progress_callback must be callable or None")
+    return ReviewOptions(
+        no_tests=cast(bool, overrides.get("no_tests", False)),
+        include_noise=cast(bool, overrides.get("include_noise", False)),
+        progress_callback=cast(Callable[[str], None] | None, progress_callback),
+        bug_hunt=cast(bool, overrides.get("bug_hunt", False)),
+        review_level=cast(Literal["error", "warning"] | None, overrides.get("review_level")),
+        review_mode=cast(Literal["shadow", "enforce"], overrides.get("review_mode", "enforce")),
+        focus=cast(ReviewFocus | None, overrides.get("focus")),
+    )
+
+
+def _collect_tool_findings(
+    files: list[Path],
+    *,
+    bug_hunt: bool,
+    progress_callback: Callable[[str], None] | None,
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    for description, runner in _tool_steps(bug_hunt=bug_hunt):
+        if progress_callback is not None:
+            progress_callback(description)
+        findings.extend(runner(files))
+    return findings
+
+
+def _collect_tdd_findings(
+    files: list[Path],
+    *,
+    no_tests: bool,
+    progress_callback: Callable[[str], None] | None,
+) -> tuple[list[ReviewFinding], bool]:
+    if no_tests:
+        return [], False
+    if progress_callback is not None:
+        progress_callback("Running targeted tests and coverage...")
+    findings, coverage_by_source = _evaluate_tdd_gate(files)
+    coverage_90_plus = bool(coverage_by_source) and all(percent >= 90.0 for percent in coverage_by_source.values())
+    return findings, coverage_90_plus
+
+
 @beartype
 @require(lambda files: isinstance(files, list), "files must be a list")
 @require(lambda files: all(isinstance(file_path, Path) for file_path in files), "files must contain Path instances")
 @ensure(lambda result: isinstance(result, ReviewReport), "result must be a ReviewReport")
 def run_review(
     files: list[Path],
-    *,
-    no_tests: bool = False,
-    include_noise: bool = False,
-    progress_callback: Callable[[str], None] | None = None,
-    bug_hunt: bool = False,
-    review_level: Literal["error", "warning"] | None = None,
-    review_mode: Literal["shadow", "enforce"] = "enforce",
+    options: ReviewOptions | None = None,
+    **overrides: object,
 ) -> ReviewReport:
     """Run all configured review runners and build the governed report."""
-    findings: list[ReviewFinding] = []
-    for description, runner in _tool_steps(bug_hunt=bug_hunt):
-        if progress_callback is not None:
-            progress_callback(description)
-        findings.extend(runner(files))
-
-    coverage_90_plus = False
-    if not no_tests:
-        if progress_callback is not None:
-            progress_callback("Running targeted tests and coverage...")
-        tdd_findings, coverage_by_source = _evaluate_tdd_gate(files)
-        findings.extend(tdd_findings)
-        coverage_90_plus = bool(coverage_by_source) and all(percent >= 90.0 for percent in coverage_by_source.values())
+    review_options = _review_options_from_kwargs(options, overrides)
+    findings = _collect_tool_findings(
+        files,
+        bug_hunt=review_options.bug_hunt,
+        progress_callback=review_options.progress_callback,
+    )
+    tdd_findings, coverage_90_plus = _collect_tdd_findings(
+        files,
+        no_tests=review_options.no_tests,
+        progress_callback=review_options.progress_callback,
+    )
+    findings.extend(tdd_findings)
 
     findings.extend(_checklist_findings())
 
-    if not include_noise:
+    if not review_options.include_noise:
         findings = _suppress_known_noise(findings)
 
-    findings = _filter_findings_by_review_level(findings, review_level)
+    findings = _filter_findings_by_review_level(findings, review_options.review_level)
+    findings = _filter_findings_by_focus(findings, review_options.focus)
 
     score = score_review(
         findings=findings,
@@ -503,6 +599,6 @@ def run_review(
         findings=findings,
         summary=_summary_for_findings(findings),
     )
-    if review_mode == "shadow":
+    if review_options.review_mode == "shadow":
         return report.model_copy(update={"ci_exit_code": 0})
     return report

--- a/packages/specfact-code-review/src/specfact_code_review/run/runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/runner.py
@@ -313,7 +313,9 @@ def _belongs_to_simplification_queue(finding: ReviewFinding) -> bool:
     if finding.category == "ai_bloat":
         return True
     return (
-        finding.category in {"dry", "kiss"} and finding.confidence == "high" and finding.has_simplification_metadata()
+        finding.category in {"dry", "kiss"}
+        and finding.confidence == "high"
+        and finding.simplification_metadata_is_deterministic()
     )
 
 
@@ -511,17 +513,46 @@ def _review_options_from_kwargs(options: ReviewOptions | None, overrides: dict[s
         raise TypeError("pass either options or keyword review overrides, not both")
     if options is not None:
         return options
+    allowed_keys = {
+        "no_tests",
+        "include_noise",
+        "progress_callback",
+        "bug_hunt",
+        "review_level",
+        "review_mode",
+        "focus",
+    }
+    unknown_keys = set(overrides) - allowed_keys
+    if unknown_keys:
+        unknown = ", ".join(sorted(unknown_keys))
+        raise TypeError(f"unknown review option override: {unknown}")
+    for key in ("no_tests", "include_noise", "bug_hunt"):
+        value = overrides.get(key, False)
+        if not isinstance(value, bool):
+            raise TypeError(f"{key} must be bool")
+    no_tests = cast(bool, overrides.get("no_tests", False))
+    include_noise = cast(bool, overrides.get("include_noise", False))
+    bug_hunt = cast(bool, overrides.get("bug_hunt", False))
     progress_callback = overrides.get("progress_callback")
     if progress_callback is not None and not callable(progress_callback):
         raise TypeError("progress_callback must be callable or None")
+    review_level = overrides.get("review_level")
+    if review_level not in {"error", "warning", None}:
+        raise TypeError("review_level must be one of error, warning, or None")
+    review_mode = overrides.get("review_mode", "enforce")
+    if review_mode not in {"shadow", "enforce"}:
+        raise TypeError("review_mode must be one of shadow or enforce")
+    focus = overrides.get("focus")
+    if focus not in {"simplify", None}:
+        raise TypeError("focus must be simplify or None")
     return ReviewOptions(
-        no_tests=cast(bool, overrides.get("no_tests", False)),
-        include_noise=cast(bool, overrides.get("include_noise", False)),
+        no_tests=no_tests,
+        include_noise=include_noise,
         progress_callback=cast(Callable[[str], None] | None, progress_callback),
-        bug_hunt=cast(bool, overrides.get("bug_hunt", False)),
-        review_level=cast(Literal["error", "warning"] | None, overrides.get("review_level")),
-        review_mode=cast(Literal["shadow", "enforce"], overrides.get("review_mode", "enforce")),
-        focus=cast(ReviewFocus | None, overrides.get("focus")),
+        bug_hunt=bug_hunt,
+        review_level=cast(Literal["error", "warning"] | None, review_level),
+        review_mode=cast(Literal["shadow", "enforce"], review_mode),
+        focus=cast(ReviewFocus | None, focus),
     )
 
 
@@ -592,6 +623,7 @@ def run_review(
         all_apis_have_icontract=not any(finding.rule == "MISSING_ICONTRACT" for finding in findings),
         coverage_90_plus=coverage_90_plus,
         no_new_suppressions=_has_no_suppressions(files),
+        simplification_score_neutral=review_options.focus == "simplify",
     )
     report = ReviewReport(
         run_id=f"review-{uuid4()}",

--- a/packages/specfact-code-review/src/specfact_code_review/run/scorer.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/scorer.py
@@ -52,6 +52,8 @@ def _bonus_points(modifiers: ReviewScoreModifiers) -> int:
 def _deduction_for_finding(finding: ReviewFinding) -> int:
     if finding.category == "ai_bloat":
         return 0
+    if finding.has_simplification_metadata() and finding.category in {"dry", "kiss"}:
+        return 0
     if finding.severity == "error" and not finding.fixable:
         return 15
     if finding.severity == "error" and finding.fixable:

--- a/packages/specfact-code-review/src/specfact_code_review/run/scorer.py
+++ b/packages/specfact-code-review/src/specfact_code_review/run/scorer.py
@@ -49,10 +49,10 @@ def _bonus_points(modifiers: ReviewScoreModifiers) -> int:
     )
 
 
-def _deduction_for_finding(finding: ReviewFinding) -> int:
+def _deduction_for_finding(finding: ReviewFinding, *, simplification_score_neutral: bool) -> int:
     if finding.category == "ai_bloat":
         return 0
-    if finding.has_simplification_metadata() and finding.category in {"dry", "kiss"}:
+    if simplification_score_neutral and finding.has_simplification_metadata() and finding.category in {"dry", "kiss"}:
         return 0
     if finding.severity == "error" and not finding.fixable:
         return 15
@@ -90,12 +90,16 @@ def score_review(
         coverage_90_plus=bool(kwargs.pop("coverage_90_plus", False)),
         no_new_suppressions=bool(kwargs.pop("no_new_suppressions", False)),
     )
+    simplification_score_neutral = bool(kwargs.pop("simplification_score_neutral", False))
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise ValueError(f"Unexpected keyword arguments: {unexpected}")
 
     score = 100
-    score -= sum(_deduction_for_finding(finding) for finding in findings)
+    score -= sum(
+        _deduction_for_finding(finding, simplification_score_neutral=simplification_score_neutral)
+        for finding in findings
+    )
     score += _bonus_points(modifiers)
     score = max(0, min(120, score))
     overall_verdict, ci_exit_code = _determine_verdict(score=score, findings=findings)

--- a/packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/ai_bloat_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 
 from beartype import beartype
@@ -16,8 +17,36 @@ _LOC_FLOOR = 40
 _COMPLEXITY_CEILING = 4
 
 
+@dataclass(frozen=True)
+class _SimplificationCandidate:
+    file_path: Path
+    line: int
+    rule: str
+    message: str
+    canonical_pattern: str
+    rewrite_hint: str
+    estimated_deletion_lines: int
+
+
 def _iter_functions(tree: ast.AST) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
     return [node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)]
+
+
+def _simplification_finding(candidate: _SimplificationCandidate) -> ReviewFinding:
+    return ReviewFinding(
+        category="ai_bloat",
+        severity="info",
+        tool="ast",
+        rule=candidate.rule,
+        file=str(candidate.file_path),
+        line=candidate.line,
+        message=candidate.message,
+        fixable=False,
+        confidence="high",
+        rewrite_hint=candidate.rewrite_hint,
+        canonical_pattern=candidate.canonical_pattern,
+        estimated_deletion_lines=candidate.estimated_deletion_lines,
+    )
 
 
 def _is_none_constant(node: ast.AST | None) -> bool:
@@ -191,6 +220,24 @@ def _assigned_name(stmt: ast.stmt) -> str | None:
     return None
 
 
+def _assigned_empty_collection_name(stmt: ast.stmt) -> str | None:
+    value: ast.AST | None = None
+    target: ast.AST | None = None
+    if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+        target = stmt.targets[0]
+        value = stmt.value
+    elif isinstance(stmt, ast.AnnAssign):
+        target = stmt.target
+        value = stmt.value
+    if not isinstance(target, ast.Name) or not isinstance(value, ast.List | ast.Dict | ast.Set):
+        return None
+    if isinstance(value, ast.List | ast.Set) and value.elts:
+        return None
+    if isinstance(value, ast.Dict) and value.keys:
+        return None
+    return target.id
+
+
 def _loaded_name_count(node: ast.AST, name: str) -> int:
     return sum(
         1
@@ -218,18 +265,266 @@ def _redundant_intermediate_findings(
         if later_uses != 0:
             continue
         findings.append(
-            ReviewFinding(
-                category="ai_bloat",
-                severity="info",
-                tool="ast",
-                rule="ai-bloat.redundant-intermediate",
-                file=str(file_path),
-                line=stmt.lineno,
-                message=f"Variable `{name}` is assigned once and read only on the next statement; inline it.",
-                fixable=False,
+            _simplification_finding(
+                _SimplificationCandidate(
+                    file_path=file_path,
+                    line=stmt.lineno,
+                    rule="ai-bloat.redundant-intermediate",
+                    message=f"Variable `{name}` is assigned once and read only on the next statement; inline it.",
+                    canonical_pattern="one-use-temporary",
+                    rewrite_hint="Inline the one-use temporary into the return statement.",
+                    estimated_deletion_lines=1,
+                )
             )
         )
     return findings
+
+
+def _manual_accumulator_loop_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    for index, stmt in enumerate(function_node.body[:-1]):
+        accumulator = _manual_accumulator_name(function_node, index)
+        if accumulator is None:
+            continue
+        findings.append(
+            _simplification_finding(
+                _SimplificationCandidate(
+                    file_path=file_path,
+                    line=stmt.lineno,
+                    rule="ai-bloat.manual-accumulator-loop",
+                    message=f"Function `{function_node.name}` uses a manual accumulator loop that can likely collapse.",
+                    canonical_pattern="manual-accumulator-loop",
+                    rewrite_hint="Replace the accumulator loop with a comprehension or direct collection constructor.",
+                    estimated_deletion_lines=3,
+                )
+            )
+        )
+    return findings
+
+
+def _manual_accumulator_name(function_node: ast.FunctionDef | ast.AsyncFunctionDef, index: int) -> str | None:
+    accumulator = _assigned_empty_collection_name(function_node.body[index])
+    if accumulator is None:
+        return None
+    loop = function_node.body[index + 1]
+    return_stmt = function_node.body[index + 2] if index + 2 < len(function_node.body) else None
+    if not _returns_accumulator(return_stmt, accumulator):
+        return None
+    if not isinstance(loop, ast.For) or len(loop.body) != 1 or not isinstance(loop.body[0], ast.Expr):
+        return None
+    return accumulator if _loop_appends_to_accumulator(loop.body[0].value, accumulator) else None
+
+
+def _returns_accumulator(stmt: ast.stmt | None, accumulator: str) -> bool:
+    return isinstance(stmt, ast.Return) and isinstance(stmt.value, ast.Name) and stmt.value.id == accumulator
+
+
+def _loop_appends_to_accumulator(node: ast.AST, accumulator: str) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"append", "add"}
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == accumulator
+    )
+
+
+def _return_constant_bool(stmt: ast.stmt) -> bool | None:
+    if isinstance(stmt, ast.Return) and isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, bool):
+        return stmt.value.value
+    return None
+
+
+def _verbose_bool_return_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    for index, stmt in enumerate(function_node.body[:-1]):
+        next_stmt = function_node.body[index + 1]
+        if not isinstance(stmt, ast.If) or len(stmt.body) != 1 or stmt.orelse:
+            continue
+        first_value = _return_constant_bool(stmt.body[0])
+        second_value = _return_constant_bool(next_stmt)
+        if first_value is None or second_value is None or first_value == second_value:
+            continue
+        findings.append(
+            _simplification_finding(
+                _SimplificationCandidate(
+                    file_path=file_path,
+                    line=stmt.lineno,
+                    rule="ai-bloat.verbose-bool-return",
+                    message=f"Function `{function_node.name}` returns explicit bool branches for one predicate.",
+                    canonical_pattern="verbose-bool-return",
+                    rewrite_hint="Return the predicate directly, negating it if needed.",
+                    estimated_deletion_lines=2,
+                )
+            )
+        )
+    return findings
+
+
+def _redundant_none_branch_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    for index, stmt in enumerate(function_node.body[:-1]):
+        if not isinstance(stmt, ast.If) or len(stmt.body) != 1 or stmt.orelse:
+            continue
+        if not (isinstance(stmt.body[0], ast.Return) and _is_none_constant(stmt.body[0].value)):
+            continue
+        if not isinstance(function_node.body[index + 1], ast.Return):
+            continue
+        findings.append(
+            _simplification_finding(
+                _SimplificationCandidate(
+                    file_path=file_path,
+                    line=stmt.lineno,
+                    rule="ai-bloat.redundant-none-branch",
+                    message=f"Function `{function_node.name}` has a pass-through None branch before a single return.",
+                    canonical_pattern="redundant-none-branch",
+                    rewrite_hint="Consider collapsing the None guard into the expression or caller contract.",
+                    estimated_deletion_lines=2,
+                )
+            )
+        )
+    return findings
+
+
+def _pass_through_try_except_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    findings: list[ReviewFinding] = []
+    for stmt in function_node.body:
+        if not isinstance(stmt, ast.Try) or stmt.orelse or stmt.finalbody or len(stmt.handlers) != 1:
+            continue
+        handler = stmt.handlers[0]
+        if len(handler.body) != 1 or not isinstance(handler.body[0], ast.Raise) or handler.body[0].exc is not None:
+            continue
+        findings.append(
+            _simplification_finding(
+                _SimplificationCandidate(
+                    file_path=file_path,
+                    line=stmt.lineno,
+                    rule="ai-bloat.pass-through-try-except",
+                    message=(
+                        f"Function `{function_node.name}` catches and immediately re-raises without adding context."
+                    ),
+                    canonical_pattern="pass-through-try-except",
+                    rewrite_hint="Remove the pass-through try/except unless it adds domain context.",
+                    estimated_deletion_lines=2,
+                )
+            )
+        )
+    return findings
+
+
+def _constant_equality_return(stmt: ast.stmt) -> str | None:
+    if not isinstance(stmt, ast.If) or len(stmt.body) != 1 or stmt.orelse:
+        return None
+    if not (isinstance(stmt.body[0], ast.Return) and isinstance(stmt.body[0].value, ast.Constant)):
+        return None
+    if not isinstance(stmt.test, ast.Compare) or len(stmt.test.ops) != 1:
+        return None
+    if not isinstance(stmt.test.ops[0], ast.Eq):
+        return None
+    if not isinstance(stmt.test.left, ast.Name) or len(stmt.test.comparators) != 1:
+        return None
+    if not isinstance(stmt.test.comparators[0], ast.Constant):
+        return None
+    return stmt.test.left.id
+
+
+def _table_lookup_match_count(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    compared_name: str | None = None
+    matches = 0
+    for stmt in function_node.body:
+        if isinstance(stmt, ast.Return):
+            break
+        current_name = _constant_equality_return(stmt)
+        if current_name is None:
+            return 0
+        compared_name = compared_name or current_name
+        if current_name != compared_name:
+            return 0
+        matches += 1
+    return matches
+
+
+def _table_lookup_candidate_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    matches = _table_lookup_match_count(function_node)
+    if matches < 3:
+        return []
+    return [
+        _simplification_finding(
+            _SimplificationCandidate(
+                file_path=file_path,
+                line=function_node.lineno,
+                rule="ai-bloat.table-lookup-candidate",
+                message=f"Function `{function_node.name}` maps constants through repeated equality branches.",
+                canonical_pattern="table-lookup-candidate",
+                rewrite_hint="Consider replacing repeated equality returns with a lookup table plus default.",
+                estimated_deletion_lines=max(1, matches - 1),
+            )
+        )
+    ]
+
+
+def _stdlib_replacement_candidate_findings(
+    file_path: Path, function_node: ast.FunctionDef | ast.AsyncFunctionDef
+) -> list[ReviewFinding]:
+    candidate = _stdlib_replacement_candidate(function_node)
+    if candidate is None:
+        return []
+    line, _initial_name = candidate
+    return [
+        _simplification_finding(
+            _SimplificationCandidate(
+                file_path=file_path,
+                line=line,
+                rule="ai-bloat.stdlib-replacement-candidate",
+                message=(
+                    f"Function `{function_node.name}` manually computes a value that may have a stdlib replacement."
+                ),
+                canonical_pattern="stdlib-replacement-candidate",
+                rewrite_hint="Consider a standard helper such as max, min, any, all, sum, or dict.fromkeys.",
+                estimated_deletion_lines=3,
+            )
+        )
+    ]
+
+
+def _stdlib_replacement_candidate(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> tuple[int, str] | None:
+    if len(function_node.body) < 3:
+        return None
+    first_assign = function_node.body[0]
+    initial_name = _none_initializer_name(first_assign)
+    if initial_name is None:
+        return None
+    loop = function_node.body[1]
+    terminal = function_node.body[2]
+    if not _returns_accumulator(terminal, initial_name):
+        return None
+    if _loop_updates_name(loop, initial_name):
+        return first_assign.lineno, initial_name
+    return None
+
+
+def _none_initializer_name(stmt: ast.stmt) -> str | None:
+    name = _assigned_name(stmt)
+    if name is None or not isinstance(stmt, ast.Assign) or not _is_none_constant(stmt.value):
+        return None
+    return name
+
+
+def _loop_updates_name(stmt: ast.stmt, name: str) -> bool:
+    if not isinstance(stmt, ast.For) or len(stmt.body) != 1 or not isinstance(stmt.body[0], ast.If):
+        return False
+    guard = stmt.body[0]
+    return len(guard.body) == 1 and _assigned_name(guard.body[0]) == name
 
 
 def _findings_for_function(
@@ -240,6 +535,46 @@ def _findings_for_function(
     findings.extend(_dead_branch_findings(file_path, function_node))
     findings.extend(_loc_vs_complexity_findings(file_path, function_node))
     findings.extend(_redundant_intermediate_findings(file_path, function_node))
+    findings.extend(_manual_accumulator_loop_findings(file_path, function_node))
+    findings.extend(_verbose_bool_return_findings(file_path, function_node))
+    findings.extend(_redundant_none_branch_findings(file_path, function_node))
+    findings.extend(_pass_through_try_except_findings(file_path, function_node))
+    findings.extend(_table_lookup_candidate_findings(file_path, function_node))
+    findings.extend(_stdlib_replacement_candidate_findings(file_path, function_node))
+    return findings
+
+
+def _single_call_return_name(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    if len(function_node.body) != 1 or not isinstance(function_node.body[0], ast.Return):
+        return None
+    value = function_node.body[0].value
+    if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
+        return value.func.id
+    return None
+
+
+def _wrapper_chain_findings(file_path: Path, tree: ast.Module) -> list[ReviewFinding]:
+    functions = [node for node in tree.body if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)]
+    wrappers = {function_node.name: _single_call_return_name(function_node) for function_node in functions}
+    wrapper_names = {name for name, called in wrappers.items() if called is not None}
+    findings: list[ReviewFinding] = []
+    for function_node in functions:
+        called = wrappers.get(function_node.name)
+        if called is None or called not in wrapper_names:
+            continue
+        findings.append(
+            _simplification_finding(
+                _SimplificationCandidate(
+                    file_path=file_path,
+                    line=function_node.lineno,
+                    rule="ai-bloat.wrapper-chain",
+                    message=f"Function `{function_node.name}` is part of a pass-through wrapper chain.",
+                    canonical_pattern="wrapper-chain",
+                    rewrite_hint="Collapse the wrapper chain or keep only the compatibility boundary.",
+                    estimated_deletion_lines=max(1, _function_loc(function_node) - 1),
+                )
+            )
+        )
     return findings
 
 
@@ -262,6 +597,7 @@ def run_ai_bloat(files: list[Path]) -> list[ReviewFinding]:
                 tool_error(tool="ast", file_path=file_path, message=f"Unable to parse Python source: {exc}")
             )
             continue
+        findings.extend(_wrapper_chain_findings(file_path, tree))
         for function_node in _iter_functions(tree):
             findings.extend(_findings_for_function(file_path, function_node))
     return findings

--- a/packages/specfact-code-review/src/specfact_code_review/tools/ast_clean_code_runner.py
+++ b/packages/specfact-code-review/src/specfact_code_review/tools/ast_clean_code_runner.py
@@ -11,11 +11,30 @@ from beartype import beartype
 from icontract import ensure, require
 
 from specfact_code_review._review_utils import python_source_paths_for_tools, tool_error
-from specfact_code_review.run.findings import ReviewFinding
+from specfact_code_review.run.findings import EvidenceRef, ReviewFinding
 
 
 _REPOSITORY_ROOTS = {"repo", "repository"}
 _HTTP_ROOTS = {"client", "http_client", "requests", "session"}
+_INTENT_STOPWORDS = {
+    "build",
+    "clean",
+    "create",
+    "first",
+    "format",
+    "get",
+    "handle",
+    "load",
+    "make",
+    "normalize",
+    "prepare",
+    "process",
+    "read",
+    "second",
+    "sync",
+    "target",
+    "update",
+}
 
 
 class _ShapeNormalizer(ast.NodeTransformer):
@@ -103,6 +122,21 @@ def _duplicate_shape_id(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -
     return ast.dump(normalized, include_attributes=False)
 
 
+def _tokens(value: str) -> set[str]:
+    normalized = value.replace("-", "_").replace(".", "_")
+    return {token for token in normalized.lower().split("_") if len(token) > 2 and token not in _INTENT_STOPWORDS}
+
+
+def _intent_key(file_path: Path, duplicates: list[ast.FunctionDef | ast.AsyncFunctionDef]) -> str | None:
+    name_tokens = [_tokens(function_node.name) for function_node in duplicates]
+    common_tokens = set.intersection(*name_tokens) if name_tokens else set()
+    path_tokens = _tokens(file_path.stem)
+    intent_tokens = sorted(common_tokens | (path_tokens & set.union(*name_tokens)))
+    if len(intent_tokens) < 2:
+        return None
+    return "-".join(intent_tokens[:3])
+
+
 def _yagni_findings(file_path: Path, tree: ast.Module) -> list[ReviewFinding]:
     loaded_names = _loaded_names(tree)
     findings: list[ReviewFinding] = []
@@ -136,7 +170,13 @@ def _dry_findings(file_path: Path, tree: ast.Module) -> list[ReviewFinding]:
     for duplicates in grouped.values():
         if len(duplicates) < 2:
             continue
+        intent_key = _intent_key(file_path, duplicates)
         for duplicate in duplicates[1:]:
+            related_locations = [
+                EvidenceRef(path=str(file_path), start_line=related.lineno)
+                for related in duplicates
+                if related is not duplicate
+            ]
             findings.append(
                 ReviewFinding(
                     category="dry",
@@ -147,6 +187,16 @@ def _dry_findings(file_path: Path, tree: ast.Module) -> list[ReviewFinding]:
                     line=duplicate.lineno,
                     message=f"Function `{duplicate.name}` duplicates another function shape in this module.",
                     fixable=False,
+                    confidence="high" if intent_key is not None else None,
+                    rewrite_hint=(
+                        "Review the related locations together and extract the shared domain operation."
+                        if intent_key is not None
+                        else None
+                    ),
+                    canonical_pattern="duplicate-intent" if intent_key is not None else None,
+                    intent_key=intent_key,
+                    estimated_deletion_lines=max(1, len(duplicates) - 1) if intent_key is not None else None,
+                    related_locations=related_locations if intent_key is not None else None,
                 )
             )
     return findings

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -28,3 +28,4 @@ description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
   checksum: sha256:cbae2549ae56e7271c4f4cd0d7140cf2d14ba23b4b49ad2a9afb802275b63833
+  signature: Y95kcv6OTjCwwZrBy7R0XktoN1z/Y4T4QNCQk+LPIxkrvACvSuM3bOFiVsSIBfi2b+Jz1tHV9uKIPOOT69lLBw==

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-project
-version: 0.41.11
+version: 0.41.12
 commands:
   - project
   - plan
@@ -27,5 +27,4 @@ core_compatibility: '>=0.40.0,<1.0.0'
 description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
-  checksum: sha256:613fca64cd3937b2a36369ff44069ad56db5162904cfcd2cd426eaf7e66b2d9b
-  signature: 1euQbP9ngvSUfCy35ly6D5Ul+PNt3ykzCZob1UJgC+Ih8hOT6M/+gUdeqcAHcXeTBgn/+5tu57rYCKRBi766Dg==
+  checksum: sha256:ec22157d55c99ac7974ab62d30b54a8dd4feb5a4edbb87dea444960a8ccdc4c7

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -27,5 +27,4 @@ core_compatibility: '>=0.40.0,<1.0.0'
 description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
-  checksum: sha256:ec22157d55c99ac7974ab62d30b54a8dd4feb5a4edbb87dea444960a8ccdc4c7
-  signature: 0U+GBg48yKVhFiDKMVWw8ucJJDbtMctzEfgkxZXKs1VRRhA4nb6pmOPPB5xA+SuvtTS+UAhHjObMWZ5PsH4BAw==
+  checksum: sha256:cbae2549ae56e7271c4f4cd0d7140cf2d14ba23b4b49ad2a9afb802275b63833

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -28,3 +28,4 @@ description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
   checksum: sha256:ec22157d55c99ac7974ab62d30b54a8dd4feb5a4edbb87dea444960a8ccdc4c7
+  signature: 0U+GBg48yKVhFiDKMVWw8ucJJDbtMctzEfgkxZXKs1VRRhA4nb6pmOPPB5xA+SuvtTS+UAhHjObMWZ5PsH4BAw==

--- a/packages/specfact-project/resources/prompts/specfact.03-review.md
+++ b/packages/specfact-project/resources/prompts/specfact.03-review.md
@@ -24,6 +24,21 @@ Review project bundle to identify/resolve ambiguities and missing information. A
 
 **Quick:** `/specfact.03-review` (uses active plan) or `/specfact.03-review legacy-api`
 
+## Guidance Character
+
+Act as a project review guide, not an artifact author. Use SpecFact CLI output as the source of truth, provide clear answer options when human judgment is needed, and self-heal command drift by checking current `--help` before changing the workflow. Keep recommendations grounded in implementation evidence, domain context, and bundle metadata.
+
+## CLI Grounding
+
+Before reviewing or answering questions, verify the current command surface when needed:
+
+```bash
+specfact plan review --help
+specfact plan review [<bundle>] --list-questions --output-questions /tmp/specfact-review-questions.json
+```
+
+If an option fails, inspect `specfact plan review --help`, choose the nearest safe non-interactive alternative, and ask the user when no clear mapping exists. Do not write `.specfact/` artifacts directly; route artifact updates back through SpecFact CLI commands or CLI-consumed enrichment/answers files.
+
 ## Interactive Question Presentation
 
 **CRITICAL**: When presenting questions interactively, **ALWAYS** generate and display multiple answer options in a table format. This makes it easier for users to select appropriate answers.
@@ -712,6 +727,22 @@ When generating enrichment reports for use with `import from-code --enrichment`,
 - ❌ Missing `- Acceptance:` prefix - acceptance criteria won't be parsed
 - ❌ Using bullet points (`-`) instead of numbers (`1.`) for stories
 - ❌ Feature title not in bold (`**Title**`) - parser may not extract title correctly
+
+## Verification
+
+Use CLI output as verification evidence:
+
+```bash
+specfact plan review [<bundle>] --list-findings --output-findings /tmp/specfact-review-findings.json
+specfact plan review [<bundle>] --list-questions --output-questions /tmp/specfact-review-questions.json
+```
+
+For module development in this repository, validate packaged prompt and module payload changes with:
+
+```bash
+hatch run validate-prompt-commands
+hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump
+```
 
 ## Context
 

--- a/packages/specfact-project/resources/prompts/specfact.08-simplify.md
+++ b/packages/specfact-project/resources/prompts/specfact.08-simplify.md
@@ -18,7 +18,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Purpose
 
-Simplify advisory `ai_bloat` and metadata-backed simplification findings from `.specfact/code-review.json` using the IDE's edit tools with explicit user confirmation for every change.
+Simplify advisory `ai_bloat` and metadata-backed simplification findings from `.specfact/code-review-simplify.json` using the IDE's edit tools with explicit user confirmation for every change.
 
 **Quick:** `/specfact.08-simplify`
 
@@ -32,7 +32,7 @@ Before reading or editing source, verify the current command surface when needed
 
 ```bash
 specfact code review run --help
-specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review-simplify.json
 ```
 
 If `--focus simplify` is unavailable in the installed CLI, self-heal by inspecting `specfact code review run --help`, then run the closest non-destructive JSON review command that preserves advisory findings, usually without `--level error`.
@@ -41,13 +41,13 @@ If `--focus simplify` is unavailable in the installed CLI, self-heal by inspecti
 
 ### Step 1: Confirm Review Evidence
 
-Read `.specfact/code-review.json`. If it is missing, ask the user to run:
+Read `.specfact/code-review-simplify.json`. If it is missing, ask the user to run:
 
 ```bash
-specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review-simplify.json
 ```
 
-If the report contains no findings where `category == "ai_bloat"` or simplification metadata such as `intent_key`, `rewrite_hint`, or `canonical_pattern` is present, report that there are no simplification candidates and stop without editing files.
+If the report contains no findings where `category == "ai_bloat"` and no findings with simplification metadata such as `intent_key`, `rewrite_hint`, or `canonical_pattern`, report that there are no simplification candidates and stop without editing files.
 
 ### Step 2: Group Candidates
 
@@ -70,7 +70,7 @@ Never apply edits automatically. Never batch multiple files into one confirmatio
 After accepted edits are applied, suggest:
 
 ```bash
-specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review-simplify.json
 ```
 
 Compare the new report with the prior findings and summarize which `ai_bloat` or metadata-backed simplification candidates were cleared, skipped, or still present.
@@ -80,8 +80,8 @@ Compare the new report with the prior findings and summarize which `ai_bloat` or
 Use the CLI as the verification source:
 
 ```bash
-specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
-specfact code review run --scope changed --bug-hunt --json --out .specfact/code-review.json
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review-simplify.json
+specfact code review run --scope changed --bug-hunt --json --out .specfact/code-review-bughunt.json
 ```
 
 For module development in this repository, the expected local gates are:

--- a/packages/specfact-project/resources/prompts/specfact.08-simplify.md
+++ b/packages/specfact-project/resources/prompts/specfact.08-simplify.md
@@ -18,9 +18,24 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Purpose
 
-Simplify advisory `ai_bloat` findings from `.specfact/code-review.json` using the IDE's edit tools with explicit user confirmation for every change.
+Simplify advisory `ai_bloat` and metadata-backed simplification findings from `.specfact/code-review.json` using the IDE's edit tools with explicit user confirmation for every change.
 
 **Quick:** `/specfact.08-simplify`
+
+## Guidance Character
+
+Act as a conservative code-review simplification assistant. Use the Code Review bundle's deterministic findings as evidence, explain one cleanup at a time, and keep the user in control. Do not infer AI authorship, do not chase broad refactors, and do not edit without explicit confirmation.
+
+## CLI Grounding
+
+Before reading or editing source, verify the current command surface when needed:
+
+```bash
+specfact code review run --help
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
+```
+
+If `--focus simplify` is unavailable in the installed CLI, self-heal by inspecting `specfact code review run --help`, then run the closest non-destructive JSON review command that preserves advisory findings, usually without `--level error`.
 
 ## Workflow
 
@@ -29,20 +44,20 @@ Simplify advisory `ai_bloat` findings from `.specfact/code-review.json` using th
 Read `.specfact/code-review.json`. If it is missing, ask the user to run:
 
 ```bash
-specfact code review run --json --out .specfact/code-review.json
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
 ```
 
-If the report contains no findings where `category == "ai_bloat"`, report that there are no ai-bloat candidates and stop without editing files.
+If the report contains no findings where `category == "ai_bloat"` or simplification metadata such as `intent_key`, `rewrite_hint`, or `canonical_pattern` is present, report that there are no simplification candidates and stop without editing files.
 
 ### Step 2: Group Candidates
 
-Group findings by file, then by rule. For each candidate, inspect the referenced source location and capture a small surrounding snippet before proposing a rewrite.
+Group findings by `intent_key` first when present, then by file or domain and rule. For each candidate, inspect the referenced source location, inspect any related locations from `related_locations`, and capture small surrounding snippets before proposing a rewrite.
 
 ### Step 3: Confirm Each Rewrite
 
 For each candidate:
 
-1. Show the file, line, rule, and current snippet.
+1. Show the file, line, rule, current snippet, and related locations when present.
 2. Explain the simplification in one sentence.
 3. Draft the replacement.
 4. Ask the user to choose: accept, reject, skip, or explain.
@@ -55,7 +70,23 @@ Never apply edits automatically. Never batch multiple files into one confirmatio
 After accepted edits are applied, suggest:
 
 ```bash
-specfact code review run --json --out .specfact/code-review.json
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
 ```
 
-Compare the new report with the prior findings and summarize which `ai_bloat` candidates were cleared, skipped, or still present.
+Compare the new report with the prior findings and summarize which `ai_bloat` or metadata-backed simplification candidates were cleared, skipped, or still present.
+
+## Verification
+
+Use the CLI as the verification source:
+
+```bash
+specfact code review run --scope changed --focus simplify --json --out .specfact/code-review.json
+specfact code review run --scope changed --bug-hunt --json --out .specfact/code-review.json
+```
+
+For module development in this repository, the expected local gates are:
+
+```bash
+hatch run validate-prompt-commands
+hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump
+```

--- a/tests/unit/docs/test_code_review_docs_parity.py
+++ b/tests/unit/docs/test_code_review_docs_parity.py
@@ -10,7 +10,7 @@ import typer
 from typer.main import get_command as typer_get_command
 
 from specfact_code_review.review import commands as review_commands
-from specfact_code_review.review.commands import _resolve_review_run_flags
+from specfact_code_review.review.commands import _resolve_review_run_flags, _ReviewRunCliInputs
 from specfact_code_review.run.commands import (
     ConflictingScopeError,
     InvalidOptionCombinationError,
@@ -63,25 +63,29 @@ def _resolver_messages_for_docs_parity() -> list[str]:
     messages: list[str] = []
     with pytest.raises(typer.BadParameter) as exc:
         _resolve_review_run_flags(
-            files=[],
-            include_tests=True,
-            exclude_tests=True,
-            focus=None,
-            include_noise=False,
-            suppress_noise=False,
-            interactive=False,
+            _ReviewRunCliInputs(
+                files=[],
+                include_tests=True,
+                exclude_tests=True,
+                focus=None,
+                include_noise=False,
+                suppress_noise=False,
+                interactive=False,
+            )
         )
     messages.append(str(exc.value))
 
     with pytest.raises(typer.BadParameter) as exc:
         _resolve_review_run_flags(
-            files=[],
-            include_tests=True,
-            exclude_tests=None,
-            focus=["source"],
-            include_noise=False,
-            suppress_noise=False,
-            interactive=False,
+            _ReviewRunCliInputs(
+                files=[],
+                include_tests=True,
+                exclude_tests=None,
+                focus=["source"],
+                include_noise=False,
+                suppress_noise=False,
+                interactive=False,
+            )
         )
     messages.append(str(exc.value))
     return messages

--- a/tests/unit/specfact_code_review/review/test_commands.py
+++ b/tests/unit/specfact_code_review/review/test_commands.py
@@ -5,10 +5,17 @@ from typing import Any
 
 from typer.testing import CliRunner
 
-from specfact_code_review.review.commands import app
+from specfact_code_review.review.commands import InvalidOptionCombinationError, app
 
 
 runner = CliRunner()
+
+
+def test_review_run_help_lists_simplify_focus() -> None:
+    result = runner.invoke(app, ["review", "run", "--help"])
+
+    assert result.exit_code == 0
+    assert "simplify" in result.output
 
 
 def test_review_run_interactive_prompts_for_test_inclusion(monkeypatch: Any) -> None:
@@ -60,6 +67,64 @@ def test_review_run_focus_source_sets_include_tests_false(monkeypatch: Any) -> N
 
     assert result.exit_code == 0
     assert recorded["kwargs"]["include_tests"] is False
+
+
+def test_review_run_rejects_conflicting_test_flags() -> None:
+    result = runner.invoke(app, ["review", "run", "--include-tests", "--exclude-tests"])
+
+    assert result.exit_code != 0
+    assert "Cannot use both --include-tests and --exclude-tests" in result.output
+
+
+def test_review_run_rejects_focus_with_test_flags() -> None:
+    result = runner.invoke(app, ["review", "run", "--focus", "source", "--include-tests"])
+
+    assert result.exit_code != 0
+
+
+def test_review_run_rejects_unknown_focus() -> None:
+    result = runner.invoke(app, ["review", "run", "--focus", "unknown"])
+
+    assert result.exit_code != 0
+
+
+def test_review_run_exclude_tests_sets_include_tests_false(monkeypatch: Any) -> None:
+    recorded: dict[str, Any] = {}
+
+    def _fake_run_command(_files: list[Path], **kwargs: object) -> tuple[int, str | None]:
+        recorded["kwargs"] = kwargs
+        return 0, None
+
+    monkeypatch.setattr("specfact_code_review.review.commands.run_command", _fake_run_command)
+
+    result = runner.invoke(app, ["review", "run", "--exclude-tests"])
+
+    assert result.exit_code == 0
+    assert recorded["kwargs"]["include_tests"] is False
+
+
+def test_review_run_prints_run_command_output(monkeypatch: Any) -> None:
+    def _fake_run_command(_files: list[Path], **_kwargs: object) -> tuple[int, str | None]:
+        return 0, "review output"
+
+    monkeypatch.setattr("specfact_code_review.review.commands.run_command", _fake_run_command)
+
+    result = runner.invoke(app, ["review", "run"])
+
+    assert result.exit_code == 0
+    assert "review output" in result.output
+
+
+def test_review_run_surfaces_run_command_validation_errors(monkeypatch: Any) -> None:
+    def _fake_run_command(_files: list[Path], **_kwargs: object) -> tuple[int, str | None]:
+        raise InvalidOptionCombinationError("invalid review options")
+
+    monkeypatch.setattr("specfact_code_review.review.commands.run_command", _fake_run_command)
+
+    result = runner.invoke(app, ["review", "run"])
+
+    assert result.exit_code != 0
+    assert "invalid review options" in result.output
 
 
 def test_review_run_explicit_files_do_not_prompt_and_keep_tests(monkeypatch: Any) -> None:

--- a/tests/unit/specfact_code_review/rules/test_updater.py
+++ b/tests/unit/specfact_code_review/rules/test_updater.py
@@ -120,6 +120,8 @@ def test_load_bundled_skill_content_returns_valid_structure_when_available() -> 
     if content is None:
         pytest.skip("Bundled SKILL not found (e.g. package not installed)")
     assert "name: specfact-code-review" in content
+    assert "specfact code review run --help" in content
+    assert "--focus simplify" in content
     assert "## DO" in content
     assert "## DON'T" in content
     assert "## TOP VIOLATIONS" in content
@@ -133,6 +135,8 @@ def test_default_skill_content_stays_within_line_budget() -> None:
     assert len(skill.splitlines()) <= MAX_SKILL_LINES
     assert "name: specfact-code-review" in skill
     assert "allowed-tools: []" in skill
+    assert "Codex CLI" in skill
+    assert "--focus simplify" in skill
 
 
 def test_render_cursor_rule_uses_cursor_metadata_and_skill_body() -> None:

--- a/tests/unit/specfact_code_review/run/test_commands.py
+++ b/tests/unit/specfact_code_review/run/test_commands.py
@@ -202,6 +202,46 @@ def test_run_command_supports_changed_scope_with_repeatable_path_filters(monkeyp
     assert recorded["files"] == [package_file, test_file]
 
 
+def test_run_command_passes_simplify_focus_after_scope_resolution(monkeypatch: Any, tmp_path: Path) -> None:
+    package_file = _write_repo_file(
+        tmp_path,
+        "packages/specfact-code-review/src/specfact_code_review/run/commands.py",
+    )
+    monkeypatch.chdir(tmp_path)
+    recorded: dict[str, object] = {}
+    monkeypatch.setattr(
+        "specfact_code_review.run.commands._changed_files_from_git_diff",
+        lambda *, include_tests: [package_file],
+    )
+
+    def fake_run_review(files: list[Path], **kwargs: Any) -> ReviewReport:
+        recorded["files"] = files
+        recorded["focus"] = kwargs.get("focus")
+        return _report()
+
+    monkeypatch.setattr("specfact_code_review.run.commands.run_review", fake_run_review)
+
+    result = runner.invoke(
+        app,
+        [
+            "review",
+            "run",
+            "--scope",
+            "changed",
+            "--path",
+            "packages/specfact-code-review",
+            "--focus",
+            "simplify",
+            "--json",
+            "--out",
+            "review-report.json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert recorded == {"files": [package_file], "focus": "simplify"}
+
+
 def test_run_command_ignores_dot_specfact_in_changed_scope(monkeypatch: Any, tmp_path: Path) -> None:
     package_file = _write_repo_file(
         tmp_path,

--- a/tests/unit/specfact_code_review/run/test_findings.py
+++ b/tests/unit/specfact_code_review/run/test_findings.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, TypedDict, Unpack, cast
 import pytest
 from pydantic import ValidationError
 
-from specfact_code_review.run.findings import ReviewFinding, ReviewReport
+from specfact_code_review.run.findings import EvidenceRef, ReviewFinding, ReviewReport
 
 
 class ReviewFindingPayload(TypedDict, total=False):
@@ -33,6 +33,12 @@ class ReviewFindingPayload(TypedDict, total=False):
     line: int
     message: str
     fixable: bool
+    confidence: Literal["low", "medium", "high"]
+    rewrite_hint: str
+    canonical_pattern: str
+    intent_key: str
+    estimated_deletion_lines: int
+    related_locations: list[EvidenceRef]
 
 
 def _finding_data(**overrides: Unpack[ReviewFindingPayload]) -> ReviewFindingPayload:
@@ -55,6 +61,31 @@ def test_review_finding_accepts_valid_values() -> None:
     assert finding.category == "security"
     assert finding.severity == "warning"
     assert finding.fixable is False
+
+
+def test_review_finding_accepts_simplification_metadata() -> None:
+    finding = ReviewFinding(
+        **_finding_data(
+            category="ai_bloat",
+            severity="info",
+            rule="ai-bloat.manual-accumulator-loop",
+            confidence="high",
+            rewrite_hint="Replace the append loop with a list comprehension.",
+            canonical_pattern="manual-accumulator-loop",
+            intent_key="customer-normalization",
+            estimated_deletion_lines=3,
+            related_locations=[EvidenceRef(path="src/customer.py", start_line=42, end_line=45)],
+        )
+    )
+
+    assert finding.confidence == "high"
+    assert finding.rewrite_hint == "Replace the append loop with a list comprehension."
+    assert finding.canonical_pattern == "manual-accumulator-loop"
+    assert finding.intent_key == "customer-normalization"
+    assert finding.estimated_deletion_lines == 3
+    assert finding.related_locations is not None
+    assert finding.related_locations[0].path == "src/customer.py"
+    assert finding.model_dump()["related_locations"][0]["start_line"] == 42
 
 
 @pytest.mark.parametrize("severity", ["error", "warning", "info"])
@@ -140,6 +171,31 @@ def test_review_report_maps_pass_verdict() -> None:
     assert report.overall_verdict == "PASS"
     assert report.ci_exit_code == 0
     assert report.reward_delta == 5
+
+
+def test_review_report_uses_schema_1_1_when_simplification_metadata_is_present() -> None:
+    report = ReviewReport(
+        run_id="run-simplify",
+        timestamp=datetime(2026, 3, 11, tzinfo=UTC),
+        score=85,
+        findings=[
+            ReviewFinding(
+                **_finding_data(
+                    category="ai_bloat",
+                    severity="info",
+                    confidence="high",
+                    rewrite_hint="Inline the one-use temporary.",
+                    canonical_pattern="one-use-temporary",
+                    estimated_deletion_lines=1,
+                )
+            )
+        ],
+        summary="Simplification advisories.",
+    )
+
+    assert report.schema_version == "1.1"
+    assert report.overall_verdict == "PASS"
+    assert report.ci_exit_code == 0
 
 
 def test_review_report_maps_pass_with_advisory_verdict() -> None:

--- a/tests/unit/specfact_code_review/run/test_findings.py
+++ b/tests/unit/specfact_code_review/run/test_findings.py
@@ -88,6 +88,37 @@ def test_review_finding_accepts_simplification_metadata() -> None:
     assert finding.model_dump()["related_locations"][0]["start_line"] == 42
 
 
+def test_review_finding_marks_deterministic_simplification_metadata() -> None:
+    finding = ReviewFinding(
+        **_finding_data(
+            category="dry",
+            severity="warning",
+            rule="dry.duplicate-intent",
+            confidence="high",
+            rewrite_hint="Extract the duplicated request parsing.",
+            canonical_pattern="duplicate-request-parsing",
+            intent_key="request-parsing",
+        )
+    )
+
+    assert finding.has_simplification_metadata()
+    assert finding.simplification_metadata_is_deterministic()
+
+
+def test_review_finding_rejects_partial_simplification_metadata_as_nondeterministic() -> None:
+    finding = ReviewFinding(
+        **_finding_data(
+            category="dry",
+            severity="warning",
+            rule="dry.duplicate-intent",
+            confidence="high",
+        )
+    )
+
+    assert finding.has_simplification_metadata()
+    assert not finding.simplification_metadata_is_deterministic()
+
+
 @pytest.mark.parametrize("severity", ["error", "warning", "info"])
 def test_review_finding_accepts_supported_severity_values(
     severity: Literal["error", "warning", "info"],

--- a/tests/unit/specfact_code_review/run/test_runner.py
+++ b/tests/unit/specfact_code_review/run/test_runner.py
@@ -215,6 +215,60 @@ def test_run_review_simplify_focus_keeps_only_simplification_queue(monkeypatch: 
     assert report.overall_verdict == "PASS"
 
 
+def test_run_review_simplify_focus_excludes_partial_metadata_clean_code_findings(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ruff", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ai_bloat", lambda files: [])
+    monkeypatch.setattr(
+        "specfact_code_review.run.runner.run_ast_clean_code",
+        lambda files: [
+            ReviewFinding(
+                category="dry",
+                severity="warning",
+                tool="ast",
+                rule="dry.duplicate-intent",
+                file="packages/specfact-code-review/src/specfact_code_review/run/scorer.py",
+                line=10,
+                message="Partial metadata must not enter simplify focus.",
+                fixable=False,
+                confidence="high",
+            ),
+        ],
+    )
+    monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_contract_check", lambda files, **_: [])
+    monkeypatch.setattr("specfact_code_review.run.runner._evaluate_tdd_gate", lambda files: ([], None))
+
+    report = run_review(
+        [Path("packages/specfact-code-review/src/specfact_code_review/run/scorer.py")],
+        no_tests=True,
+        focus="simplify",
+    )
+
+    assert report.findings == []
+
+
+def test_run_review_rejects_unknown_override_key() -> None:
+    try:
+        run_review([], unknown=True)
+    except TypeError as exc:
+        assert "unknown" in str(exc)
+    else:
+        raise AssertionError("run_review accepted an unknown override")
+
+
+def test_run_review_rejects_invalid_override_type() -> None:
+    try:
+        run_review([], no_tests="yes")
+    except TypeError as exc:
+        assert "no_tests" in str(exc)
+    else:
+        raise AssertionError("run_review accepted an invalid boolean override")
+
+
 def test_run_tdd_gate_reports_missing_test_file() -> None:
     findings = run_tdd_gate([Path("packages/specfact-code-review/src/specfact_code_review/rules/commands.py")])
 

--- a/tests/unit/specfact_code_review/run/test_runner.py
+++ b/tests/unit/specfact_code_review/run/test_runner.py
@@ -54,6 +54,28 @@ def _finding(
     )
 
 
+def _simplification_finding(
+    *,
+    category: Literal["ai_bloat", "dry", "kiss"] = "ai_bloat",
+    confidence: Literal["low", "medium", "high"] = "high",
+) -> ReviewFinding:
+    return ReviewFinding(
+        category=category,
+        severity="info",
+        tool="ast",
+        rule="ai-bloat.manual-accumulator-loop",
+        file="packages/specfact-code-review/src/specfact_code_review/run/scorer.py",
+        line=10,
+        message="Manual accumulator loop can be collapsed.",
+        fixable=False,
+        confidence=confidence,
+        rewrite_hint="Replace the append loop with a list comprehension.",
+        canonical_pattern="manual-accumulator-loop",
+        intent_key="score-review",
+        estimated_deletion_lines=3,
+    )
+
+
 def test_run_review_calls_runners_in_order(monkeypatch: MonkeyPatch) -> None:
     calls: list[str] = []
 
@@ -155,6 +177,42 @@ def test_run_review_merges_findings_from_all_runners(monkeypatch: MonkeyPatch) -
         "contract_runner",
         "pytest",
     ]
+
+
+def test_run_review_simplify_focus_keeps_only_simplification_queue(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr("specfact_code_review.run.runner.run_ruff", lambda files: [_finding(tool="ruff", rule="E501")])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_radon", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_semgrep_bugs", lambda files: [])
+    monkeypatch.setattr(
+        "specfact_code_review.run.runner.run_ai_bloat",
+        lambda files: [_simplification_finding(category="ai_bloat")],
+    )
+    monkeypatch.setattr(
+        "specfact_code_review.run.runner.run_ast_clean_code",
+        lambda files: [
+            _simplification_finding(category="dry"),
+            _simplification_finding(category="kiss", confidence="medium"),
+            _finding(tool="ast", rule="solid.mixed-dependency-role", category="solid"),
+        ],
+    )
+    monkeypatch.setattr("specfact_code_review.run.runner.run_basedpyright", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_pylint", lambda files: [])
+    monkeypatch.setattr("specfact_code_review.run.runner.run_contract_check", lambda files, **_: [])
+    monkeypatch.setattr("specfact_code_review.run.runner._evaluate_tdd_gate", lambda files: ([], None))
+
+    report = run_review(
+        [Path("packages/specfact-code-review/src/specfact_code_review/run/scorer.py")],
+        no_tests=True,
+        focus="simplify",
+    )
+
+    assert [(finding.category, finding.confidence) for finding in report.findings] == [
+        ("ai_bloat", "high"),
+        ("dry", "high"),
+    ]
+    assert report.schema_version == "1.1"
+    assert report.overall_verdict == "PASS"
 
 
 def test_run_tdd_gate_reports_missing_test_file() -> None:

--- a/tests/unit/specfact_code_review/run/test_scorer.py
+++ b/tests/unit/specfact_code_review/run/test_scorer.py
@@ -32,6 +32,23 @@ def _ai_bloat_finding() -> ReviewFinding:
     )
 
 
+def _dry_simplification_finding() -> ReviewFinding:
+    return ReviewFinding(
+        category="dry",
+        severity="warning",
+        tool="ast",
+        rule="dry.duplicate-intent",
+        file="src/example.py",
+        line=10,
+        message="Duplicated intent can be simplified.",
+        fixable=False,
+        confidence="high",
+        rewrite_hint="Extract the repeated parsing branch.",
+        canonical_pattern="duplicate-request-parsing",
+        intent_key="request-parsing",
+    )
+
+
 def test_score_review_clean_run() -> None:
     result = score_review(findings=[])
 
@@ -69,6 +86,18 @@ def test_score_review_ai_bloat_findings_are_score_neutral() -> None:
     assert result.score == 100
     assert result.overall_verdict == "PASS"
     assert result.ci_exit_code == 0
+
+
+def test_score_review_deducts_dry_simplification_findings_by_default() -> None:
+    result = score_review(findings=[_dry_simplification_finding()])
+
+    assert result.score == 98
+
+
+def test_score_review_can_make_simplification_findings_score_neutral() -> None:
+    result = score_review(findings=[_dry_simplification_finding()], simplification_score_neutral=True)
+
+    assert result.score == 100
 
 
 def test_score_review_verdict_thresholds() -> None:

--- a/tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_ai_bloat_runner.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from specfact_code_review.tools.ai_bloat_runner import run_ai_bloat
 
 
@@ -86,6 +88,111 @@ def total(values: list[int]) -> int:
     assert {finding.rule for finding in run_ai_bloat([target])} == {"ai-bloat.redundant-intermediate"}
 
 
+@pytest.mark.parametrize(
+    ("source", "expected_rule", "expected_pattern"),
+    [
+        (
+            """
+def normalize_names(names: list[str]) -> list[str]:
+    result: list[str] = []
+    for name in names:
+        result.append(name.strip().lower())
+    return result
+""",
+            "ai-bloat.manual-accumulator-loop",
+            "manual-accumulator-loop",
+        ),
+        (
+            """
+def is_allowed(role: str) -> bool:
+    if role in {"admin", "owner"}:
+        return True
+    return False
+""",
+            "ai-bloat.verbose-bool-return",
+            "verbose-bool-return",
+        ),
+        (
+            """
+def normalized_name(name: str | None) -> str | None:
+    if name is None:
+        return None
+    return name.strip()
+""",
+            "ai-bloat.redundant-none-branch",
+            "redundant-none-branch",
+        ),
+        (
+            """
+def load_customer(customer_id: str) -> dict[str, str]:
+    return fetch_customer(customer_id)
+
+
+def read_customer(customer_id: str) -> dict[str, str]:
+    return load_customer(customer_id)
+""",
+            "ai-bloat.wrapper-chain",
+            "wrapper-chain",
+        ),
+        (
+            """
+def parse_customer(raw: str) -> dict[str, str]:
+    try:
+        return parse_json(raw)
+    except Exception:
+        raise
+""",
+            "ai-bloat.pass-through-try-except",
+            "pass-through-try-except",
+        ),
+        (
+            """
+def status_label(code: str) -> str:
+    if code == "new":
+        return "New"
+    if code == "done":
+        return "Done"
+    if code == "blocked":
+        return "Blocked"
+    return "Unknown"
+""",
+            "ai-bloat.table-lookup-candidate",
+            "table-lookup-candidate",
+        ),
+        (
+            """
+def highest_score(scores: list[int]) -> int | None:
+    best = None
+    for score in scores:
+        if best is None or score > best:
+            best = score
+    return best
+""",
+            "ai-bloat.stdlib-replacement-candidate",
+            "stdlib-replacement-candidate",
+        ),
+    ],
+)
+def test_expanded_simplification_patterns_emit_metadata(
+    tmp_path: Path,
+    source: str,
+    expected_rule: str,
+    expected_pattern: str,
+) -> None:
+    target = _write(tmp_path, source)
+
+    findings = run_ai_bloat([target])
+
+    matching = [finding for finding in findings if finding.rule == expected_rule]
+    assert len(matching) == 1
+    assert matching[0].category == "ai_bloat"
+    assert matching[0].severity == "info"
+    assert matching[0].confidence == "high"
+    assert matching[0].canonical_pattern == expected_pattern
+    assert matching[0].rewrite_hint
+    assert matching[0].estimated_deletion_lines is not None
+
+
 def test_redundant_intermediate_ignores_reused_names(tmp_path: Path) -> None:
     target = _write(
         tmp_path,
@@ -94,6 +201,24 @@ def total(values: list[int]) -> tuple[int, str]:
     result = sum(values)
     label = f"total={result}"
     return result, label
+""",
+    )
+
+    assert run_ai_bloat([target]) == []
+
+
+def test_simplification_patterns_ignore_ambiguous_domain_logic(tmp_path: Path) -> None:
+    target = _write(
+        tmp_path,
+        """
+def classify_score(score: int) -> str:
+    if score > 90:
+        return "excellent"
+    if score > 70:
+        return "good"
+    if score > 50:
+        return "review"
+    return "blocked"
 """,
     )
 

--- a/tests/unit/specfact_code_review/tools/test_ast_clean_code_runner.py
+++ b/tests/unit/specfact_code_review/tools/test_ast_clean_code_runner.py
@@ -53,6 +53,59 @@ def second(values: list[int]) -> list[int]:
     assert any(finding.category == "dry" and finding.rule == "dry.duplicate-function-shape" for finding in findings)
 
 
+def test_duplicate_intent_finding_includes_related_locations_and_intent_key(tmp_path: Path) -> None:
+    file_path = tmp_path / "customer_orders.py"
+    file_path.write_text(
+        """
+def normalize_customer_order(order: dict[str, object]) -> dict[str, object]:
+    cleaned: dict[str, object] = {}
+    for key, value in order.items():
+        if value is not None:
+            cleaned[key] = str(value).strip()
+    return cleaned
+
+
+def prepare_customer_order(payload: dict[str, object]) -> dict[str, object]:
+    normalized: dict[str, object] = {}
+    for name, item in payload.items():
+        if item is not None:
+            normalized[name] = str(item).strip()
+    return normalized
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    findings = run_ast_clean_code([file_path])
+    duplicate = next(finding for finding in findings if finding.rule == "dry.duplicate-function-shape")
+
+    assert duplicate.intent_key == "customer-order"
+    assert duplicate.rewrite_hint
+    assert duplicate.related_locations is not None
+    assert duplicate.related_locations[0].path == str(file_path)
+    assert duplicate.related_locations[0].start_line == 1
+
+
+def test_duplicate_intent_does_not_group_similar_names_without_matching_shape(tmp_path: Path) -> None:
+    file_path = tmp_path / "customer_orders.py"
+    file_path.write_text(
+        """
+def normalize_customer_order(order: dict[str, object]) -> dict[str, object]:
+    return {key: value for key, value in order.items() if value is not None}
+
+
+def prepare_customer_order(payload: dict[str, object]) -> list[str]:
+    return [str(item) for item in payload.values()]
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    findings = run_ast_clean_code([file_path])
+
+    assert not any(finding.rule == "dry.duplicate-function-shape" for finding in findings)
+
+
 def test_run_ast_clean_code_reports_mixed_dependency_roles(tmp_path: Path) -> None:
     file_path = tmp_path / "target.py"
     file_path.write_text(

--- a/tests/unit/test_bundle_resource_payloads.py
+++ b/tests/unit/test_bundle_resource_payloads.py
@@ -269,6 +269,7 @@ def test_code_review_artifact_contains_policy_pack_payload(tmp_path: Path) -> No
     assert "specfact-code-review/resources/policy-packs/specfact/clean-code-principles.yaml" in names
     assert "specfact-code-review/resources/policy-packs/specfact/ai-bloat-patterns.yaml" in names
     assert "specfact-code-review/resources/semgrep-rules/ai-bloat.yaml" in names
+    assert "specfact-code-review/src/specfact_code_review/resources/skills/specfact-code-review/SKILL.md" in names
 
 
 def test_project_artifact_contains_runtime_generator_templates(tmp_path: Path) -> None:

--- a/tests/unit/test_check_prompt_commands_script.py
+++ b/tests/unit/test_check_prompt_commands_script.py
@@ -11,6 +11,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "check-prompt-commands.py"
 DOCS_REVIEW_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs-review.yml"
 PRE_COMMIT_SCRIPT = REPO_ROOT / "scripts" / "pre-commit-quality-checks.sh"
+SIMPLIFY_PROMPT = REPO_ROOT / "packages" / "specfact-project" / "resources" / "prompts" / "specfact.08-simplify.md"
+PROJECT_REVIEW_PROMPT = REPO_ROOT / "packages" / "specfact-project" / "resources" / "prompts" / "specfact.03-review.md"
 
 
 def _load_script():
@@ -238,9 +240,35 @@ def test_docs_review_workflow_runs_prompt_command_validation() -> None:
 def test_pre_commit_runs_prompt_validation_before_safe_change_skip() -> None:
     script = PRE_COMMIT_SCRIPT.read_text(encoding="utf-8")
 
+    assert "check-prompt-commands.py" in script
     validation_index = script.index("run_prompt_command_validation_gate")
     safe_change_index = script.index("if check_safe_change; then")
     assert validation_index < safe_change_index
+
+
+def test_simplify_prompt_groups_by_simplification_metadata_before_edits() -> None:
+    prompt = SIMPLIFY_PROMPT.read_text(encoding="utf-8")
+
+    assert "intent_key" in prompt
+    assert "related locations" in prompt.lower()
+    assert "file or domain" in prompt.lower()
+    assert "accept, reject, skip, or explain" in prompt
+    assert "Apply only accepted edits" in prompt
+    assert "Guidance Character" in prompt
+    assert "specfact code review run --help" in prompt
+    assert "hatch run validate-prompt-commands" in prompt
+    assert "hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump" in prompt
+
+
+def test_project_review_prompt_has_self_healing_cli_and_verification_guidance() -> None:
+    prompt = PROJECT_REVIEW_PROMPT.read_text(encoding="utf-8")
+
+    assert "Guidance Character" in prompt
+    assert "self-heal command drift" in prompt
+    assert "specfact plan review --help" in prompt
+    assert "Do not write `.specfact/` artifacts directly" in prompt
+    assert "hatch run validate-prompt-commands" in prompt
+    assert "hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump" in prompt
 
 
 def test_pre_commit_prompt_validation_covers_cli_command_implementations() -> None:


### PR DESCRIPTION
## Summary
- add simplification metadata and --focus simplify support for code review reports
- expand deterministic AI-bloat and duplicate-intent simplification findings
- update review/simplify prompts, docs, module packaging, and reusable code-review skill guidance
- address review findings for simplify docs, deterministic metadata filtering, override validation, and simplify-scoped score neutrality

## Verification
- openspec validate code-review-11-simplification-feedback-loop --strict
- hatch run format
- hatch run type-check
- hatch run lint
- hatch run yaml-lint
- hatch run check-bundle-imports
- hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump
- hatch run pytest tests/unit/specfact_code_review/run/test_findings.py tests/unit/specfact_code_review/run/test_scorer.py tests/unit/specfact_code_review/run/test_runner.py tests/unit/specfact_code_review/review/test_commands.py tests/unit/docs/test_code_review_docs_parity.py tests/unit/test_check_prompt_commands_script.py -q
- hatch run pytest tests/unit/specfact_code_review/review/test_commands.py --cov=specfact_code_review.review.commands --cov-report=term-missing -q
- hatch run contract-test
- hatch run smart-test
- hatch run test
- hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed
- pre-commit on d1dd700: signature check, format, yaml-lint, check-bundle-imports, lint, staged code review, and contract-test all passed
- real-world local linked module smoke: SPECFACT_MODULES_ROOTS=<feature-worktree>/packages SPECFACT_ALLOW_UNSIGNED=1 python -m specfact_cli.cli code review rules init --ide codex, then codex -C /tmp/specfact-skill-smoke-roots debug prompt-input "Use specfact-code-review" confirmed Codex listed specfact-code-review from the installed .codex skill path

Notes: the latest changed-scope SpecFact review exits 0. Remaining findings are non-blocking Typer wrapper shape advisories and score-neutral ai-bloat LOC-vs-complexity hints, not the pasted review findings. Initial skill smoke without SPECFACT_MODULES_ROOTS exposed that the user-scoped installed module can mask a local checkout, so the recorded smoke pins the local module root explicitly.