### PR TITLE
fix(code-review): stabilize PR 289 guidance checks

### DIFF
--- a/docs/bundles/code-review/run.md
+++ b/docs/bundles/code-review/run.md
@@ -107,7 +107,7 @@ When an IDE does not support bundled prompts or skills, print the same guided si
 specfact code review run --instructions
 ```
 
-The output explains how to remove AI bloat and apply clean-code simplifications using SpecFact evidence, including `safe_mechanical`, `needs_tests`, `design_judgment`, and `preserve` handling, patch previews, conservative keep/skip defaults, and per-file validation. It also tells assistants how to handle clean PR branches where `--scope changed` has no worktree files: find branch-delta Python files with a base-ref diff such as `git diff --name-only origin/dev...HEAD -- '*.py' '*.pyi'`, review those files as explicit positional files, and treat findings without `guidance_kind` as unguided advisories rather than auto-fix input.
+The output explains how to remove AI bloat and apply clean-code simplifications using SpecFact evidence, including `safe_mechanical`, `needs_tests`, `design_judgment`, and `preserve` handling, patch previews, conservative keep/skip defaults, and per-file validation. It also tells assistants how to handle clean PR branches where `--scope changed` has no worktree files: find branch-delta Python files with a base-ref diff such as `git diff --name-only <base-ref>...HEAD -- '*.py' '*.pyi'`, review those files as explicit positional files, and treat findings without `guidance_kind` as unguided advisories rather than auto-fix input.
 
 ### Positional files (explicit Python paths)
 

--- a/docs/modules/code-review.md
+++ b/docs/modules/code-review.md
@@ -129,7 +129,7 @@ AI bloat with SpecFact. The instructions explain the expected report file,
 for `design_judgment`, and per-file validation. They also cover clean PR
 branches where `--scope changed` has no worktree files: the assistant should
 find branch-delta Python files with a base-ref diff such as
-`git diff --name-only origin/dev...HEAD -- '*.py' '*.pyi'`, review those files
+`git diff --name-only <base-ref>...HEAD -- '*.py' '*.pyi'`, review those files
 as explicit positional files, and treat findings without `guidance_kind` as
 unguided advisories, not auto-fix input.
 

--- a/openspec/changes/code-review-12-guided-simplification-enforcement/TDD_EVIDENCE.md
+++ b/openspec/changes/code-review-12-guided-simplification-enforcement/TDD_EVIDENCE.md
@@ -81,6 +81,22 @@
   - Result after AI instructions fallback: PASS, CI exit 0, 0 findings.
 - `openspec validate code-review-12-guided-simplification-enforcement --strict`
   - Result after AI instructions fallback: valid.
+- `hatch run pytest tests/unit/specfact_code_review/review/test_commands.py::test_review_run_help_lists_simplify_focus tests/unit/specfact_code_review/review/test_commands.py::test_review_run_instructions_prints_ai_workflow_without_running_review tests/unit/docs/test_code_review_docs_parity.py::test_code_review_run_doc_mentions_public_ty_options tests/unit/test_guided_simplify_resources.py -q`
+  - Result after PR #289 follow-up fixes: 5 passed.
+- `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump --version-check-base origin/dev`
+  - Result after PR #289 follow-up fixes: verified 6 module manifests.
+- `hatch run yaml-lint`
+  - Result after PR #289 follow-up fixes: validated 6 manifests and `registry/index.json`.
+- `openspec validate code-review-12-guided-simplification-enforcement --strict`
+  - Result after PR #289 follow-up fixes: valid.
+- `hatch run contract-test`
+  - Result after PR #289 follow-up fixes: 773 passed, 2 warnings.
+- `hatch run type-check`
+  - Result after PR #289 follow-up fixes: 0 errors, 0 warnings, 0 notes.
+- `hatch run lint`
+  - Result after PR #289 follow-up fixes: formatted check passed, basedpyright reported 0 errors/0 warnings/0 notes, pylint score 10.00/10.
+- `hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed`
+  - Result after PR #289 follow-up fixes: PASS, CI exit 0, score 120, 0 findings.
 
 ## Local Dev-Link Validation
 
@@ -106,4 +122,8 @@
 
 ## Signing Note
 
-`hatch run verify-modules-signature --payload-from-filesystem --require-signature --enforce-version-bump --version-check-base origin/main` passed before the final source edits, verifying the existing `0.47.23` signature was a real cryptographic signature. The final local payload is refreshed at `0.47.25` for `specfact-code-review` and `0.41.16` for `specfact-project` with `hatch run sign-modules --changed-only --base-ref origin/dev --bump-version patch --allow-unsigned --payload-from-filesystem`, because no private signing key is available in the local worktree. Cryptographic signature restoration remains an approval-time or post-merge signing step.
+`0.47.25` for `specfact-code-review` and `0.41.16` for `specfact-project` were intermediate local refreshes produced with `hatch run sign-modules --changed-only --base-ref origin/dev --bump-version patch --allow-unsigned --payload-from-filesystem`, because no private signing key is available in the local worktree. The reviewed PR #289 head shipped `specfact-code-review` `0.47.26` and `specfact-project` `0.41.17`; the signing/publish follow-up used the same payload mode through `python scripts/sign-modules.py --changed-only --base-ref "$MERGE_BASE" --bump-version patch --payload-from-filesystem` and the publish workflow's same-version signing path. `hatch run verify-modules-signature --payload-from-filesystem --require-signature --enforce-version-bump --version-check-base origin/main` passed for that shipped head, verifying the final module manifest checksums and signatures.
+
+This PR #289 follow-up changes the `specfact-code-review` source payload again, so the local manifest is refreshed to `0.47.27` with `hatch run sign-modules --changed-only --base-ref origin/dev --bump-version patch --allow-unsigned --payload-from-filesystem`. CI must restore the cryptographic signature with the repository private key before the follow-up lands on `main`.
+
+The `packages/specfact-code-review/module-package.yaml` `integrity.checksum` covers the canonical module source payload, while `registry/modules/specfact-code-review-0.47.26.tar.gz.sha256` covers the published tarball artifact. These digests are intentionally different; the registry sidecar matches the `0.47.26` tarball SHA256, and the manifest signature verifier validates the source-payload checksum/signature. The next publish step will produce the corresponding `0.47.27` registry artifact after signing.

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.26
+version: 0.47.27
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:87a17f884d717d6def557d2bfc3076288d610e4751a38b12aed4e72e64ed32e2
-  signature: uGnmRW920celR5bugIuq8XLjBJ4qdWT/WZmUz/h/Gk7/V0VD7NY+F7O0wB8BgaClL55yxochTTFEjEM18iHmCA==
+  checksum: sha256:a86d8cfde2035059414370bdadd323dcdcf02bd5104e3b30b252bc350a96cd98

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:a86d8cfde2035059414370bdadd323dcdcf02bd5104e3b30b252bc350a96cd98
+  signature: F/Ld51xKWPkQWWS8c00cs9UTbe/kJJ6chBh08sFuKTlAwpRTydf8//wLVaDuI2jt4jX0CwYaHnBqoTd0ELMLAQ==

--- a/packages/specfact-code-review/src/specfact_code_review/review/commands.py
+++ b/packages/specfact-code-review/src/specfact_code_review/review/commands.py
@@ -33,7 +33,7 @@ Use this when the user asks to remove AI bloat, simplify code, apply clean-code 
 1. Generate evidence first:
    specfact code review run --scope changed --focus simplify --json --out .specfact/code-review-simplify.json
 
-   If the worktree is clean on a PR branch and --scope changed finds no files, review the branch-delta Python files as explicit positional files and omit --scope. Find them with the PR base ref, for example: git diff --name-only origin/dev...HEAD -- '*.py' '*.pyi'
+   If the worktree is clean on a PR branch and --scope changed finds no files, review the branch-delta Python files as explicit positional files and omit --scope. Find them with the PR base ref, for example: git diff --name-only <base-ref>...HEAD -- '*.py' '*.pyi'
 
 2. Treat guidance_kind as the action contract:
    - safe_mechanical: apply only after local safety checks pass.

--- a/tests/unit/specfact_code_review/review/test_commands.py
+++ b/tests/unit/specfact_code_review/review/test_commands.py
@@ -19,10 +19,11 @@ def _plain_output(text: str) -> str:
 
 def test_review_run_help_lists_simplify_focus() -> None:
     result = runner.invoke(app, ["review", "run", "--help"])
+    output = _plain_output(result.output)
 
     assert result.exit_code == 0
-    assert "simplify" in result.output
-    assert "--instructions" in result.output
+    assert "simplify" in output
+    assert "--instructions" in output
 
 
 def test_review_run_instructions_prints_ai_workflow_without_running_review(monkeypatch: Any) -> None:
@@ -38,7 +39,7 @@ def test_review_run_instructions_prints_ai_workflow_without_running_review(monke
     assert "safe_mechanical" in result.output
     assert "design_judgment" in result.output
     assert "branch-delta Python files" in result.output
-    assert "git diff --name-only origin/dev...HEAD" in result.output
+    assert "git diff --name-only <base-ref>...HEAD" in result.output
     assert "Findings without guidance_kind are unguided advisories" in result.output
     assert "exact patch preview" in result.output
     assert "default to keep or skip" in result.output


### PR DESCRIPTION
## Summary
- Fix CI contract-test failure by stripping ANSI from review help assertions before checking --instructions
- Replace hard-coded origin/dev...HEAD guidance with <base-ref>...HEAD across CLI guidance, tests, and docs
- Bump specfact-code-review to 0.47.27 with refreshed source-payload checksum; CI signing restored the cryptographic manifest signature

## Validation
- hatch run pytest tests/unit/specfact_code_review/review/test_commands.py::test_review_run_help_lists_simplify_focus tests/unit/specfact_code_review/review/test_commands.py::test_review_run_instructions_prints_ai_workflow_without_running_review tests/unit/docs/test_code_review_docs_parity.py::test_code_review_run_doc_mentions_public_ty_options tests/unit/test_guided_simplify_resources.py -q
- hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump --version-check-base origin/dev
- hatch run yaml-lint
- openspec validate code-review-12-guided-simplification-enforcement --strict
- hatch run contract-test
- hatch run type-check
- hatch run lint
- hatch run specfact code review run --bug-hunt --json --out .specfact/code-review.json --scope changed
- CI signing follow-up: hatch run verify-modules-signature --payload-from-filesystem --require-signature --enforce-version-bump --version-check-base origin/dev