### PR TITLE
docs: align flat command references

### DIFF
--- a/packages/specfact-backlog/module-package.yaml
+++ b/packages/specfact-backlog/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-backlog
-version: 0.41.29
+version: 0.41.30
 commands:
   - backlog
 tier: official
@@ -27,5 +27,4 @@ schema_extensions:
   project_metadata:
     - backlog_core.backlog_config
 integrity:
-  checksum: sha256:f822ed52ec5f6a8f2cbf77108115fbe54620fc7a7fa9197e63fc4146f8088941
-  signature: zdqcnaRFt1OqVK8SAu9NgI8EAC6Nv1jGqgtH1OcXQeuM3P+dlTSCeyb+6jnPj5wqHt5BUDfoVrprePrLWwjjAA==
+  checksum: sha256:04fd4c5154c053b14ada29f31fef1ad96ac904384c5fca28cae187ef16cc0bb0

--- a/packages/specfact-backlog/module-package.yaml
+++ b/packages/specfact-backlog/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-backlog
-version: 0.41.28
+version: 0.41.29
 commands:
   - backlog
 tier: official
@@ -27,5 +27,4 @@ schema_extensions:
   project_metadata:
     - backlog_core.backlog_config
 integrity:
-  checksum: sha256:7aee384a5e0b1b6cf1eaa54e259d35efab0fb38fb4498c171d2fe37b0d6d94c3
-  signature: Sx6pQMGz1pjW3LAnuGtI2olvlX5OcetOOW5L4CWPx+RmsWQRLEgMqkonKUSiJMe90NXzgNvfqtqTPKB7gS5hCg==
+  checksum: sha256:f822ed52ec5f6a8f2cbf77108115fbe54620fc7a7fa9197e63fc4146f8088941

--- a/packages/specfact-backlog/module-package.yaml
+++ b/packages/specfact-backlog/module-package.yaml
@@ -28,3 +28,4 @@ schema_extensions:
     - backlog_core.backlog_config
 integrity:
   checksum: sha256:04fd4c5154c053b14ada29f31fef1ad96ac904384c5fca28cae187ef16cc0bb0
+  signature: bXUHGlYfxsuUgBfZBw8hfTDDFjq/gO27qxfFLxtQyUxTIav5Os3AR6i0j/I6kAzsv2zu1TK4Qc1utxVp04OUBQ==

--- a/packages/specfact-backlog/module-package.yaml
+++ b/packages/specfact-backlog/module-package.yaml
@@ -28,3 +28,4 @@ schema_extensions:
     - backlog_core.backlog_config
 integrity:
   checksum: sha256:f822ed52ec5f6a8f2cbf77108115fbe54620fc7a7fa9197e63fc4146f8088941
+  signature: zdqcnaRFt1OqVK8SAu9NgI8EAC6Nv1jGqgtH1OcXQeuM3P+dlTSCeyb+6jnPj5wqHt5BUDfoVrprePrLWwjjAA==

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.45
+version: 0.47.46
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:9e09dfd0f2987054e981631eb0ea0d15ad8d917a4080871311a3f0a3415b0e29
-  signature: gW1Dd9nZIk/FpkC8waZB6lGYHeiW61KU07mOEYrBzN+7ZNR6hgKa1kKGdXwDA0eJlVjOVjmywybkjpckj7PfDQ==
+  checksum: sha256:0fedb467919d0ad5315bb11200e6c9366d5922b613b06c9cebfe24a7f3039b2e

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.44
+version: 0.47.45
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:cecd1326fbe7263666fd436c030c86b64218c33798ad8eb0d72f0fa4d5b48dde
-  signature: vf+BeYHAPkQrWhkw0j8PWzFBAwlNXkXRix6mj525QTiOzAP2PlkMHgvPsOLnDhW9/F+YJw7cqUqLHamgUn/xCA==
+  checksum: sha256:9e09dfd0f2987054e981631eb0ea0d15ad8d917a4080871311a3f0a3415b0e29

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:0fedb467919d0ad5315bb11200e6c9366d5922b613b06c9cebfe24a7f3039b2e
+  signature: +fR+YZcmqgLSY5YwXC2XjFReJ0XMDxBpaFNJDO0XdOeNkXNTwhDILye/trX+GWx5BTF8xUOjm7lww8Pa0szhCg==

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:9e09dfd0f2987054e981631eb0ea0d15ad8d917a4080871311a3f0a3415b0e29
+  signature: gW1Dd9nZIk/FpkC8waZB6lGYHeiW61KU07mOEYrBzN+7ZNR6hgKa1kKGdXwDA0eJlVjOVjmywybkjpckj7PfDQ==

--- a/packages/specfact-codebase/module-package.yaml
+++ b/packages/specfact-codebase/module-package.yaml
@@ -25,3 +25,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:f9ae8e10498fd0df61213dde6c23743508b5cbed39fe120b0a87ddc8c46dc603
+  signature: 8PfWLx5IKgXLonU71BIbs4dz6ORyO/nCLPOM2VKb8gpDlP1qodxiBaZGiouNk1Hu8dHTDPN1BBl5YtWq+tXHDg==

--- a/packages/specfact-codebase/module-package.yaml
+++ b/packages/specfact-codebase/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-codebase
-version: 0.41.12
+version: 0.41.13
 commands:
   - code
 tier: official
@@ -24,5 +24,4 @@ description: Official SpecFact codebase bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:fab6a4686c29301d877713b12abfe70d5a29871d6f388eaa69d9de93e10796a4
-  signature: C/mcMpoLaItu8+R5PoPsOKtLzHOWN5iu/TpsntC7Y3vSAEpAj+dnIYksNxRdoR31OsGAZChvcKiUXrk5XVsAAw==
+  checksum: sha256:f9ae8e10498fd0df61213dde6c23743508b5cbed39fe120b0a87ddc8c46dc603

--- a/packages/specfact-codebase/module-package.yaml
+++ b/packages/specfact-codebase/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-codebase
-version: 0.41.11
+version: 0.41.12
 commands:
   - code
 tier: official
@@ -24,5 +24,4 @@ description: Official SpecFact codebase bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:21d8bc02de6e01ecc0b7d68c2ba9f736f90f97b128eb925aca721dbd02874c74
-  signature: H1rUcKFH31LleuADUIuLwghMtHwtKWp+4o5cCZbObumSil9c27bIrdH6u8K04AYChea0vHZld4Pr7S2oIDBZBQ==
+  checksum: sha256:fab6a4686c29301d877713b12abfe70d5a29871d6f388eaa69d9de93e10796a4

--- a/packages/specfact-codebase/module-package.yaml
+++ b/packages/specfact-codebase/module-package.yaml
@@ -25,3 +25,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:fab6a4686c29301d877713b12abfe70d5a29871d6f388eaa69d9de93e10796a4
+  signature: C/mcMpoLaItu8+R5PoPsOKtLzHOWN5iu/TpsntC7Y3vSAEpAj+dnIYksNxRdoR31OsGAZChvcKiUXrk5XVsAAw==

--- a/packages/specfact-codebase/src/specfact_codebase/analyze/commands.py
+++ b/packages/specfact-codebase/src/specfact_codebase/analyze/commands.py
@@ -3,6 +3,10 @@ Analyze command - Analyze codebase for contract coverage and quality.
 
 This module provides commands for analyzing codebases to determine
 contract coverage, code quality metrics, and enhancement opportunities.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 from __future__ import annotations
@@ -55,7 +59,7 @@ def analyze_contracts(
     bundle: str | None = typer.Option(
         None,
         "--bundle",
-        help="Project bundle name (e.g., legacy-api). Default: active plan from 'specfact plan select'",
+        help="Project bundle name (e.g., legacy-api). Default: active project bundle configuration",
     ),
 ) -> None:
     """
@@ -68,7 +72,7 @@ def analyze_contracts(
     - **Target/Input**: --repo, --bundle (required)
 
     **Examples:**
-        specfact analyze contracts --repo . --bundle legacy-api
+        specfact code analyze contracts --repo . --bundle legacy-api
     """
     if is_debug_mode():
         debug_log_operation("command", "analyze contracts", "started", extra={"repo": str(repo), "bundle": bundle})
@@ -88,7 +92,7 @@ def analyze_contracts(
                     extra={"reason": "no_bundle"},
                 )
             console.print("[bold red]✗[/bold red] Bundle name required")
-            console.print("[yellow]→[/yellow] Use --bundle option or run 'specfact plan select' to set active plan")
+            console.print("[yellow]→[/yellow] Use --bundle option or configure an active project bundle")
             raise typer.Exit(1)
         console.print(f"[dim]Using active plan: {bundle}[/dim]")
 

--- a/packages/specfact-codebase/src/specfact_codebase/drift/commands.py
+++ b/packages/specfact-codebase/src/specfact_codebase/drift/commands.py
@@ -3,6 +3,10 @@ Drift command - Detect misalignment between code and specifications.
 
 This module provides commands for detecting drift between actual code/tests
 and specifications.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 from __future__ import annotations
