### PR TITLE
chore(modules): recover signed module publication

### DIFF
--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -24,3 +24,4 @@ category: codebase
 bundle_group_command: code
 integrity:
   checksum: sha256:2fc7b2456493245328c294008e17a72a224edfeb7c3ca2fc581b5de94fe941ca
+  signature: QJB9dXYvdTTzboXBRGGqMXoEKvoVdVwK/B9NVZ/xk2F8QwusMkXMGVqmQzF+biH4xIaujqK94wqw30s2yIUMDQ==

--- a/packages/specfact-code-review/module-package.yaml
+++ b/packages/specfact-code-review/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-code-review
-version: 0.47.51
+version: 0.47.52
 commands:
   - code
 tier: official
@@ -23,5 +23,4 @@ description: Official SpecFact code review bundle package.
 category: codebase
 bundle_group_command: code
 integrity:
-  checksum: sha256:f85ae00bc406952621b590367370ef7a9d28acbc26703befa5b1b1a76a6ef516
-  signature: fJJEEZliDUcVlOmmjMLAqrYAjHz+r1jVLU8JB09SDeKTVM0yrilkWCqnGpKKMAwat4dw/s0ispT+brZogMqoAQ==
+  checksum: sha256:2fc7b2456493245328c294008e17a72a224edfeb7c3ca2fc581b5de94fe941ca

--- a/packages/specfact-requirements/module-package.yaml
+++ b/packages/specfact-requirements/module-package.yaml
@@ -20,3 +20,4 @@ category: project
 bundle_group_command: requirements
 integrity:
   checksum: sha256:ed53370ebcfb4a0667e5fc7e0af097d0dd4896fc70b583965664ccc833d1e8b3
+  signature: piqKk1AXxSRms2k+hGRn8IHFQE4g60M14qU/rDdChn++sq/HBCj7S9fNq1LfhyKD0TfendIbz01Is+dIoB1cDw==

--- a/packages/specfact-requirements/module-package.yaml
+++ b/packages/specfact-requirements/module-package.yaml
@@ -1,5 +1,5 @@
 name: nold-ai/specfact-requirements
-version: 0.2.3
+version: 0.2.4
 commands:
   - requirements
 tier: official
@@ -19,5 +19,4 @@ description: Official SpecFact requirements evidence runtime bundle package.
 category: project
 bundle_group_command: requirements
 integrity:
-  checksum: sha256:02ae009efbaba529ba0b4abc14a0ca11c0d08d6451dff094236ce3e850f046a7
-  signature: 2WfMBL5+ISTzij7cpqX25K2blP7XXG52jcWc43xE8lPEJE8AKnMsYzZfArd75VVPjTS1kPqzwKxmGlGwodpaDg==
+  checksum: sha256:ed53370ebcfb4a0667e5fc7e0af097d0dd4896fc70b583965664ccc833d1e8b3


### PR DESCRIPTION
## Summary

Prepare corrected releases for the requirements and code-review modules:

- `nold-ai/specfact-requirements`: `0.2.3` → `0.2.4`
- `nold-ai/specfact-code-review`: `0.47.51` → `0.47.52`

## Root cause

The prior feature PR committed registry entries and tarballs before the canonical `publish-modules` workflow ran. The source manifests were later signed by CI, while the committed tarballs still embedded unsigned manifests. Because `dev` already recorded the same versions, a manual publish dispatch selected no corrective release.

## Release path

This change intentionally leaves `registry/**` untouched and keeps local manifests checksum-only. After merge to `dev`, CI must generate the signed manifest and registry publication PRs for these new versions.

## Validation

- `hatch run yaml-lint`
- `hatch run verify-modules-signature --payload-from-filesystem --enforce-version-bump --allow-missing-public-key`
- pre-commit format, YAML, import-boundary, command-reference, documentation, and manifest-signature checks