@@ -41,7 +45,7 @@ validate_bundle = module_io_shim.validate_bundle
 def detect_drift(
     # Target/Input
     bundle: str | None = typer.Argument(
-        None, help="Project bundle name (e.g., legacy-api). Default: active plan from 'specfact plan select'"
+        None, help="Project bundle name (e.g., legacy-api). Default: active project bundle configuration"
     ),
     repo: Path = typer.Option(
         Path("."),
@@ -79,8 +83,8 @@ def detect_drift(
     - **Output**: --format, --out
 
     **Examples:**
-        specfact drift detect legacy-api --repo .
-        specfact drift detect my-bundle --repo . --format json --out drift-report.json
+        specfact code drift detect legacy-api --repo .
+        specfact code drift detect my-bundle --repo . --format json --out drift-report.json
     """
     if is_debug_mode():
         debug_log_operation(
@@ -101,7 +105,7 @@ def detect_drift(
                     "command", "drift detect", "failed", error="Bundle name required", extra={"reason": "no_bundle"}
                 )
             console.print("[bold red]✗[/bold red] Bundle name required")
-            console.print("[yellow]→[/yellow] Use --bundle option or run 'specfact plan select' to set active plan")
+            console.print("[yellow]→[/yellow] Use --bundle option or configure an active project bundle")
             raise typer.Exit(1)
         console.print(f"[dim]Using active plan: {bundle}[/dim]")
     from specfact_codebase.sync.drift_detector import DriftDetector

--- a/packages/specfact-codebase/src/specfact_codebase/import_cmd/commands.py
+++ b/packages/specfact-codebase/src/specfact_codebase/import_cmd/commands.py
@@ -1,4 +1,9 @@
-"""Code-owned import command surface for brownfield workflows."""
+"""Code-owned import command surface for brownfield workflows.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
+"""
 
 from __future__ import annotations
 
@@ -78,7 +83,7 @@ def import_codebase(
     ctx: typer.Context,
     bundle: str | None = typer.Argument(
         None,
-        help="Project bundle name (e.g., legacy-api, auth-module). Default: active plan from 'specfact plan select'.",
+        help="Project bundle name (e.g., legacy-api, auth-module). Default: active project bundle configuration.",
     ),
     repo: Path = typer.Option(
         Path("."),

--- a/packages/specfact-codebase/src/specfact_codebase/repro/commands.py
+++ b/packages/specfact-codebase/src/specfact_codebase/repro/commands.py
@@ -3,6 +3,10 @@ Repro command - Run full validation suite for reproducibility.
 
 This module provides commands for running comprehensive validation
 including linting, type checking, contract exploration, and tests.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 from __future__ import annotations
@@ -210,10 +214,10 @@ def main(
     Works on external repositories without requiring SpecFact CLI adoption.
 
     Example:
-        specfact repro --verbose --budget 120
-        specfact repro --repo /path/to/external/repo --verbose
-        specfact repro --fix --budget 120
-        specfact repro --sidecar --sidecar-bundle legacy-api --repo /path/to/repo
+        specfact code repro --verbose --budget 120
+        specfact code repro --repo /path/to/external/repo --verbose
+        specfact code repro --fix --budget 120
+        specfact code repro --sidecar --sidecar-bundle legacy-api --repo /path/to/repo
     """
     # If a subcommand was invoked, don't run the main validation
     if ctx.invoked_subcommand is not None:
@@ -467,9 +471,9 @@ def setup(
     - Provides guidance on next steps
 
     Example:
-        specfact repro setup
-        specfact repro setup --repo /path/to/repo
-        specfact repro setup --install-crosshair
+        specfact code repro setup
+        specfact code repro setup --repo /path/to/repo
+        specfact code repro setup --install-crosshair
     """
     console.print("[bold cyan]Setting up CrossHair configuration...[/bold cyan]")
     console.print(f"[dim]Repository: {repo}[/dim]\n")
@@ -559,7 +563,7 @@ def setup(
     # Summary
     console.print("\n[bold green]✓[/bold green] Setup complete!")
     console.print("\n[bold]Next steps:[/bold]")
-    console.print("  1. Run [cyan]specfact repro[/cyan] to execute validation checks")
+    console.print("  1. Run [cyan]specfact code repro[/cyan] to execute validation checks")
     if not crosshair_available:
         console.print("  2. Install crosshair-tool to enable contract exploration:")
         if env_info.manager == "hatch":

--- a/packages/specfact-govern/module-package.yaml
+++ b/packages/specfact-govern/module-package.yaml
@@ -20,3 +20,4 @@ category: govern
 bundle_group_command: govern
 integrity:
   checksum: sha256:e9d5fe437db8a01693a2558b61294605bda1a54322debfdc9cb216c29254a654
+  signature: JUL2blqZMy6aEGK18+MM0DIHnai5FtPPrJktnrabJPEsCKnRVcVxC+wYe7dH958qYbE5fhuPbpNv8v0JtbOFCg==

--- a/packages/specfact-govern/module-package.yaml
+++ b/packages/specfact-govern/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-govern
-version: 0.40.23
+version: 0.40.24
 commands:
   - govern
 tier: official
@@ -19,5 +19,4 @@ description: Official SpecFact governance bundle package.
 category: govern
 bundle_group_command: govern
 integrity:
-  checksum: sha256:b08213f3b3dfe4dee712646272a204b2f28cd57cf6145edd8d851abacd3635c5
-  signature: HY3pzZz8ryiohpLlG0eVcQIda5/Ls6EMAOwDxQZNKbld8Zmg6kZD0pQtMQ86e2i774D963G6lZvaGs/QE3LYBA==
+  checksum: sha256:c12b6c4cffa7199dfc625556f9840603f6ef1bbd43ed9ce7c1e5b254da775515

--- a/packages/specfact-govern/module-package.yaml
+++ b/packages/specfact-govern/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-govern
-version: 0.40.24
+version: 0.40.25
 commands:
   - govern
 tier: official
@@ -19,5 +19,4 @@ description: Official SpecFact governance bundle package.
 category: govern
 bundle_group_command: govern
 integrity:
-  checksum: sha256:c12b6c4cffa7199dfc625556f9840603f6ef1bbd43ed9ce7c1e5b254da775515
-  signature: LtQ4pQ7MdRcfFKQBNeWLb+PC+AMNsRntbSUVWbvUEH0LB+2SzmywRchR1D0b21RFkHJ2GcayZijaOZ48IovBCg==
+  checksum: sha256:e9d5fe437db8a01693a2558b61294605bda1a54322debfdc9cb216c29254a654

--- a/packages/specfact-govern/module-package.yaml
+++ b/packages/specfact-govern/module-package.yaml
@@ -20,3 +20,4 @@ category: govern
 bundle_group_command: govern
 integrity:
   checksum: sha256:c12b6c4cffa7199dfc625556f9840603f6ef1bbd43ed9ce7c1e5b254da775515
+  signature: LtQ4pQ7MdRcfFKQBNeWLb+PC+AMNsRntbSUVWbvUEH0LB+2SzmywRchR1D0b21RFkHJ2GcayZijaOZ48IovBCg==

--- a/packages/specfact-govern/src/specfact_govern/enforce/commands.py
+++ b/packages/specfact-govern/src/specfact_govern/enforce/commands.py
@@ -3,6 +3,10 @@ Enforce command - Configure contract validation quality gates.
 
 This module provides commands for configuring enforcement modes
 and validation policies.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 from __future__ import annotations
@@ -213,7 +217,7 @@ def enforce_sdd(
     # Target/Input
     bundle: str | None = typer.Argument(
         None,
-        help="Project bundle name (e.g., legacy-api, auth-module). Default: active plan from 'specfact plan select'",
+        help="Project bundle name (e.g., legacy-api, auth-module). Default: active project bundle configuration",
     ),
     sdd: Path | None = typer.Option(
         None,
@@ -278,7 +282,7 @@ def enforce_sdd(
                     "command", "enforce sdd", "failed", error="Bundle name required", extra={"reason": "no_bundle"}
                 )
             console.print("[bold red]✗[/bold red] Bundle name required")
-            console.print("[yellow]→[/yellow] Use --bundle option or run 'specfact plan select' to set active plan")
+            console.print("[yellow]→[/yellow] Use --bundle option or configure an active project bundle")
             raise typer.Exit(1)
         console.print(f"[dim]Using active plan: {bundle}[/dim]")
 
@@ -309,7 +313,7 @@ def enforce_sdd(
                     extra={"reason": "bundle_missing"},
                 )
             console.print(f"[bold red]✗[/bold red] Project bundle not found: {bundle_dir}")
-            console.print(f"[dim]Create one with: specfact plan init {bundle}[/dim]")
+            console.print(f"[dim]Create or configure project bundle '{bundle}' before rerunning.[/dim]")
             raise typer.Exit(1)
 
         # Find SDD manifest path using discovery utility
@@ -328,7 +332,7 @@ def enforce_sdd(
                 )
             console.print("[bold red]✗[/bold red] SDD manifest not found")
             console.print(f"[dim]Searched for: .specfact/projects/{bundle}/sdd.yaml (bundle-specific)[/dim]")
-            console.print(f"[dim]Create one with: specfact plan harden {bundle}[/dim]")
+            console.print(f"[dim]Update the SDD manifest for '{bundle}' before rerunning.[/dim]")
             raise typer.Exit(1)
 
         sdd = discovered_sdd
@@ -378,7 +382,7 @@ def enforce_sdd(
                     severity=DeviationSeverity.HIGH,
                     description=f"SDD bundle hash mismatch: expected {project_hash[:16]}..., got {sdd_manifest.plan_bundle_hash[:16]}...",
                     location=str(sdd),
-                    fix_hint=f"Run 'specfact plan harden {bundle}' to update SDD manifest with current bundle hash",
+                    fix_hint=f"Update SDD manifest for {bundle} with current bundle hash",
                 )
                 report.add_deviation(deviation)
                 console.print("[bold red]✗[/bold red] Hash mismatch detected")
@@ -559,9 +563,7 @@ def enforce_sdd(
                     console.print("   - Features (add/remove/update)")
                     console.print("   - Stories (add/remove/update)")
                     console.print("   - Product, idea, business, or clarifications")
-                    console.print(
-                        f"\n   [bold]Fix:[/bold] Run [cyan]specfact plan harden {bundle}[/cyan] to update the SDD manifest"
-                    )
+                    console.print(f"\n   [bold]Fix:[/bold] Update the SDD manifest for {bundle}")
                     console.print(
                         "   [dim]This updates the SDD with the current bundle hash and regenerates HOW sections[/dim]"
                     )
@@ -576,11 +578,11 @@ def enforce_sdd(
                         f"   - Invariants/feature: {metrics.invariants_per_feature:.2f} (required: {thresholds.invariants_per_feature})"
                     )
                     console.print("\n   [bold]Fix:[/bold] Add more contracts to stories and invariants to features")
-                    console.print("   [dim]Tip: Use 'specfact plan review' to identify areas needing contracts[/dim]")
+                    console.print("   [dim]Tip: review project bundle contract coverage before rerunning[/dim]")
 
                 console.print("\n[bold cyan]Next Steps:[/bold cyan]")
                 if hash_mismatches:
-                    console.print(f"   1. Update SDD: [cyan]specfact plan harden {bundle}[/cyan]")
+                    console.print(f"   1. Update the SDD manifest for {bundle}")
                 if coverage_issues:
                     console.print("   2. Add contracts: Review features and add @icontract decorators")
                     console.print("   3. Re-validate: Run this command again after fixes")

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-project
-version: 0.41.24
+version: 0.41.25
 commands:
   - project
   - plan
@@ -27,5 +27,4 @@ core_compatibility: '>=0.40.0,<1.0.0'
 description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
-  checksum: sha256:2362ef8f6141c39ac70653f7c3de617c8b2335a979c3d0758b222b313f08cedd
-  signature: KBmWK8v60RNK6la+JYmG92RCOr7j4OOpel1zGgTv1tUI7BS8EHmitknObLa2Pc4gcTaWI8EhAJAo4NFCz4t2DQ==
+  checksum: sha256:63dc847bb59d7a568f14f79705a61de083b79dd06bd5fe553605164fe51848f6

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -28,3 +28,4 @@ description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
   checksum: sha256:2362ef8f6141c39ac70653f7c3de617c8b2335a979c3d0758b222b313f08cedd
+  signature: KBmWK8v60RNK6la+JYmG92RCOr7j4OOpel1zGgTv1tUI7BS8EHmitknObLa2Pc4gcTaWI8EhAJAo4NFCz4t2DQ==

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-project
-version: 0.41.23
+version: 0.41.24
 commands:
   - project
   - plan
@@ -27,5 +27,4 @@ core_compatibility: '>=0.40.0,<1.0.0'
 description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
-  checksum: sha256:34cc434009a5e06cc2565584a0713cd418105d7961f7683ecb116eb73086bfab
-  signature: yBgNCMzBT6dNJOVEHajZlJneB/0ice84uaGYNkxUF6avTn+ZMmGVwWbf6HI4QEeXrohxLF/9PI1mafpqHro2Ag==
+  checksum: sha256:2362ef8f6141c39ac70653f7c3de617c8b2335a979c3d0758b222b313f08cedd

--- a/packages/specfact-project/module-package.yaml
+++ b/packages/specfact-project/module-package.yaml
@@ -28,3 +28,4 @@ description: Official SpecFact project bundle package.
 bundle_group_command: project
 integrity:
   checksum: sha256:63dc847bb59d7a568f14f79705a61de083b79dd06bd5fe553605164fe51848f6
+  signature: idSvNwnNcYslhzCZlJpjrWQPxuGYItcy9S1cYocECVvGSlmt0+CFBPfa+P3QzRVtAvPyix4A7SxrLMCXdKhTAw==

--- a/packages/specfact-project/src/specfact_project/import_cmd/commands.py
+++ b/packages/specfact-project/src/specfact_project/import_cmd/commands.py
@@ -4,6 +4,10 @@ Import command - Import codebases and external tool projects to contract-driven 
 This module provides commands for importing existing codebases (brownfield) and
 external tool projects (e.g., Spec-Kit, OpenSpec, generic-markdown) and converting them to
 SpecFact contract-driven format using the bridge architecture.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 from __future__ import annotations
@@ -1662,11 +1666,11 @@ def _suggest_next_steps(repo: Path, bundle: str, plan_bundle: PlanBundle | None)
 
     if is_first_run:
         console.print("  [yellow]→[/yellow] [bold]Review your plan:[/bold]")
-        console.print(f"     specfact plan review {bundle}")
+        console.print(f"     Review generated project artifacts for {bundle}")
         console.print("     [dim]Review and refine the generated plan bundle[/dim]\n")
 
         console.print("  [yellow]→[/yellow] [bold]Compare with code:[/bold]")
-        console.print(f"     specfact plan compare --bundle {bundle}")
+        console.print(f"     Review deviations for {bundle}")
         console.print("     [dim]Detect deviations between plan and code[/dim]\n")
 
         console.print("  [yellow]→[/yellow] [bold]Validate SDD:[/bold]")
@@ -1674,11 +1678,11 @@ def _suggest_next_steps(repo: Path, bundle: str, plan_bundle: PlanBundle | None)
         console.print("     [dim]Check for violations and coverage thresholds[/dim]\n")
     else:
         console.print("  [yellow]→[/yellow] [bold]Review changes:[/bold]")
-        console.print(f"     specfact plan review {bundle}")
+        console.print(f"     Review generated project artifacts for {bundle}")
         console.print("     [dim]Review updates to your plan bundle[/dim]\n")
 
         console.print("  [yellow]→[/yellow] [bold]Check deviations:[/bold]")
-        console.print(f"     specfact plan compare --bundle {bundle}")
+        console.print(f"     Review deviations for {bundle}")
         console.print("     [dim]See what changed since last import[/dim]\n")
 
 
@@ -1723,7 +1727,7 @@ def _suggest_constitution_bootstrap(repo: Path) -> None:
             else:
                 console.print()
                 console.print(
-                    "[dim]💡 Tip: Run 'specfact sdd constitution bootstrap --repo .' to generate constitution[/dim]"
+                    "[dim]💡 Tip: Run 'specfact spec constitution bootstrap --repo .' to generate constitution[/dim]"
                 )
 
 
@@ -1958,9 +1962,9 @@ def from_bridge(
     - **Advanced/Configuration**: --adapter
 
     **Examples:**
-        specfact import from-bridge --repo ./my-project --adapter speckit --write
-        specfact import from-bridge --repo ./my-project --write  # Auto-detect adapter
-        specfact import from-bridge --repo ./my-project --dry-run  # Preview changes
+        specfact code import from-bridge --repo ./my-project --adapter speckit --write
+        specfact code import from-bridge --repo ./my-project --write  # Auto-detect adapter
+        specfact code import from-bridge --repo ./my-project --dry-run  # Preview changes
     """
     from specfact_cli.utils.structure import SpecFactStructure
 
@@ -2403,7 +2407,7 @@ def from_code(
     # Target/Input
     bundle: str | None = typer.Argument(
         None,
-        help="Project bundle name (e.g., legacy-api, auth-module). Default: active plan from 'specfact plan select'",
+        help="Project bundle name (e.g., legacy-api, auth-module). Default: active project bundle configuration",
     ),
     repo: Path = typer.Option(
         Path("."),
@@ -2528,7 +2532,7 @@ def from_code(
                     extra={"reason": "no_bundle"},
                 )
             console.print("[bold red]✗[/bold red] Bundle name required")
-            console.print("[yellow]→[/yellow] Use --bundle option or run 'specfact plan select' to set active plan")
+            console.print("[yellow]→[/yellow] Use --bundle option or configure an active project bundle")
             raise typer.Exit(1)
         console.print(f"[dim]Using active plan: {bundle}[/dim]")
 

--- a/packages/specfact-project/src/specfact_project/sync/commands.py
+++ b/packages/specfact-project/src/specfact_project/sync/commands.py
@@ -4,6 +4,10 @@ Sync command - Bidirectional synchronization for external tools and repositories
 This module provides commands for synchronizing changes between external tool artifacts
 (e.g., Spec-Kit, Linear, Jira), repository changes, and SpecFact plans using the
 bridge architecture.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 # pylint: disable=too-many-lines,import-outside-toplevel,line-too-long,broad-exception-caught,too-many-nested-blocks,too-many-arguments,too-many-locals,reimported,redefined-outer-name,logging-fstring-interpolation,unused-argument,protected-access,too-many-positional-arguments,consider-using-in,unused-import,redefined-argument-from-local,using-constant-test,too-many-boolean-expressions,too-many-return-statements,use-implicit-booleaness-not-comparison,too-many-branches,too-many-statements
@@ -708,7 +712,7 @@ def sync_repository(
     features/stories, and tracks deviations from manual plans.
 
     Example:
-        specfact sync repository --repo . --confidence 0.5
+        specfact project sync repository --repo . --confidence 0.5
     """
     if is_debug_mode():
         debug_log_operation(
@@ -789,7 +793,7 @@ def sync_repository(
             console.print(f"[bold cyan]Plan Updates:[/bold cyan] {len(result.plan_updates)}")
         if result.deviations:
             console.print(f"[yellow]⚠[/yellow] Found {len(result.deviations)} deviations from manual plan")
-            console.print("[dim]Run 'specfact plan compare' for detailed deviation report[/dim]")
+            console.print("[dim]Review the generated deviation report for details[/dim]")
         else:
             console.print("[bold green]✓[/bold green] No deviations detected")
         console.print("[bold green]✓[/bold green] Repository sync complete!")
@@ -808,7 +812,7 @@ def sync_repository(
 def sync_intelligent(
     # Target/Input
     bundle: str | None = typer.Argument(
-        None, help="Project bundle name (e.g., legacy-api). Default: active plan from 'specfact plan select'"
+        None, help="Project bundle name (e.g., legacy-api). Default: active project bundle configuration"
     ),
     repo: Path = typer.Option(
         Path("."),
@@ -853,9 +857,9 @@ def sync_intelligent(
     - **Behavior/Options**: --watch, --code-to-spec, --spec-to-code, --tests
 
     **Examples:**
-        specfact sync intelligent legacy-api --repo .
-        specfact sync intelligent my-bundle --repo . --watch
-        specfact sync intelligent my-bundle --repo . --code-to-spec auto --spec-to-code llm-prompt --tests specmatic
+        specfact project sync intelligent legacy-api --repo .
+        specfact project sync intelligent my-bundle --repo . --watch
+        specfact project sync intelligent my-bundle --repo . --code-to-spec auto --spec-to-code llm-prompt --tests specmatic
     """
     if is_debug_mode():
         debug_log_operation(
@@ -875,7 +879,7 @@ def sync_intelligent(
         bundle = SpecFactStructure.get_active_bundle_name(repo)
         if bundle is None:
             console.print("[bold red]✗[/bold red] Bundle name required")
-            console.print("[yellow]→[/yellow] Use --bundle option or run 'specfact plan select' to set active plan")
+            console.print("[yellow]→[/yellow] Use --bundle option or configure an active project bundle")
             raise typer.Exit(1)
         console.print(f"[dim]Using active plan: {bundle}[/dim]")
 

--- a/packages/specfact-project/src/specfact_project/sync_runtime/sync_perform_operation_impl.py
+++ b/packages/specfact-project/src/specfact_project/sync_runtime/sync_perform_operation_impl.py
@@ -51,7 +51,7 @@ def _pso_validate_constitution_required(
     console.print("[bold red]✗[/bold red] Constitution required")
     console.print("[red]Constitution file not found or is empty[/red]")
     console.print("\n[bold yellow]Next Steps:[/bold yellow]")
-    console.print("1. Run 'specfact sdd constitution bootstrap --repo .' to auto-generate constitution")
+    console.print("1. Run 'specfact spec constitution bootstrap --repo .' to auto-generate constitution")
     console.print("2. Or run tool-specific constitution command in your AI assistant")
     console.print("3. Then run 'specfact project sync bridge --adapter <adapter>' again")
     raise typer.Exit(1)
@@ -92,10 +92,12 @@ def _pso_maybe_bootstrap_constitution(repo: Path, adapter_type: AdapterType, con
             console.print("[bold green]✓[/bold green] Bootstrap constitution generated")
             console.print("[dim]Review and adjust as needed before syncing[/dim]")
         else:
-            console.print("[dim]Skipping bootstrap. Run 'specfact sdd constitution bootstrap' manually if needed[/dim]")
+            console.print(
+                "[dim]Skipping bootstrap. Run 'specfact spec constitution bootstrap' manually if needed[/dim]"
+            )
         return
     console.print("[yellow]⚠[/yellow] Constitution is minimal (essentially empty)")
-    console.print("[dim]Run 'specfact sdd constitution bootstrap --repo .' to generate constitution[/dim]")
+    console.print("[dim]Run 'specfact spec constitution bootstrap --repo .' to generate constitution[/dim]")
 
 
 def _pso_ensure_specfact(repo: Path, console: Any) -> bool:

--- a/packages/specfact-project/src/specfact_project/sync_runtime/sync_perform_operation_impl.py
+++ b/packages/specfact-project/src/specfact_project/sync_runtime/sync_perform_operation_impl.py
@@ -102,7 +102,7 @@ def _pso_ensure_specfact(repo: Path, console: Any) -> bool:
     specfact_exists = (repo / SpecFactStructure.ROOT).exists()
     if not specfact_exists:
         console.print("[yellow]⚠[/yellow] SpecFact structure not found")
-        console.print(f"[dim]Initialize with: specfact plan init --scaffold --repo {repo}[/dim]")
+        console.print(f"[dim]Initialize project bundle artifacts before syncing repo {repo}[/dim]")
         SpecFactStructure.ensure_structure(repo)
         console.print("[bold green]✓[/bold green] Created SpecFact structure")
     else:

--- a/packages/specfact-spec/module-package.yaml
+++ b/packages/specfact-spec/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-spec
-version: 0.40.21
+version: 0.40.22
 commands:
   - spec
 tier: official
@@ -21,5 +21,4 @@ description: Official SpecFact specification bundle package.
 category: spec
 bundle_group_command: spec
 integrity:
-  checksum: sha256:95117af3b79e184ffb84e231c8796beaa2cd4f44173a719a356258deb1b5046e
-  signature: MthYcByRkxA5UTRsdDx4fVZ6akRKsTTr51SJXM2gzxDmixTJiojCPduaWl6OzXdNfLuwrqoTbs1NktK5bxJJAw==
+  checksum: sha256:ca3aef139f4b16a192bbc1a5f0a0c4025cefb602229526082e3989278a5aca33

--- a/packages/specfact-spec/module-package.yaml
+++ b/packages/specfact-spec/module-package.yaml
@@ -22,3 +22,4 @@ category: spec
 bundle_group_command: spec
 integrity:
   checksum: sha256:ca3aef139f4b16a192bbc1a5f0a0c4025cefb602229526082e3989278a5aca33
+  signature: 9t/5fNMqbw5fO1kwY1K4qTYz2mmRx1aCRTW4Wa7ijh2rLI2iK1TNH4LnN3+0xry65MbbIFRJlBx1rf05MRuHBw==

--- a/packages/specfact-spec/module-package.yaml
+++ b/packages/specfact-spec/module-package.yaml
@@ -22,3 +22,4 @@ category: spec
 bundle_group_command: spec
 integrity:
   checksum: sha256:a342f8035eb7f82ee863a7c2abd55a10a8887616328ce1e927087c0da4977c10
+  signature: iKmrXd7JvrRnAXHITE8zcXEJ/nVteGeIl8NKV5CphiKVpifQA4RQu2wO8WJxMrCvyQFv8Gsk0uGb+H5Htsq+DA==

--- a/packages/specfact-spec/module-package.yaml
+++ b/packages/specfact-spec/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-spec
-version: 0.40.22
+version: 0.40.23
 commands:
   - spec
 tier: official
@@ -21,5 +21,4 @@ description: Official SpecFact specification bundle package.
 category: spec
 bundle_group_command: spec
 integrity:
-  checksum: sha256:ca3aef139f4b16a192bbc1a5f0a0c4025cefb602229526082e3989278a5aca33
-  signature: 9t/5fNMqbw5fO1kwY1K4qTYz2mmRx1aCRTW4Wa7ijh2rLI2iK1TNH4LnN3+0xry65MbbIFRJlBx1rf05MRuHBw==
+  checksum: sha256:a342f8035eb7f82ee863a7c2abd55a10a8887616328ce1e927087c0da4977c10

--- a/packages/specfact-spec/src/specfact_spec/generate/commands.py
+++ b/packages/specfact-spec/src/specfact_spec/generate/commands.py
@@ -558,10 +558,10 @@ def generate_contracts_prompt(
         console.print("  - icontract     (pre/post condition decorators)")
         console.print("  - crosshair     (property-based test functions)")
         console.print("\n[yellow]Examples:[/yellow]")
-        console.print("  specfact generate contracts-prompt src/file.py --apply all-contracts")
-        console.print("  specfact generate contracts-prompt src/file.py --apply beartype,icontract")
-        console.print("  specfact generate contracts-prompt --bundle my-bundle --apply all-contracts")
-        console.print("\n[dim]Use 'specfact generate contracts-prompt --help' for full documentation.[/dim]")
+        console.print("  specfact spec generate contracts-prompt src/file.py --apply all-contracts")
+        console.print("  specfact spec generate contracts-prompt src/file.py --apply beartype,icontract")
+        console.print("  specfact spec generate contracts-prompt --bundle my-bundle --apply all-contracts")
+        console.print("\n[dim]Use 'specfact spec generate contracts-prompt --help' for full documentation.[/dim]")
         raise typer.Exit(1)
 
     if not file and not bundle:
@@ -953,7 +953,7 @@ def generate_contracts_prompt(
             console.print("4. Save enhanced code from AI IDE to a file (e.g., enhanced_<filename>.py)")
             console.print("5. AI IDE should run validation command (iterative workflow):")
             console.print("   ```bash")
-            console.print("   specfact generate contracts-apply enhanced_<filename>.py --original <original-file>")
+            console.print("   specfact spec generate contracts-apply enhanced_<filename>.py --original <original-file>")
             console.print("   ```")
             console.print("6. If validation fails:")
             console.print("   - CLI will show specific error messages")
@@ -1688,10 +1688,10 @@ def generate_fix_prompt(
                     console.print(f"\n[dim]... and {len(gaps) - top} more gaps. Use --top to see more.[/dim]")
 
                 console.print("\n[bold]To generate a fix prompt:[/bold]")
-                console.print("  specfact generate fix-prompt <GAP-ID>")
+                console.print("  specfact spec generate fix-prompt <GAP-ID>")
                 console.print("\n[bold]Example:[/bold]")
                 if gaps:
-                    console.print(f"  specfact generate fix-prompt {gaps[0].get('id', 'GAP-001')}")
+                    console.print(f"  specfact spec generate fix-prompt {gaps[0].get('id', 'GAP-001')}")
 
                 record({"action": "list_gaps", "gap_count": len(gaps)})
                 raise typer.Exit(0)
@@ -2015,9 +2015,9 @@ def generate_test_prompt(
                         console.print(f"\n[dim]... and {len(files_without_tests) - 15} more files[/dim]")
 
                     console.print("\n[bold]To generate test prompt:[/bold]")
-                    console.print("  specfact generate test-prompt <file-path>")
+                    console.print("  specfact spec generate test-prompt <file-path>")
                     console.print("\n[bold]Example:[/bold]")
-                    console.print(f"  specfact generate test-prompt {files_without_tests[0][1]}")
+                    console.print(f"  specfact spec generate test-prompt {files_without_tests[0][1]}")
                 else:
                     print_success("All source files appear to have tests!")
 

--- a/packages/specfact-spec/src/specfact_spec/generate/commands.py
+++ b/packages/specfact-spec/src/specfact_spec/generate/commands.py
@@ -2,6 +2,10 @@
 
 This module provides commands for generating contract stubs, CrossHair harnesses,
 and other artifacts from SDD manifests and plan bundles.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 from __future__ import annotations
@@ -108,10 +112,10 @@ def _show_apply_help() -> None:
     console.print("  - icontract     (pre/post condition decorators)")
     console.print("  - crosshair     (property-based test functions)")
     console.print("\n[yellow]Examples:[/yellow]")
-    console.print("  specfact generate contracts-prompt src/file.py --apply all-contracts")
-    console.print("  specfact generate contracts-prompt src/file.py --apply beartype,icontract")
-    console.print("  specfact generate contracts-prompt --bundle my-bundle --apply all-contracts")
-    console.print("\n[dim]Use 'specfact generate contracts-prompt --help' for full documentation.[/dim]")
+    console.print("  specfact spec generate contracts-prompt src/file.py --apply all-contracts")
+    console.print("  specfact spec generate contracts-prompt src/file.py --apply beartype,icontract")
+    console.print("  specfact spec generate contracts-prompt --bundle my-bundle --apply all-contracts")
+    console.print("\n[dim]Use 'specfact spec generate contracts-prompt --help' for full documentation.[/dim]")
 
 
 @app.command("contracts")
@@ -164,8 +168,8 @@ def generate_contracts(
     - **Behavior/Options**: --no-interactive
 
     **Examples:**
-        specfact generate contracts --bundle legacy-api
-        specfact generate contracts --bundle legacy-api --no-interactive
+        specfact spec generate contracts --bundle legacy-api
+        specfact spec generate contracts --bundle legacy-api --no-interactive
     """
 
     telemetry_metadata = {
@@ -206,7 +210,7 @@ def generate_contracts(
                             extra={"reason": "bundle_not_found", "bundle": bundle},
                         )
                     print_error(f"Project bundle not found: {bundle_dir}")
-                    print_info(f"Create one with: specfact plan init {bundle}")
+                    print_info(f"Create or configure project bundle '{bundle}' before rerunning.")
                     raise typer.Exit(1)
 
                 plan_path = bundle_dir
@@ -225,7 +229,7 @@ def generate_contracts(
                             extra={"reason": "no_plan_or_bundle"},
                         )
                     print_error("Bundle or plan path is required")
-                    print_info("Run 'specfact plan init <bundle-name>' then rerun with --bundle <name>")
+                    print_info("Create or configure the project bundle, then rerun with --bundle <name>")
                     raise typer.Exit(1)
                 plan_path = Path(plan).resolve()
 
@@ -249,7 +253,7 @@ def generate_contracts(
                     format_type, _ = detect_bundle_format(plan_path)
                     if format_type != BundleFormat.MODULAR:
                         print_error("Legacy monolithic bundles are not supported by this command.")
-                        print_info("Migrate to the new structure with: specfact migrate artifacts --repo .")
+                        print_info("Migrate legacy artifacts before rerunning, then pass --bundle <name>.")
                         raise typer.Exit(1)
 
                     if plan_path.is_dir():
@@ -286,7 +290,7 @@ def generate_contracts(
                             extra={"reason": "sdd_not_found"},
                         )
                     print_error(f"SDD manifest not found: {sdd_path}")
-                    print_info("Run 'specfact plan harden' to create SDD manifest")
+                    print_info("Create the SDD manifest for the active bundle before rerunning")
                     raise typer.Exit(1)
 
             # Load SDD manifest
@@ -337,7 +341,7 @@ def generate_contracts(
             # Verify hash match (SDD uses plan_bundle_hash field)
             if sdd_manifest.plan_bundle_hash != plan_hash:
                 print_error("SDD manifest hash does not match plan bundle hash")
-                print_info("Run 'specfact plan harden' to update SDD manifest")
+                print_info("Update the SDD manifest for the active bundle before rerunning")
                 raise typer.Exit(1)
 
             # Determine contracts directory based on bundle
@@ -470,7 +474,7 @@ def generate_contracts_prompt(
     bundle: str | None = typer.Option(
         None,
         "--bundle",
-        help="Project bundle name (e.g., legacy-api). If provided, selects files from bundle. Default: active plan from 'specfact plan select'",
+        help="Project bundle name (e.g., legacy-api). If provided, selects files from bundle. Default: active project bundle configuration",
     ),
     apply: str = typer.Option(
         ...,
@@ -519,22 +523,22 @@ def generate_contracts_prompt(
     - **Output**: --output (currently unused, prompt is saved to .specfact/prompts/)
 
     **Examples:**
-        specfact generate contracts-prompt src/auth/login.py --apply beartype,icontract
-        specfact generate contracts-prompt --bundle legacy-api --apply beartype
-        specfact generate contracts-prompt --bundle legacy-api --apply beartype,icontract  # Interactive selection
-        specfact generate contracts-prompt --bundle legacy-api --apply beartype --no-interactive  # Process all files in bundle
+        specfact spec generate contracts-prompt src/auth/login.py --apply beartype,icontract
+        specfact spec generate contracts-prompt --bundle legacy-api --apply beartype
+        specfact spec generate contracts-prompt --bundle legacy-api --apply beartype,icontract  # Interactive selection
+        specfact spec generate contracts-prompt --bundle legacy-api --apply beartype --no-interactive  # Process all files in bundle
 
     **Complete Workflow:**
-        1. Generate prompt: specfact generate contracts-prompt --bundle legacy-api --apply all-contracts
+        1. Generate prompt: specfact spec generate contracts-prompt --bundle legacy-api --apply all-contracts
         2. Select file(s) from interactive list (if multiple)
         3. Open prompt file: .specfact/prompts/enhance-<filename>-beartype-icontract-crosshair.md
         4. Copy prompt to your AI IDE (Cursor, CoPilot, etc.)
         5. AI IDE reads the file and provides enhanced code (does NOT modify file directly)
         6. AI IDE writes enhanced code to temporary file: enhanced_<filename>.py
-        7. AI IDE runs validation: specfact generate contracts-apply enhanced_<filename>.py --original <original-file>
+        7. AI IDE runs validation: specfact spec generate contracts-apply enhanced_<filename>.py --original <original-file>
         8. If validation fails, AI IDE fixes issues and re-validates (up to 3 attempts)
         9. If validation succeeds, CLI applies changes automatically
-        10. Verify contract coverage: specfact analyze contracts --bundle legacy-api
+        10. Verify contract coverage: specfact code analyze contracts --bundle legacy-api
         11. Run your test suite: pytest (or your project's test command)
         12. Commit the enhanced code
     """
@@ -743,7 +747,7 @@ def generate_contracts_prompt(
                     "   ```",
                     "   ❌ SpecFact CLI is required but not available or outdated.",
                     "   Please install/upgrade: pip install -U specfact-cli",
-                    "   Then verify: specfact --version",
+                    "   Then verify: specfact --help",
                     "   This task cannot proceed without SpecFact CLI.",
                     "   ```",
                     "5. **END THE CONVERSATION** - Do not continue until SpecFact CLI is working",
@@ -752,13 +756,13 @@ def generate_contracts_prompt(
                     "",
                     "1. Check if `specfact` command is available:",
                     "   ```bash",
-                    "   specfact --version",
+                    "   specfact --help",
                     "   ```",
                     "   - **If this fails**: STOP and inform user (see message above)",
                     "",
                     "2. Verify the required command exists:",
                     "   ```bash",
-                    "   specfact generate contracts-apply --help",
+                    "   specfact spec generate contracts-apply --help",
                     "   ```",
                     "   - **If this fails**: STOP and inform user (see message above)",
                     "",
@@ -855,11 +859,11 @@ def generate_contracts_prompt(
                         "2. Ensure the file is properly formatted and complete",
                         "",
                         "### Step 4: Validate with CLI",
-                        "**CRITICAL**: If `specfact generate contracts-apply` command is not available or fails, DO NOT proceed. STOP and inform the user that SpecFact CLI must be installed/upgraded first.",
+                        "**CRITICAL**: If `specfact spec generate contracts-apply` command is not available or fails, DO NOT proceed. STOP and inform the user that SpecFact CLI must be installed/upgraded first.",
                         "",
                         "1. Run the validation command:",
                         "   ```bash",
-                        f"   specfact generate contracts-apply enhanced_{file_path.stem}.py --original {file_path_relative}",
+                        f"   specfact spec generate contracts-apply enhanced_{file_path.stem}.py --original {file_path_relative}",
                         "   ```",
                         "",
                         "   - **If command not found**: STOP immediately and inform user (see mandatory pre-check message)",
@@ -879,7 +883,7 @@ def generate_contracts_prompt(
                         "- Run the validation command again",
                         "- Repeat until validation passes (maximum 3 attempts)",
                         "",
-                        "**CRITICAL**: If `specfact generate contracts-apply` command is not available or fails with 'command not found', DO NOT manually apply changes to the original file. STOP and inform the user that SpecFact CLI must be installed/upgraded first.",
+                        "**CRITICAL**: If `specfact spec generate contracts-apply` command is not available or fails with 'command not found', DO NOT manually apply changes to the original file. STOP and inform the user that SpecFact CLI must be installed/upgraded first.",
                         "",
                         "### Common Validation Errors and Fixes",
                         "",
@@ -913,7 +917,7 @@ def generate_contracts_prompt(
                         "",
                         f"- **Target File:** `{file_path_relative}`",
                         f"- **Enhanced File:** `enhanced_{file_path.stem}.py`",
-                        f"- **Validation Command:** `specfact generate contracts-apply enhanced_{file_path.stem}.py --original {file_path_relative}`",
+                        f"- **Validation Command:** `specfact spec generate contracts-apply enhanced_{file_path.stem}.py --original {file_path_relative}`",
                         "- **Contracts:** " + ", ".join(contracts_to_apply),
                         "",
                         "**BEFORE STARTING**: Complete the mandatory SpecFact CLI verification at the top of this prompt. Do NOT proceed with file reading or code generation until SpecFact CLI is verified.",
@@ -959,9 +963,9 @@ def generate_contracts_prompt(
             console.print("   - CLI will automatically apply the changes")
             console.print("   - Verify contract coverage:")
             if bundle:
-                console.print(f"     - specfact analyze contracts --bundle {bundle}")
+                console.print(f"     - specfact code analyze contracts --bundle {bundle}")
             else:
-                console.print("     - specfact analyze contracts --bundle <bundle>")
+                console.print("     - specfact code analyze contracts --bundle <bundle>")
             console.print("   - Run your test suite: pytest (or your project's test command)")
             console.print("   - Commit the enhanced code")
             if bundle_dir:
@@ -1045,10 +1049,10 @@ def apply_enhanced_contracts(
     - **Behavior/Options**: --yes, --dry-run
 
     **Examples:**
-        specfact generate contracts-apply enhanced_telemetry.py
-        specfact generate contracts-apply enhanced_telemetry.py --original src/telemetry.py
-        specfact generate contracts-apply enhanced_telemetry.py --dry-run  # Preview only
-        specfact generate contracts-apply enhanced_telemetry.py --yes  # Auto-apply
+        specfact spec generate contracts-apply enhanced_telemetry.py
+        specfact spec generate contracts-apply enhanced_telemetry.py --original src/telemetry.py
+        specfact spec generate contracts-apply enhanced_telemetry.py --dry-run  # Preview only
+        specfact spec generate contracts-apply enhanced_telemetry.py --yes  # Auto-apply
     """
     import difflib
     import subprocess
@@ -1339,7 +1343,7 @@ def apply_enhanced_contracts(
     test_output = ""
 
     # For single-file validation, we scope tests to the specific file only (not full repo)
-    # This is much faster than running specfact repro on the entire repository
+    # This is much faster than running specfact code repro on the entire repository
     try:
         # Find the original file path to determine test file location
         original_file_rel = original_file.relative_to(repo_path) if original_file else None
@@ -1503,8 +1507,8 @@ def apply_enhanced_contracts(
         print_success(f"Enhanced code applied to: {original_file.relative_to(repo_path)}")
         console.print("\n[bold green]✓ All validations passed and changes applied successfully![/bold green]")
         console.print("\n[bold]Next Steps:[/bold]")
-        console.print("1. Verify contract coverage: specfact analyze contracts --bundle <bundle>")
-        console.print("2. Run full test suite: specfact repro (or pytest)")
+        console.print("1. Verify contract coverage: specfact code analyze contracts --bundle <bundle>")
+        console.print("2. Run full test suite with specfact code repro, or use pytest")
         console.print("3. Commit the enhanced code")
     except Exception as e:
         if is_debug_mode():
@@ -1541,7 +1545,7 @@ def generate_fix_prompt(
     bundle: str | None = typer.Option(
         None,
         "--bundle",
-        help="Project bundle name. Default: active plan from 'specfact plan select'",
+        help="Project bundle name. Default: active project bundle configuration",
     ),
     # Output
     output: Path | None = typer.Option(
@@ -1569,11 +1573,11 @@ def generate_fix_prompt(
     to fix identified gaps in your codebase. This is the recommended workflow for v0.17+.
 
     **Workflow:**
-    1. Run `specfact analyze gaps --bundle <bundle>` to identify gaps
-    2. Run `specfact generate fix-prompt GAP-001` to get a fix prompt
+    1. Provide a generated gap report at `.specfact/reports/gaps.json` to identify gaps
+    2. Run `specfact spec generate fix-prompt GAP-001` to get a fix prompt
     3. Copy the prompt to your AI IDE
     4. AI IDE provides the fix
-    5. Validate with `specfact govern enforce sdd --bundle <bundle>`
+    5. Validate with `specfact govern enforce sdd <bundle>`
 
     **Parameter Groups:**
     - **Target/Input**: gap_id (optional argument), --bundle
@@ -1581,10 +1585,10 @@ def generate_fix_prompt(
     - **Behavior/Options**: --top, --no-interactive
 
     **Examples:**
-        specfact generate fix-prompt                     # List available gaps
-        specfact generate fix-prompt GAP-001             # Generate fix prompt for GAP-001
-        specfact generate fix-prompt --bundle legacy-api # List gaps for specific bundle
-        specfact generate fix-prompt GAP-001 --output fix.md  # Save to specific file
+        specfact spec generate fix-prompt                     # List available gaps
+        specfact spec generate fix-prompt GAP-001             # Generate fix prompt for GAP-001
+        specfact spec generate fix-prompt --bundle legacy-api # List gaps for specific bundle
+        specfact spec generate fix-prompt GAP-001 --output fix.md  # Save to specific file
     """
     from rich.table import Table
     from specfact_cli.utils.structure import SpecFactStructure
@@ -1620,7 +1624,7 @@ def generate_fix_prompt(
                 bundle_dir = SpecFactStructure.project_dir(base_path=repo_path, bundle_name=bundle)
                 if not bundle_dir.exists():
                     print_error(f"Project bundle not found: {bundle_dir}")
-                    print_info(f"Create one with: specfact plan init {bundle}")
+                    print_info(f"Create or configure project bundle '{bundle}' before rerunning.")
                     raise typer.Exit(1)
 
             # Look for gap report
@@ -1634,9 +1638,9 @@ def generate_fix_prompt(
                 print_warning("No gap report found.")
                 console.print("\n[bold]To generate a gap report, run:[/bold]")
                 if bundle:
-                    console.print(f"  specfact analyze gaps --bundle {bundle} --output json")
+                    console.print("  Create .specfact/reports/gaps.json, then rerun this command")
                 else:
-                    console.print("  specfact analyze gaps --bundle <bundle-name> --output json")
+                    console.print("  Create .specfact/reports/gaps.json, then rerun this command")
                 raise typer.Exit(1)
 
             # Load gap report
@@ -1785,7 +1789,7 @@ def generate_fix_prompt(
                         "1. **Check OpenAPI Spec**: Review the OpenAPI contract",
                         "2. **Update Implementation**: Align the code with the spec",
                         "3. **Or Update Spec**: If the implementation is correct, update the spec",
-                        "4. **Run Drift Check**: Verify with `specfact analyze drift`",
+                        "4. **Run Drift Check**: Verify with `specfact code drift detect`",
                     ]
                 )
             else:
@@ -1880,7 +1884,7 @@ def generate_test_prompt(
     bundle: str | None = typer.Option(
         None,
         "--bundle",
-        help="Project bundle name. Default: active plan from 'specfact plan select'",
+        help="Project bundle name. Default: active project bundle configuration",
     ),
     # Output
     output: Path | None = typer.Option(
@@ -1908,7 +1912,7 @@ def generate_test_prompt(
     to generate comprehensive tests for your code. This is the recommended workflow for v0.17+.
 
     **Workflow:**
-    1. Run `specfact generate test-prompt src/module.py` to get a test prompt
+    1. Run `specfact spec generate test-prompt src/module.py` to get a test prompt
     2. Copy the prompt to your AI IDE
     3. AI IDE generates tests
     4. Save tests to appropriate location
@@ -1920,9 +1924,9 @@ def generate_test_prompt(
     - **Behavior/Options**: --type, --no-interactive
 
     **Examples:**
-        specfact generate test-prompt src/auth/login.py              # Generate test prompt
-        specfact generate test-prompt src/api.py --type integration  # Integration tests
-        specfact generate test-prompt --bundle legacy-api            # List files needing tests
+        specfact spec generate test-prompt src/auth/login.py              # Generate test prompt
+        specfact spec generate test-prompt src/api.py --type integration  # Integration tests
+        specfact spec generate test-prompt --bundle legacy-api            # List files needing tests
     """
     from rich.table import Table
     from specfact_cli.utils.structure import SpecFactStructure
@@ -1959,7 +1963,7 @@ def generate_test_prompt(
                 bundle_dir = SpecFactStructure.project_dir(base_path=repo_path, bundle_name=bundle)
                 if not bundle_dir.exists():
                     print_error(f"Project bundle not found: {bundle_dir}")
-                    print_info(f"Create one with: specfact plan init {bundle}")
+                    print_info(f"Create or configure project bundle '{bundle}' before rerunning.")
                     raise typer.Exit(1)
 
             # If no file provided, show files that might need tests

--- a/packages/specfact-spec/src/specfact_spec/sdd/commands.py
+++ b/packages/specfact-spec/src/specfact_spec/sdd/commands.py
@@ -3,6 +3,10 @@ SDD (Spec-Driven Development) manifest management commands.
 
 This module provides commands for managing SDD manifests, including listing
 all SDD manifests in a repository, and constitution management for Spec-Kit compatibility.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 from __future__ import annotations
@@ -77,8 +81,8 @@ def sdd_list(
     - **Target/Input**: --repo
 
     **Examples:**
-        specfact sdd list
-        specfact sdd list --repo /path/to/repo
+        specfact spec list
+        specfact spec list --repo /path/to/repo
     """
     if is_debug_mode():
         debug_log_operation("command", "sdd list", "started", extra={"repo": str(repo)})
@@ -99,8 +103,8 @@ def sdd_list(
         console.print(
             f"[dim]Legacy fallback: {base_path / SpecFactStructure.SDD}/* and {base_path / SpecFactStructure.ROOT / 'sdd.yaml'}[/dim]"
         )
-        console.print("\n[dim]Create SDD manifests with: specfact plan harden <bundle-name>[/dim]")
-        console.print("[dim]If you have legacy bundles, migrate with: specfact migrate artifacts --repo .[/dim]")
+        console.print("\n[dim]Create SDD manifests for the selected bundle before rerunning[/dim]")
+        console.print("[dim]If you have legacy bundles, migrate them before rerunning.[/dim]")
         raise typer.Exit(0)
 
     # Create table
@@ -220,9 +224,9 @@ def constitution_bootstrap(
     - **Behavior/Options**: --overwrite
 
     **Examples:**
-        specfact sdd constitution bootstrap --repo .
-        specfact sdd constitution bootstrap --repo . --out custom-constitution.md
-        specfact sdd constitution bootstrap --repo . --overwrite
+        specfact spec constitution bootstrap --repo .
+        specfact spec constitution bootstrap --repo . --out custom-constitution.md
+        specfact spec constitution bootstrap --repo . --overwrite
     """
     from specfact_cli.telemetry import telemetry
 
@@ -256,7 +260,7 @@ def constitution_bootstrap(
         console.print("\n[bold]Next Steps:[/bold]")
         console.print("1. Review the generated constitution")
         console.print("2. Adjust principles and sections as needed")
-        console.print("3. Run 'specfact sdd constitution validate' to check completeness")
+        console.print("3. Run 'specfact spec constitution validate' to check completeness")
         console.print("4. Run 'specfact project sync bridge --adapter speckit' to sync with Spec-Kit artifacts")
 
 
@@ -293,7 +297,7 @@ def constitution_enrich(
     additional principles and details extracted from repository context.
 
     Example:
-        specfact sdd constitution enrich --repo .
+        specfact spec constitution enrich --repo .
     """
     from specfact_cli.telemetry import telemetry
 
@@ -304,7 +308,7 @@ def constitution_enrich(
 
         if not constitution.exists():
             console.print(f"[bold red]✗[/bold red] Constitution not found: {constitution}")
-            console.print("[dim]Run 'specfact sdd constitution bootstrap' first[/dim]")
+            console.print("[dim]Run 'specfact spec constitution bootstrap' first[/dim]")
             raise typer.Exit(1)
 
         console.print(f"[bold cyan]Enriching constitution:[/bold cyan] {constitution}")
@@ -355,7 +359,7 @@ def constitution_enrich(
         console.print("\n[bold]Next Steps:[/bold]")
         console.print("1. Review the enriched constitution")
         console.print("2. Adjust as needed")
-        console.print("3. Run 'specfact sdd constitution validate' to check completeness")
+        console.print("3. Run 'specfact spec constitution validate' to check completeness")
 
 
 @constitution_app.command("validate")
@@ -383,8 +387,8 @@ def constitution_validate(
     has governance section, etc.).
 
     Example:
-        specfact sdd constitution validate
-        specfact sdd constitution validate --constitution custom-constitution.md
+        specfact spec constitution validate
+        specfact spec constitution validate --constitution custom-constitution.md
     """
     from specfact_cli.telemetry import telemetry
 

--- a/packages/specfact-spec/src/specfact_spec/sdd/commands.py
+++ b/packages/specfact-spec/src/specfact_spec/sdd/commands.py
@@ -407,8 +407,8 @@ def constitution_validate(
                 console.print(f"  - {issue}")
 
             console.print("\n[bold]Next Steps:[/bold]")
-            console.print("1. Run 'specfact sdd constitution bootstrap' to generate a complete constitution")
-            console.print("2. Or run 'specfact sdd constitution enrich' to enrich existing constitution")
+            console.print("1. Run 'specfact spec constitution bootstrap' to generate a complete constitution")
+            console.print("2. Or run 'specfact spec constitution enrich' to enrich existing constitution")
             raise typer.Exit(1)
 
 

--- a/packages/specfact-spec/src/specfact_spec/spec/commands.py
+++ b/packages/specfact-spec/src/specfact_spec/spec/commands.py
@@ -4,6 +4,10 @@ Spec command - Specmatic integration for API contract testing.
 This module provides commands for validating OpenAPI/AsyncAPI specifications,
 checking backward compatibility, generating test suites, and running mock servers
 using Specmatic.
+
+Operating guidance: embedded command examples are not the source of truth;
+CLI help is authoritative, so run the relevant --help command and ask the user
+before acting when examples and runtime behavior diverge.
 """
 
 from __future__ import annotations
@@ -58,7 +62,7 @@ def validate(
     bundle: str | None = typer.Option(
         None,
         "--bundle",
-        help="Project bundle name (e.g., legacy-api). If provided, validates all contracts in bundle. Default: active plan from 'specfact plan select'",
+        help="Project bundle name (e.g., legacy-api). If provided, validates all contracts in bundle. Default: active project bundle configuration",
     ),
     # Advanced
     previous_version: Path | None = typer.Option(
@@ -89,7 +93,7 @@ def validate(
     - Backward compatibility check (if previous version provided)
 
     Can validate a single contract file or all contracts in a project bundle.
-    Uses active plan (from 'specfact plan select') as default if --bundle not provided.
+    Uses the active project bundle configuration as default if --bundle is not provided.
 
     **Caching:**
     Validation results are cached in `.specfact/cache/specmatic-validation.json` based on
@@ -214,7 +218,7 @@ def validate(
         console.print("\n[bold]Options:[/bold]")
         console.print("  1. Provide a spec file: specfact spec validate api/openapi.yaml")
         console.print("  2. Use --bundle option: specfact spec validate --bundle legacy-api")
-        console.print("  3. Set active plan first: specfact plan select")
+        console.print("  3. Pass --bundle or configure an active project bundle")
         raise typer.Exit(1)
 
     if not spec_paths:
@@ -715,7 +719,7 @@ def mock(
     bundle: str | None = typer.Option(
         None,
         "--bundle",
-        help="Project bundle name (e.g., legacy-api). If provided, selects contract from bundle. Default: active plan from 'specfact plan select'",
+        help="Project bundle name (e.g., legacy-api). If provided, selects contract from bundle. Default: active project bundle configuration",
     ),
     # Behavior/Options
     port: int = typer.Option(9000, "--port", help="Port number for mock server (default: 9000)"),
@@ -851,7 +855,7 @@ def mock(
             console.print("\n[bold]Options:[/bold]")
             console.print("  1. Provide a spec file: specfact spec mock --spec api/openapi.yaml")
             console.print("  2. Use --bundle option: specfact spec mock --bundle legacy-api")
-            console.print("  3. Set active plan first: specfact plan select")
+            console.print("  3. Pass --bundle or configure an active project bundle")
             console.print("\n[bold]Common locations for auto-detection:[/bold]")
             console.print("  - openapi.yaml")
             console.print("  - api/openapi.yaml")

--- a/tests/unit/sync_runtime/test_bridge_sync.py
+++ b/tests/unit/sync_runtime/test_bridge_sync.py
@@ -8,7 +8,6 @@ import hashlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from beartype import beartype
 from specfact_cli.adapters.registry import AdapterRegistry
 from specfact_cli.models.bridge import AdapterType, ArtifactMapping, BridgeConfig
 from specfact_cli.models.project import ProjectBundle
@@ -656,7 +655,6 @@ class TestSyncResult:
 class TestBridgeSyncDevOpsFeatures:
     """Test DevOps-specific features in BridgeSync."""
 
-    @beartype
     def test_content_hash_calculation(self, tmp_path: Path) -> None:
         """Test content hash calculation for change detection."""
         bridge_config = BridgeConfig.preset_github()
@@ -679,7 +677,6 @@ class TestBridgeSyncDevOpsFeatures:
         assert hash_result == expected_hash
         assert len(hash_result) == 16  # First 16 chars of SHA-256
 
-    @beartype
     def test_content_change_detection(self, tmp_path: Path) -> None:
         """Test content change detection logic."""
         bridge_config = BridgeConfig.preset_github()
@@ -717,7 +714,6 @@ class TestBridgeSyncDevOpsFeatures:
             assert current_hash == "new_hash_789abc"
             assert stored_hash == "old_hash_123456"
 
-    @beartype
     def test_content_change_detection_no_change(self, tmp_path: Path) -> None:
         """Test content change detection when hash matches."""
         bridge_config = BridgeConfig.preset_github()
@@ -749,7 +745,6 @@ class TestBridgeSyncDevOpsFeatures:
             assert current_hash == stored_hash
             assert current_hash == "same_hash_123456"
 
-    @beartype
     def test_change_filtering_by_ids(self, tmp_path: Path) -> None:
         """Test filtering change proposals by change IDs."""
         bridge_config = BridgeConfig.preset_github()
@@ -801,7 +796,6 @@ class TestBridgeSyncDevOpsFeatures:
             # (adapter should be called twice, once for each filtered proposal)
             assert mock_adapter.export_artifact.call_count == 2
 
-    @beartype
     def test_change_filtering_all_proposals(self, tmp_path: Path) -> None:
         """Test that all proposals are exported when no filter specified."""
         bridge_config = BridgeConfig.preset_github()
@@ -846,7 +840,6 @@ class TestBridgeSyncDevOpsFeatures:
             # Verify all proposals were processed
             assert mock_adapter.export_artifact.call_count == 2
 
-    @beartype
     def test_temporary_file_export(self, tmp_path: Path) -> None:
         """Test exporting proposal content to temporary file."""
         bridge_config = BridgeConfig.preset_github()
@@ -883,7 +876,6 @@ class TestBridgeSyncDevOpsFeatures:
             assert "Test Change" in content or "test-change" in content
             assert "Test rationale" in content or "Test description" in content
 
-    @beartype
     def test_temporary_file_import(self, tmp_path: Path) -> None:
         """Test importing sanitized content from temporary file."""
         bridge_config = BridgeConfig.preset_github()
@@ -942,7 +934,6 @@ Sanitized description
             assert artifact_data["rationale"] == "Sanitized rationale"
             assert artifact_data["description"] == "Sanitized description"
 
-    @beartype
     def test_temporary_file_import_missing_file(self, tmp_path: Path) -> None:
         """Test error handling when sanitized file doesn't exist."""
         bridge_config = BridgeConfig.preset_github()
@@ -974,7 +965,6 @@ Sanitized description
             assert len(result.errors) > 0
             assert any("not found" in error.lower() for error in result.errors)
 
-    @beartype
     def test_source_tracking_formatting(self, tmp_path: Path) -> None:
         """Test Source Tracking markdown formatting."""
         bridge_config = BridgeConfig.preset_github()
@@ -1032,7 +1022,6 @@ Test description
         separator_count = saved_content.count("---")
         assert separator_count >= 1  # At least one separator
 
-    @beartype
     def test_update_existing_flag_enabled(self, tmp_path: Path) -> None:
         """Test that update_existing flag triggers issue body update."""
         from unittest.mock import MagicMock, patch
@@ -1091,7 +1080,6 @@ Test description
             ]
             assert len(update_calls) == 1
 
-    @beartype
     def test_update_existing_flag_disabled(self, tmp_path: Path) -> None:
         """Test that update_existing=False skips issue body update."""
         from unittest.mock import MagicMock, patch
@@ -1146,7 +1134,6 @@ Test description
             ]
             assert len(update_calls) == 0
 
-    @beartype
     def test_multi_repository_source_tracking(self, tmp_path: Path) -> None:
         """Test that source_tracking supports multiple repository entries."""
         from unittest.mock import MagicMock, patch
@@ -1214,7 +1201,6 @@ Test description
             assert isinstance(proposal["source_tracking"], list)
             assert len(proposal["source_tracking"]) == 2
 
-    @beartype
     def test_multi_repository_entry_matching(self, tmp_path: Path) -> None:
         """Test that entries are matched by source_repo."""
         from unittest.mock import MagicMock, patch
@@ -1275,7 +1261,6 @@ Test description
             assert internal_entry is not None
             assert internal_entry.get("source_id") == "14"
 
-    @beartype
     def test_multi_repository_content_hash_independence(self, tmp_path: Path) -> None:
         """Test that content hash is tracked per repository independently."""
         from unittest.mock import MagicMock, patch

--- a/tests/unit/sync_runtime/test_drift_detector.py
+++ b/tests/unit/sync_runtime/test_drift_detector.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from beartype import beartype
 from specfact_cli.models.plan import Feature, Product, Story
 from specfact_cli.models.project import BundleManifest, ProjectBundle
 from specfact_cli.models.source_tracking import SourceTracking
@@ -22,7 +21,6 @@ from specfact_project.sync_runtime.drift_detector import DriftDetector, DriftRep
 class TestDriftDetector:
     """Test suite for DriftDetector class."""
 
-    @beartype
     def test_scan_no_bundle(self, tmp_path: Path) -> None:
         """Test scan when bundle doesn't exist."""
         detector = DriftDetector("nonexistent", tmp_path)
@@ -36,7 +34,6 @@ class TestDriftDetector:
         assert len(report.test_coverage_gaps) == 0
         assert len(report.contract_violations) == 0
 
-    @beartype
     def test_scan_added_code(self, tmp_path: Path) -> None:
         """Test detection of added code files (no spec)."""
         from specfact_cli.utils.bundle_loader import save_project_bundle
@@ -95,7 +92,6 @@ class TestDriftDetector:
         assert len(report.added_code) > 0
         assert any("untracked.py" in file for file in report.added_code)
 
-    @beartype
     def test_scan_removed_code(self, tmp_path: Path) -> None:
         """Test detection of removed code files (spec exists but file deleted)."""
         from specfact_cli.utils.bundle_loader import save_project_bundle
@@ -136,7 +132,6 @@ class TestDriftDetector:
         assert len(report.removed_code) > 0
         assert any("deleted.py" in file for file in report.removed_code)
 
-    @beartype
     def test_scan_modified_code(self, tmp_path: Path) -> None:
         """Test detection of modified code files (hash changed)."""
         from specfact_cli.utils.bundle_loader import save_project_bundle
@@ -186,7 +181,6 @@ class TestDriftDetector:
         assert len(report.modified_code) > 0
         assert any("modified.py" in file for file in report.modified_code)
 
-    @beartype
     def test_scan_orphaned_specs(self, tmp_path: Path) -> None:
         """Test detection of orphaned specs (no source tracking)."""
         from specfact_cli.utils.bundle_loader import save_project_bundle
@@ -223,7 +217,6 @@ class TestDriftDetector:
         assert len(report.orphaned_specs) > 0
         assert "FEATURE-ORPHAN" in report.orphaned_specs
 
-    @beartype
     def test_scan_test_coverage_gaps(self, tmp_path: Path) -> None:
         """Test detection of test coverage gaps (stories without tests)."""
         from specfact_cli.utils.bundle_loader import save_project_bundle
@@ -282,7 +275,6 @@ class TestDriftDetector:
             for feature_key, story_key in report.test_coverage_gaps
         )
 
-    @beartype
     def test_scan_no_test_coverage_gaps_when_tests_exist(self, tmp_path: Path) -> None:
         """Test that stories with tests don't show up as coverage gaps."""
         from specfact_cli.utils.bundle_loader import save_project_bundle
@@ -341,7 +333,6 @@ class TestDriftDetector:
             for feature_key, story_key in report.test_coverage_gaps
         )
 
-    @beartype
     def test_is_implementation_file(self, tmp_path: Path) -> None:
         """Test _is_implementation_file method."""
         detector = DriftDetector("test", tmp_path)
@@ -358,7 +349,6 @@ class TestDriftDetector:
         assert detector._is_implementation_file(tmp_path / "__pycache__" / "module.pyc") is False
         assert detector._is_implementation_file(tmp_path / ".specfact" / "bundle.yaml") is False
 
-    @beartype
     def test_scan_no_drift_when_in_sync(self, tmp_path: Path) -> None:
         """Test that no drift is detected when code and specs are in sync."""
         from specfact_cli.utils.bundle_loader import save_project_bundle


### PR DESCRIPTION
## Summary

- update module command examples away from removed flat command shims
- add CLI reality-check guidance to source files that embed executable examples
- refresh official module package manifests generated by the signature/version hook
- remove test-only beartype wrappers that block pytest fixture discovery on Python 3.14

Related to nold-ai/specfact-cli#605.

## Validation

- hatch run python scripts/check-prompt-commands.py on changed command files
- hatch run ruff check on changed source and test files
- hatch run ruff format --check on changed source and test files
- hatch run contract-test-contracts: 28 passed, 813 deselected, 2 warnings
- pre-commit Block 1: format, yaml-lint, bundle imports, lint
- pre-commit Block 2: command overview, command contract, prompt validation, code review gate, contract tests