### PR TITLE
chore(openspec): archive docs-16 accountability sync

### DIFF
--- a/docs/reference/commands.generated.json
+++ b/docs/reference/commands.generated.json
@@ -6,7 +6,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--install-completion",
+      "--show-completion"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -34,7 +37,27 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--acceptance-criteria",
+      "--adapter",
+      "--body",
+      "--body-end-marker",
+      "--business-value",
+      "--check-dor",
+      "--custom-config",
+      "--description-format",
+      "--non-interactive",
+      "--parent",
+      "--priority",
+      "--project-id",
+      "--provider-field",
+      "--repo-path",
+      "--sprint",
+      "--story-points",
+      "--template",
+      "--title",
+      "--type"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -48,7 +71,14 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--custom-config",
+      "--json-export",
+      "--output",
+      "--project-id",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -81,7 +111,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--pat",
+      "--use-device-code"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -95,7 +128,9 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--provider"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -109,7 +144,11 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--base-url",
+      "--client-id",
+      "--scopes"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -151,13 +190,21 @@
     ]
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ADAPTER",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog ceremony flow",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--mode"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -165,13 +212,21 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ADAPTER",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog ceremony pi-summary",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--mode"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -179,13 +234,21 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ADAPTER",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog ceremony planning",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--mode"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -193,7 +256,13 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ADAPTER",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog ceremony refinement",
     "deprecated": false,
@@ -207,13 +276,21 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ADAPTER",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog ceremony standup",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--mode"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -221,13 +298,58 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ADAPTER",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog daily",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--ado-org",
+      "--ado-project",
+      "--ado-team",
+      "--ado-token",
+      "--annotations",
+      "--assignee",
+      "--blockers",
+      "--blockers-first",
+      "--comments",
+      "--copilot-export",
+      "--first-comments",
+      "--first-issues",
+      "--github-token",
+      "--id",
+      "--interactive",
+      "--iteration",
+      "--labels",
+      "--last-comments",
+      "--last-issues",
+      "--limit",
+      "--mode",
+      "--no-show-unassigned",
+      "--patch",
+      "--post",
+      "--release",
+      "--repo-name",
+      "--repo-owner",
+      "--search",
+      "--show-unassigned",
+      "--sprint",
+      "--state",
+      "--suggest-next",
+      "--summarize",
+      "--summarize-to",
+      "--tags",
+      "--today",
+      "--unassigned-only",
+      "--yesterday"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -260,7 +382,12 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--baseline-file",
+      "--project-id",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -268,13 +395,23 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ITEM_ID",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog delta impact",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--project-id",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -288,7 +425,12 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--baseline-file",
+      "--project-id",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -296,13 +438,27 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ADAPTER_ARG",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog delta status",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--baseline-file",
+      "--project-id",
+      "--repo-name",
+      "--repo-owner",
+      "--since",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -316,7 +472,12 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--baseline-file",
+      "--project-id",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -330,7 +491,9 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--force"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -344,7 +507,20 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--ado-base-url",
+      "--ado-framework",
+      "--ado-org",
+      "--ado-project",
+      "--ado-token",
+      "--github-project-id",
+      "--github-project-v2-id",
+      "--github-type-field-id",
+      "--github-type-option",
+      "--non-interactive",
+      "--provider",
+      "--reset"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -358,7 +534,13 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--item-id",
+      "--project-id",
+      "--template",
+      "--to-status"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -366,13 +548,58 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "ADAPTER",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact backlog refine",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--ado-org",
+      "--ado-project",
+      "--ado-team",
+      "--ado-token",
+      "--assignee",
+      "--auto-accept-high-confidence",
+      "--auto-bundle",
+      "--bundle",
+      "--check-dor",
+      "--custom-field-mapping",
+      "--export-to-tmp",
+      "--first-comments",
+      "--first-issues",
+      "--framework",
+      "--github-token",
+      "--id",
+      "--ignore-refined",
+      "--import-from-tmp",
+      "--iteration",
+      "--labels",
+      "--last-comments",
+      "--last-issues",
+      "--limit",
+      "--no-ignore-refined",
+      "--no-preview",
+      "--openspec-comment",
+      "--persona",
+      "--preview",
+      "--release",
+      "--repo-name",
+      "--repo-owner",
+      "--search",
+      "--sprint",
+      "--state",
+      "--tags",
+      "--template",
+      "--tmp-file",
+      "--write"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -386,7 +613,14 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--baseline-file",
+      "--force-baseline-overwrite",
+      "--output-format",
+      "--project-id",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -400,7 +634,12 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-backlog",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--project-id",
+      "--target-items",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-backlog",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -414,7 +653,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--install-completion",
+      "--show-completion"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -450,7 +692,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -474,13 +719,23 @@
     ]
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "BUNDLE",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact code drift detect",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--format",
+      "--out",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -488,13 +743,34 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "BUNDLE",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact code import",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--confidence",
+      "--enrich-for-speckit",
+      "--enrichment",
+      "--entry-point",
+      "--exclude-tests",
+      "--force",
+      "--include-tests",
+      "--key-format",
+      "--no-enrich-for-speckit",
+      "--no-revalidate-features",
+      "--repo",
+      "--report",
+      "--revalidate-features",
+      "--shadow-only"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -511,7 +787,15 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--dry-run",
+      "--force",
+      "--out-branch",
+      "--repo",
+      "--report",
+      "--write"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -519,13 +803,34 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "BUNDLE",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact code import from-code",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--confidence",
+      "--enrich-for-speckit",
+      "--enrichment",
+      "--entry-point",
+      "--exclude-tests",
+      "--force",
+      "--include-tests",
+      "--key-format",
+      "--no-enrich-for-speckit",
+      "--no-revalidate-features",
+      "--repo",
+      "--report",
+      "--revalidate-features",
+      "--shadow-only"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -539,7 +844,18 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--budget",
+      "--crosshair-per-path-timeout",
+      "--crosshair-required",
+      "--fail-fast",
+      "--fix",
+      "--out",
+      "--repo",
+      "--sidecar",
+      "--sidecar-bundle",
+      "--verbose"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -555,7 +871,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--install-crosshair",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -569,7 +888,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-code-review",
-    "options": [],
+    "options": [
+      "--install-completion",
+      "--show-completion"
+    ],
     "owner_package": "nold-ai/specfact-code-review",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -621,7 +943,9 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-code-review",
-    "options": [],
+    "options": [
+      "--confirm"
+    ],
     "owner_package": "nold-ai/specfact-code-review",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -649,7 +973,9 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-code-review",
-    "options": [],
+    "options": [
+      "--from"
+    ],
     "owner_package": "nold-ai/specfact-code-review",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -681,7 +1007,9 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-code-review",
-    "options": [],
+    "options": [
+      "--ide"
+    ],
     "owner_package": "nold-ai/specfact-code-review",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -709,7 +1037,9 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-code-review",
-    "options": [],
+    "options": [
+      "--ide"
+    ],
     "owner_package": "nold-ai/specfact-code-review",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -717,13 +1047,40 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "FILES",
+        "nargs": -1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact code review review run",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-code-review",
-    "options": [],
+    "options": [
+      "--bug-hunt",
+      "--enforcement",
+      "--exclude-tests",
+      "--fix",
+      "--focus",
+      "--include-noise",
+      "--include-tests",
+      "--instructions",
+      "--interactive",
+      "--json",
+      "--level",
+      "--mode",
+      "--no-tests",
+      "--out",
+      "--path",
+      "--preview-fixes",
+      "--scope",
+      "--score-only",
+      "--suppress-noise",
+      "--with-mutation"
+    ],
     "owner_package": "nold-ai/specfact-code-review",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -764,7 +1121,18 @@
     ]
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "BUNDLE_NAME",
+        "nargs": 1,
+        "required": true
+      },
+      {
+        "name": "REPO_PATH",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact code validate sidecar init",
     "deprecated": false,
@@ -778,13 +1146,29 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "BUNDLE_NAME",
+        "nargs": 1,
+        "required": true
+      },
+      {
+        "name": "REPO_PATH",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact code validate sidecar run",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-codebase",
-    "options": [],
+    "options": [
+      "--no-run-crosshair",
+      "--no-run-specmatic",
+      "--run-crosshair",
+      "--run-specmatic"
+    ],
     "owner_package": "nold-ai/specfact-codebase",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -798,7 +1182,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-govern",
-    "options": [],
+    "options": [
+      "--install-completion",
+      "--show-completion"
+    ],
     "owner_package": "nold-ai/specfact-govern",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -826,13 +1213,24 @@
     ]
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "BUNDLE",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact govern enforce sdd",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-govern",
-    "options": [],
+    "options": [
+      "--no-interactive",
+      "--out",
+      "--output-format",
+      "--sdd"
+    ],
     "owner_package": "nold-ai/specfact-govern",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -846,7 +1244,9 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-govern",
-    "options": [],
+    "options": [
+      "--preset"
+    ],
     "owner_package": "nold-ai/specfact-govern",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -870,13 +1270,23 @@
     ]
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "PATCH_FILE",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact govern patch apply",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-govern",
-    "options": [],
+    "options": [
+      "--dry-run",
+      "--write",
+      "--yes"
+    ],
     "owner_package": "nold-ai/specfact-govern",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -890,7 +1300,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--install-completion",
+      "--show-completion"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -921,7 +1334,15 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--action",
+      "--bundle",
+      "--no-interactive",
+      "--project-name",
+      "--repo",
+      "--stage",
+      "--verbose"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -935,7 +1356,18 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--list-personas",
+      "--no-interactive",
+      "--out",
+      "--output",
+      "--output-dir",
+      "--persona",
+      "--repo",
+      "--stdout",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -949,7 +1381,13 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--output",
+      "--project-name",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -963,7 +1401,13 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--project-name",
+      "--repo",
+      "--verbose"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -977,7 +1421,15 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--dry-run",
+      "--file",
+      "--input",
+      "--no-interactive",
+      "--persona",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -991,7 +1443,12 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--persona",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1005,7 +1462,15 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--bundle",
+      "--no-interactive",
+      "--project-id",
+      "--project-name",
+      "--repo",
+      "--template"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1019,7 +1484,13 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--persona",
+      "--repo",
+      "--section"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1033,7 +1504,11 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1047,7 +1522,19 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--base",
+      "--bundle",
+      "--no-interactive",
+      "--ours",
+      "--out",
+      "--output",
+      "--persona-ours",
+      "--persona-theirs",
+      "--repo",
+      "--strategy",
+      "--theirs"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1061,7 +1548,14 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--project-name",
+      "--repo",
+      "--strict",
+      "--verbose"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1075,7 +1569,14 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--path",
+      "--persona",
+      "--repo",
+      "--resolution"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1089,7 +1590,13 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--output",
+      "--project-name",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1121,7 +1628,49 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--adapter",
+      "--add-progress-comment",
+      "--ado-base-url",
+      "--ado-org",
+      "--ado-project",
+      "--ado-token",
+      "--ado-work-item-type",
+      "--all",
+      "--backlog-ids",
+      "--backlog-ids-file",
+      "--bidirectional",
+      "--bundle",
+      "--change-ids",
+      "--code-repo",
+      "--ensure-compliance",
+      "--export-to-tmp",
+      "--external-base-path",
+      "--feature",
+      "--github-token",
+      "--import-from-tmp",
+      "--include-archived",
+      "--interactive",
+      "--interval",
+      "--mode",
+      "--no-add-progress-comment",
+      "--no-gh-cli",
+      "--no-include-archived",
+      "--no-sanitize",
+      "--no-track-code-changes",
+      "--no-update-existing",
+      "--overwrite",
+      "--repo",
+      "--repo-name",
+      "--repo-owner",
+      "--sanitize",
+      "--target-repo",
+      "--tmp-file",
+      "--track-code-changes",
+      "--update-existing",
+      "--use-gh-cli",
+      "--watch"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1129,13 +1678,25 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "BUNDLE",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact project sync intelligent",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--code-to-spec",
+      "--repo",
+      "--spec-to-code",
+      "--tests",
+      "--watch"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1149,7 +1710,13 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--confidence",
+      "--interval",
+      "--repo",
+      "--target",
+      "--watch"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1163,7 +1730,12 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--no-interactive",
+      "--repo",
+      "--section"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1195,7 +1767,11 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--repo",
+      "--type"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1209,7 +1785,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--repo"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1223,7 +1802,11 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-project",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--repo",
+      "--version"
+    ],
     "owner_package": "nold-ai/specfact-project",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1237,7 +1820,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-requirements",
-    "options": [],
+    "options": [
+      "--install-completion",
+      "--show-completion"
+    ],
     "owner_package": "nold-ai/specfact-requirements",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1256,7 +1842,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-requirements",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--format"
+    ],
     "owner_package": "nold-ai/specfact-requirements",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1264,13 +1853,25 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "SOURCE_PATH",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact requirements import",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-requirements",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--format",
+      "--from-file",
+      "--from-openspec",
+      "--from-speckit"
+    ],
     "owner_package": "nold-ai/specfact-requirements",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1284,7 +1885,11 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-requirements",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--format",
+      "--show-coverage"
+    ],
     "owner_package": "nold-ai/specfact-requirements",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1298,7 +1903,11 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-requirements",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--format",
+      "--profile"
+    ],
     "owner_package": "nold-ai/specfact-requirements",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1312,7 +1921,10 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-spec",
-    "options": [],
+    "options": [
+      "--install-completion",
+      "--show-completion"
+    ],
     "owner_package": "nold-ai/specfact-spec",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1325,7 +1937,18 @@
     ]
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "OLD_SPEC",
+        "nargs": 1,
+        "required": true
+      },
+      {
+        "name": "NEW_SPEC",
+        "nargs": 1,
+        "required": true
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact spec backward-compat",
     "deprecated": false,
@@ -1339,13 +1962,24 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "SPEC_PATH",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact spec generate-tests",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-spec",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--force",
+      "--out",
+      "--output"
+    ],
     "owner_package": "nold-ai/specfact-spec",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1359,7 +1993,14 @@
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-spec",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--examples",
+      "--no-interactive",
+      "--port",
+      "--spec",
+      "--strict"
+    ],
     "owner_package": "nold-ai/specfact-spec",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",
@@ -1367,13 +2008,24 @@
     "subcommands": []
   },
   {
-    "arguments": [],
+    "arguments": [
+      {
+        "name": "SPEC_PATH",
+        "nargs": 1,
+        "required": false
+      }
+    ],
     "bare_invocation": "executes",
     "command": "specfact spec validate",
     "deprecated": false,
     "hidden": false,
     "install_prerequisite": "specfact module install nold-ai/specfact-spec",
-    "options": [],
+    "options": [
+      "--bundle",
+      "--force",
+      "--no-interactive",
+      "--previous"
+    ],
     "owner_package": "nold-ai/specfact-spec",
     "owner_repo": "nold-ai/specfact-cli-modules",
     "short_help": "",

--- a/docs/reference/commands.generated.md
+++ b/docs/reference/commands.generated.md
@@ -12,94 +12,94 @@ This file is generated from the current module command trees. Do not edit by han
 
 | Command | Module | Install | Options | Subcommands | Context |
 | --- | --- | --- | --- | --- | --- |
-| `specfact backlog` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | add, analyze-deps, auth, ceremony, daily, delta, diff, init-config, map-fields, promote, refine, sync, verify-readiness |  |
-| `specfact backlog add` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog analyze-deps` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
+| `specfact backlog` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --install-completion, --show-completion; args: - | add, analyze-deps, auth, ceremony, daily, delta, diff, init-config, map-fields, promote, refine, sync, verify-readiness |  |
+| `specfact backlog add` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --acceptance-criteria, --adapter, --body, --body-end-marker, --business-value, --check-dor, --custom-config, --description-format, --non-interactive, --parent, --priority, --project-id, --provider-field, --repo-path, --sprint, --story-points, --template, --title, --type; args: - | - |  |
+| `specfact backlog analyze-deps` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --custom-config, --json-export, --output, --project-id, --template; args: - | - |  |
 | `specfact backlog auth` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | azure-devops, clear, github, status |  |
-| `specfact backlog auth azure-devops` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog auth clear` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog auth github` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
+| `specfact backlog auth azure-devops` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --pat, --use-device-code; args: - | - |  |
+| `specfact backlog auth clear` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --provider; args: - | - |  |
+| `specfact backlog auth github` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --base-url, --client-id, --scopes; args: - | - |  |
 | `specfact backlog auth status` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
 | `specfact backlog ceremony` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | flow, pi-summary, planning, refinement, standup |  |
-| `specfact backlog ceremony flow` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog ceremony pi-summary` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog ceremony planning` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog ceremony refinement` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog ceremony standup` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog daily` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
+| `specfact backlog ceremony flow` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --mode; args: ADAPTER (required) | - |  |
+| `specfact backlog ceremony pi-summary` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --mode; args: ADAPTER (required) | - |  |
+| `specfact backlog ceremony planning` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --mode; args: ADAPTER (required) | - |  |
+| `specfact backlog ceremony refinement` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: ADAPTER (required) | - |  |
+| `specfact backlog ceremony standup` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --mode; args: ADAPTER (required) | - |  |
+| `specfact backlog daily` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --ado-org, --ado-project, --ado-team, --ado-token, --annotations, --assignee, --blockers, --blockers-first, --comments, --copilot-export, --first-comments, --first-issues, --github-token, --id, --interactive, --iteration, --labels, --last-comments, --last-issues, --limit, --mode, --no-show-unassigned, --patch, --post, --release, --repo-name, --repo-owner, --search, --show-unassigned, --sprint, --state, --suggest-next, --summarize, --summarize-to, --tags, --today, --unassigned-only, --yesterday; args: ADAPTER (required) | - |  |
 | `specfact backlog delta` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | cost-estimate, impact, rollback-analysis, status |  |
-| `specfact backlog delta cost-estimate` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog delta impact` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog delta rollback-analysis` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog delta status` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog diff` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog init-config` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog map-fields` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog promote` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog refine` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog sync` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog verify-readiness` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact code` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | analyze, drift, import, repro, validate |  |
+| `specfact backlog delta cost-estimate` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --project-id, --template; args: - | - |  |
+| `specfact backlog delta impact` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --project-id, --template; args: ITEM_ID (required) | - |  |
+| `specfact backlog delta rollback-analysis` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --project-id, --template; args: - | - |  |
+| `specfact backlog delta status` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --project-id, --repo-name, --repo-owner, --since, --template; args: ADAPTER_ARG | - |  |
+| `specfact backlog diff` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --project-id, --template; args: - | - |  |
+| `specfact backlog init-config` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --force; args: - | - |  |
+| `specfact backlog map-fields` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --ado-base-url, --ado-framework, --ado-org, --ado-project, --ado-token, --github-project-id, --github-project-v2-id, --github-type-field-id, --github-type-option, --non-interactive, --provider, --reset; args: - | - |  |
+| `specfact backlog promote` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --item-id, --project-id, --template, --to-status; args: - | - |  |
+| `specfact backlog refine` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --ado-org, --ado-project, --ado-team, --ado-token, --assignee, --auto-accept-high-confidence, --auto-bundle, --bundle, --check-dor, --custom-field-mapping, --export-to-tmp, --first-comments, --first-issues, --framework, --github-token, --id, --ignore-refined, --import-from-tmp, --iteration, --labels, --last-comments, --last-issues, --limit, --no-ignore-refined, --no-preview, --openspec-comment, --persona, --preview, --release, --repo-name, --repo-owner, --search, --sprint, --state, --tags, --template, --tmp-file, --write; args: ADAPTER (required) | - |  |
+| `specfact backlog sync` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --force-baseline-overwrite, --output-format, --project-id, --template; args: - | - |  |
+| `specfact backlog verify-readiness` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --project-id, --target-items, --template; args: - | - |  |
+| `specfact code` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --install-completion, --show-completion; args: - | analyze, drift, import, repro, validate |  |
 | `specfact code analyze` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | contracts |  |
-| `specfact code analyze contracts` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
+| `specfact code analyze contracts` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --bundle, --repo; args: - | - |  |
 | `specfact code drift` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | detect |  |
-| `specfact code drift detect` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code import` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | from-bridge, from-code |  |
-| `specfact code import from-bridge` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code import from-code` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code repro` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | setup |  |
-| `specfact code repro setup` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code review` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | review |  |
+| `specfact code drift detect` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --format, --out, --repo; args: BUNDLE | - |  |
+| `specfact code import` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --confidence, --enrich-for-speckit, --enrichment, --entry-point, --exclude-tests, --force, --include-tests, --key-format, --no-enrich-for-speckit, --no-revalidate-features, --repo, --report, --revalidate-features, --shadow-only; args: BUNDLE | from-bridge, from-code |  |
+| `specfact code import from-bridge` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --adapter, --dry-run, --force, --out-branch, --repo, --report, --write; args: - | - |  |
+| `specfact code import from-code` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --confidence, --enrich-for-speckit, --enrichment, --entry-point, --exclude-tests, --force, --include-tests, --key-format, --no-enrich-for-speckit, --no-revalidate-features, --repo, --report, --revalidate-features, --shadow-only; args: BUNDLE | - |  |
+| `specfact code repro` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --budget, --crosshair-per-path-timeout, --crosshair-required, --fail-fast, --fix, --out, --repo, --sidecar, --sidecar-bundle, --verbose; args: - | setup |  |
+| `specfact code repro setup` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --install-crosshair, --repo; args: - | - |  |
+| `specfact code review` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --install-completion, --show-completion; args: - | review |  |
 | `specfact code review review` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | ledger, rules, run |  |
 | `specfact code review review ledger` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | reset, status, update |  |
-| `specfact code review review ledger reset` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
+| `specfact code review review ledger reset` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --confirm; args: - | - |  |
 | `specfact code review review ledger status` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
-| `specfact code review review ledger update` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
+| `specfact code review review ledger update` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --from; args: - | - |  |
 | `specfact code review review rules` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | init, show, update |  |
-| `specfact code review review rules init` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
+| `specfact code review review rules init` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --ide; args: - | - |  |
 | `specfact code review review rules show` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
-| `specfact code review review rules update` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
-| `specfact code review review run` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
+| `specfact code review review rules update` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --ide; args: - | - |  |
+| `specfact code review review run` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --bug-hunt, --enforcement, --exclude-tests, --fix, --focus, --include-noise, --include-tests, --instructions, --interactive, --json, --level, --mode, --no-tests, --out, --path, --preview-fixes, --scope, --score-only, --suppress-noise, --with-mutation; args: FILES | - |  |
 | `specfact code validate` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | sidecar |  |
 | `specfact code validate sidecar` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | init, run |  |
-| `specfact code validate sidecar init` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code validate sidecar run` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact govern` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | enforce, patch |  |
+| `specfact code validate sidecar init` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: BUNDLE_NAME (required), REPO_PATH (required) | - |  |
+| `specfact code validate sidecar run` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --no-run-crosshair, --no-run-specmatic, --run-crosshair, --run-specmatic; args: BUNDLE_NAME (required), REPO_PATH (required) | - |  |
+| `specfact govern` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | --install-completion, --show-completion; args: - | enforce, patch |  |
 | `specfact govern enforce` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | sdd, stage |  |
-| `specfact govern enforce sdd` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | - |  |
-| `specfact govern enforce stage` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | - |  |
+| `specfact govern enforce sdd` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | --no-interactive, --out, --output-format, --sdd; args: BUNDLE | - |  |
+| `specfact govern enforce stage` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | --preset; args: - | - |  |
 | `specfact govern patch` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | apply |  |
-| `specfact govern patch apply` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | - |  |
-| `specfact project` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | devops-flow, export, export-roadmap, health-check, import, init-personas, link-backlog, lock, locks, merge, regenerate, resolve-conflict, snapshot, sync, unlock, version |  |
-| `specfact project devops-flow` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project export` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project export-roadmap` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project health-check` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project import` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project init-personas` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project link-backlog` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project lock` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project locks` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project merge` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project regenerate` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project resolve-conflict` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project snapshot` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
+| `specfact govern patch apply` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | --dry-run, --write, --yes; args: PATCH_FILE (required) | - |  |
+| `specfact project` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --install-completion, --show-completion; args: - | devops-flow, export, export-roadmap, health-check, import, init-personas, link-backlog, lock, locks, merge, regenerate, resolve-conflict, snapshot, sync, unlock, version |  |
+| `specfact project devops-flow` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --action, --bundle, --no-interactive, --project-name, --repo, --stage, --verbose; args: - | - |  |
+| `specfact project export` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --list-personas, --no-interactive, --out, --output, --output-dir, --persona, --repo, --stdout, --template; args: - | - |  |
+| `specfact project export-roadmap` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --output, --project-name, --repo; args: - | - |  |
+| `specfact project health-check` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --project-name, --repo, --verbose; args: - | - |  |
+| `specfact project import` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --dry-run, --file, --input, --no-interactive, --persona, --repo; args: - | - |  |
+| `specfact project init-personas` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --persona, --repo; args: - | - |  |
+| `specfact project link-backlog` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --adapter, --bundle, --no-interactive, --project-id, --project-name, --repo, --template; args: - | - |  |
+| `specfact project lock` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --persona, --repo, --section; args: - | - |  |
+| `specfact project locks` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --repo; args: - | - |  |
+| `specfact project merge` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --base, --bundle, --no-interactive, --ours, --out, --output, --persona-ours, --persona-theirs, --repo, --strategy, --theirs; args: - | - |  |
+| `specfact project regenerate` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --project-name, --repo, --strict, --verbose; args: - | - |  |
+| `specfact project resolve-conflict` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --path, --persona, --repo, --resolution; args: - | - |  |
+| `specfact project snapshot` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --output, --project-name, --repo; args: - | - |  |
 | `specfact project sync` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | bridge, intelligent, repository |  |
-| `specfact project sync bridge` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project sync intelligent` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project sync repository` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project unlock` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
+| `specfact project sync bridge` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --adapter, --add-progress-comment, --ado-base-url, --ado-org, --ado-project, --ado-token, --ado-work-item-type, --all, --backlog-ids, --backlog-ids-file, --bidirectional, --bundle, --change-ids, --code-repo, --ensure-compliance, --export-to-tmp, --external-base-path, --feature, --github-token, --import-from-tmp, --include-archived, --interactive, --interval, --mode, --no-add-progress-comment, --no-gh-cli, --no-include-archived, --no-sanitize, --no-track-code-changes, --no-update-existing, --overwrite, --repo, --repo-name, --repo-owner, --sanitize, --target-repo, --tmp-file, --track-code-changes, --update-existing, --use-gh-cli, --watch; args: - | - |  |
+| `specfact project sync intelligent` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --code-to-spec, --repo, --spec-to-code, --tests, --watch; args: BUNDLE | - |  |
+| `specfact project sync repository` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --confidence, --interval, --repo, --target, --watch; args: - | - |  |
+| `specfact project unlock` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --repo, --section; args: - | - |  |
 | `specfact project version` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | bump, check, set |  |
-| `specfact project version bump` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project version check` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project version set` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact requirements` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | coverage, import, list, validate |  |
-| `specfact requirements coverage` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | - |  |
-| `specfact requirements import` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | - |  |
-| `specfact requirements list` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | - |  |
-| `specfact requirements validate` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | - |  |
-| `specfact spec` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | backward-compat, generate-tests, mock, validate |  |
-| `specfact spec backward-compat` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | - |  |
-| `specfact spec generate-tests` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | - |  |
-| `specfact spec mock` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | - |  |
-| `specfact spec validate` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | - |  |
+| `specfact project version bump` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --repo, --type; args: - | - |  |
+| `specfact project version check` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --repo; args: - | - |  |
+| `specfact project version set` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --repo, --version; args: - | - |  |
+| `specfact requirements` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --install-completion, --show-completion; args: - | coverage, import, list, validate |  |
+| `specfact requirements coverage` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --bundle, --format; args: - | - |  |
+| `specfact requirements import` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --bundle, --format, --from-file, --from-openspec, --from-speckit; args: SOURCE_PATH | - |  |
+| `specfact requirements list` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --bundle, --format, --show-coverage; args: - | - |  |
+| `specfact requirements validate` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --bundle, --format, --profile; args: - | - |  |
+| `specfact spec` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | --install-completion, --show-completion; args: - | backward-compat, generate-tests, mock, validate |  |
+| `specfact spec backward-compat` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: OLD_SPEC (required), NEW_SPEC (required) | - |  |
+| `specfact spec generate-tests` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | --bundle, --force, --out, --output; args: SPEC_PATH | - |  |
+| `specfact spec mock` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | --bundle, --examples, --no-interactive, --port, --spec, --strict; args: - | - |  |
+| `specfact spec validate` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | --bundle, --force, --no-interactive, --previous; args: SPEC_PATH | - |  |

--- a/llms.txt
+++ b/llms.txt
@@ -16,94 +16,94 @@ This file is generated from the current module command trees. Do not edit by han
 
 | Command | Module | Install | Options | Subcommands | Context |
 | --- | --- | --- | --- | --- | --- |
-| `specfact backlog` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | add, analyze-deps, auth, ceremony, daily, delta, diff, init-config, map-fields, promote, refine, sync, verify-readiness |  |
-| `specfact backlog add` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog analyze-deps` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
+| `specfact backlog` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --install-completion, --show-completion; args: - | add, analyze-deps, auth, ceremony, daily, delta, diff, init-config, map-fields, promote, refine, sync, verify-readiness |  |
+| `specfact backlog add` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --acceptance-criteria, --adapter, --body, --body-end-marker, --business-value, --check-dor, --custom-config, --description-format, --non-interactive, --parent, --priority, --project-id, --provider-field, --repo-path, --sprint, --story-points, --template, --title, --type; args: - | - |  |
+| `specfact backlog analyze-deps` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --custom-config, --json-export, --output, --project-id, --template; args: - | - |  |
 | `specfact backlog auth` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | azure-devops, clear, github, status |  |
-| `specfact backlog auth azure-devops` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog auth clear` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog auth github` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
+| `specfact backlog auth azure-devops` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --pat, --use-device-code; args: - | - |  |
+| `specfact backlog auth clear` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --provider; args: - | - |  |
+| `specfact backlog auth github` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --base-url, --client-id, --scopes; args: - | - |  |
 | `specfact backlog auth status` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
 | `specfact backlog ceremony` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | flow, pi-summary, planning, refinement, standup |  |
-| `specfact backlog ceremony flow` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog ceremony pi-summary` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog ceremony planning` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog ceremony refinement` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog ceremony standup` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog daily` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
+| `specfact backlog ceremony flow` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --mode; args: ADAPTER (required) | - |  |
+| `specfact backlog ceremony pi-summary` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --mode; args: ADAPTER (required) | - |  |
+| `specfact backlog ceremony planning` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --mode; args: ADAPTER (required) | - |  |
+| `specfact backlog ceremony refinement` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: ADAPTER (required) | - |  |
+| `specfact backlog ceremony standup` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --mode; args: ADAPTER (required) | - |  |
+| `specfact backlog daily` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --ado-org, --ado-project, --ado-team, --ado-token, --annotations, --assignee, --blockers, --blockers-first, --comments, --copilot-export, --first-comments, --first-issues, --github-token, --id, --interactive, --iteration, --labels, --last-comments, --last-issues, --limit, --mode, --no-show-unassigned, --patch, --post, --release, --repo-name, --repo-owner, --search, --show-unassigned, --sprint, --state, --suggest-next, --summarize, --summarize-to, --tags, --today, --unassigned-only, --yesterday; args: ADAPTER (required) | - |  |
 | `specfact backlog delta` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | cost-estimate, impact, rollback-analysis, status |  |
-| `specfact backlog delta cost-estimate` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog delta impact` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog delta rollback-analysis` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog delta status` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog diff` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog init-config` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog map-fields` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog promote` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog refine` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog sync` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact backlog verify-readiness` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | -; args: - | - |  |
-| `specfact code` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | analyze, drift, import, repro, validate |  |
+| `specfact backlog delta cost-estimate` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --project-id, --template; args: - | - |  |
+| `specfact backlog delta impact` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --project-id, --template; args: ITEM_ID (required) | - |  |
+| `specfact backlog delta rollback-analysis` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --project-id, --template; args: - | - |  |
+| `specfact backlog delta status` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --project-id, --repo-name, --repo-owner, --since, --template; args: ADAPTER_ARG | - |  |
+| `specfact backlog diff` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --project-id, --template; args: - | - |  |
+| `specfact backlog init-config` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --force; args: - | - |  |
+| `specfact backlog map-fields` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --ado-base-url, --ado-framework, --ado-org, --ado-project, --ado-token, --github-project-id, --github-project-v2-id, --github-type-field-id, --github-type-option, --non-interactive, --provider, --reset; args: - | - |  |
+| `specfact backlog promote` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --item-id, --project-id, --template, --to-status; args: - | - |  |
+| `specfact backlog refine` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --ado-org, --ado-project, --ado-team, --ado-token, --assignee, --auto-accept-high-confidence, --auto-bundle, --bundle, --check-dor, --custom-field-mapping, --export-to-tmp, --first-comments, --first-issues, --framework, --github-token, --id, --ignore-refined, --import-from-tmp, --iteration, --labels, --last-comments, --last-issues, --limit, --no-ignore-refined, --no-preview, --openspec-comment, --persona, --preview, --release, --repo-name, --repo-owner, --search, --sprint, --state, --tags, --template, --tmp-file, --write; args: ADAPTER (required) | - |  |
+| `specfact backlog sync` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --baseline-file, --force-baseline-overwrite, --output-format, --project-id, --template; args: - | - |  |
+| `specfact backlog verify-readiness` | nold-ai/specfact-backlog | `specfact module install nold-ai/specfact-backlog` | --adapter, --project-id, --target-items, --template; args: - | - |  |
+| `specfact code` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --install-completion, --show-completion; args: - | analyze, drift, import, repro, validate |  |
 | `specfact code analyze` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | contracts |  |
-| `specfact code analyze contracts` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
+| `specfact code analyze contracts` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --bundle, --repo; args: - | - |  |
 | `specfact code drift` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | detect |  |
-| `specfact code drift detect` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code import` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | from-bridge, from-code |  |
-| `specfact code import from-bridge` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code import from-code` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code repro` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | setup |  |
-| `specfact code repro setup` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code review` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | review |  |
+| `specfact code drift detect` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --format, --out, --repo; args: BUNDLE | - |  |
+| `specfact code import` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --confidence, --enrich-for-speckit, --enrichment, --entry-point, --exclude-tests, --force, --include-tests, --key-format, --no-enrich-for-speckit, --no-revalidate-features, --repo, --report, --revalidate-features, --shadow-only; args: BUNDLE | from-bridge, from-code |  |
+| `specfact code import from-bridge` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --adapter, --dry-run, --force, --out-branch, --repo, --report, --write; args: - | - |  |
+| `specfact code import from-code` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --confidence, --enrich-for-speckit, --enrichment, --entry-point, --exclude-tests, --force, --include-tests, --key-format, --no-enrich-for-speckit, --no-revalidate-features, --repo, --report, --revalidate-features, --shadow-only; args: BUNDLE | - |  |
+| `specfact code repro` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --budget, --crosshair-per-path-timeout, --crosshair-required, --fail-fast, --fix, --out, --repo, --sidecar, --sidecar-bundle, --verbose; args: - | setup |  |
+| `specfact code repro setup` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --install-crosshair, --repo; args: - | - |  |
+| `specfact code review` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --install-completion, --show-completion; args: - | review |  |
 | `specfact code review review` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | ledger, rules, run |  |
 | `specfact code review review ledger` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | reset, status, update |  |
-| `specfact code review review ledger reset` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
+| `specfact code review review ledger reset` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --confirm; args: - | - |  |
 | `specfact code review review ledger status` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
-| `specfact code review review ledger update` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
+| `specfact code review review ledger update` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --from; args: - | - |  |
 | `specfact code review review rules` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | init, show, update |  |
-| `specfact code review review rules init` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
+| `specfact code review review rules init` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --ide; args: - | - |  |
 | `specfact code review review rules show` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
-| `specfact code review review rules update` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
-| `specfact code review review run` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | -; args: - | - |  |
+| `specfact code review review rules update` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --ide; args: - | - |  |
+| `specfact code review review run` | nold-ai/specfact-code-review | `specfact module install nold-ai/specfact-code-review` | --bug-hunt, --enforcement, --exclude-tests, --fix, --focus, --include-noise, --include-tests, --instructions, --interactive, --json, --level, --mode, --no-tests, --out, --path, --preview-fixes, --scope, --score-only, --suppress-noise, --with-mutation; args: FILES | - |  |
 | `specfact code validate` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | sidecar |  |
 | `specfact code validate sidecar` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | init, run |  |
-| `specfact code validate sidecar init` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact code validate sidecar run` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: - | - |  |
-| `specfact govern` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | enforce, patch |  |
+| `specfact code validate sidecar init` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | -; args: BUNDLE_NAME (required), REPO_PATH (required) | - |  |
+| `specfact code validate sidecar run` | nold-ai/specfact-codebase | `specfact module install nold-ai/specfact-codebase` | --no-run-crosshair, --no-run-specmatic, --run-crosshair, --run-specmatic; args: BUNDLE_NAME (required), REPO_PATH (required) | - |  |
+| `specfact govern` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | --install-completion, --show-completion; args: - | enforce, patch |  |
 | `specfact govern enforce` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | sdd, stage |  |
-| `specfact govern enforce sdd` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | - |  |
-| `specfact govern enforce stage` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | - |  |
+| `specfact govern enforce sdd` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | --no-interactive, --out, --output-format, --sdd; args: BUNDLE | - |  |
+| `specfact govern enforce stage` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | --preset; args: - | - |  |
 | `specfact govern patch` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | apply |  |
-| `specfact govern patch apply` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | -; args: - | - |  |
-| `specfact project` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | devops-flow, export, export-roadmap, health-check, import, init-personas, link-backlog, lock, locks, merge, regenerate, resolve-conflict, snapshot, sync, unlock, version |  |
-| `specfact project devops-flow` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project export` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project export-roadmap` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project health-check` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project import` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project init-personas` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project link-backlog` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project lock` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project locks` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project merge` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project regenerate` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project resolve-conflict` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project snapshot` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
+| `specfact govern patch apply` | nold-ai/specfact-govern | `specfact module install nold-ai/specfact-govern` | --dry-run, --write, --yes; args: PATCH_FILE (required) | - |  |
+| `specfact project` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --install-completion, --show-completion; args: - | devops-flow, export, export-roadmap, health-check, import, init-personas, link-backlog, lock, locks, merge, regenerate, resolve-conflict, snapshot, sync, unlock, version |  |
+| `specfact project devops-flow` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --action, --bundle, --no-interactive, --project-name, --repo, --stage, --verbose; args: - | - |  |
+| `specfact project export` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --list-personas, --no-interactive, --out, --output, --output-dir, --persona, --repo, --stdout, --template; args: - | - |  |
+| `specfact project export-roadmap` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --output, --project-name, --repo; args: - | - |  |
+| `specfact project health-check` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --project-name, --repo, --verbose; args: - | - |  |
+| `specfact project import` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --dry-run, --file, --input, --no-interactive, --persona, --repo; args: - | - |  |
+| `specfact project init-personas` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --persona, --repo; args: - | - |  |
+| `specfact project link-backlog` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --adapter, --bundle, --no-interactive, --project-id, --project-name, --repo, --template; args: - | - |  |
+| `specfact project lock` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --persona, --repo, --section; args: - | - |  |
+| `specfact project locks` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --repo; args: - | - |  |
+| `specfact project merge` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --base, --bundle, --no-interactive, --ours, --out, --output, --persona-ours, --persona-theirs, --repo, --strategy, --theirs; args: - | - |  |
+| `specfact project regenerate` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --project-name, --repo, --strict, --verbose; args: - | - |  |
+| `specfact project resolve-conflict` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --path, --persona, --repo, --resolution; args: - | - |  |
+| `specfact project snapshot` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --output, --project-name, --repo; args: - | - |  |
 | `specfact project sync` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | bridge, intelligent, repository |  |
-| `specfact project sync bridge` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project sync intelligent` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project sync repository` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project unlock` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
+| `specfact project sync bridge` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --adapter, --add-progress-comment, --ado-base-url, --ado-org, --ado-project, --ado-token, --ado-work-item-type, --all, --backlog-ids, --backlog-ids-file, --bidirectional, --bundle, --change-ids, --code-repo, --ensure-compliance, --export-to-tmp, --external-base-path, --feature, --github-token, --import-from-tmp, --include-archived, --interactive, --interval, --mode, --no-add-progress-comment, --no-gh-cli, --no-include-archived, --no-sanitize, --no-track-code-changes, --no-update-existing, --overwrite, --repo, --repo-name, --repo-owner, --sanitize, --target-repo, --tmp-file, --track-code-changes, --update-existing, --use-gh-cli, --watch; args: - | - |  |
+| `specfact project sync intelligent` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --code-to-spec, --repo, --spec-to-code, --tests, --watch; args: BUNDLE | - |  |
+| `specfact project sync repository` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --confidence, --interval, --repo, --target, --watch; args: - | - |  |
+| `specfact project unlock` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --no-interactive, --repo, --section; args: - | - |  |
 | `specfact project version` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | bump, check, set |  |
-| `specfact project version bump` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project version check` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact project version set` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | -; args: - | - |  |
-| `specfact requirements` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | coverage, import, list, validate |  |
-| `specfact requirements coverage` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | - |  |
-| `specfact requirements import` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | - |  |
-| `specfact requirements list` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | - |  |
-| `specfact requirements validate` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | -; args: - | - |  |
-| `specfact spec` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | backward-compat, generate-tests, mock, validate |  |
-| `specfact spec backward-compat` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | - |  |
-| `specfact spec generate-tests` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | - |  |
-| `specfact spec mock` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | - |  |
-| `specfact spec validate` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: - | - |  |
+| `specfact project version bump` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --repo, --type; args: - | - |  |
+| `specfact project version check` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --repo; args: - | - |  |
+| `specfact project version set` | nold-ai/specfact-project | `specfact module install nold-ai/specfact-project` | --bundle, --repo, --version; args: - | - |  |
+| `specfact requirements` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --install-completion, --show-completion; args: - | coverage, import, list, validate |  |
+| `specfact requirements coverage` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --bundle, --format; args: - | - |  |
+| `specfact requirements import` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --bundle, --format, --from-file, --from-openspec, --from-speckit; args: SOURCE_PATH | - |  |
+| `specfact requirements list` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --bundle, --format, --show-coverage; args: - | - |  |
+| `specfact requirements validate` | nold-ai/specfact-requirements | `specfact module install nold-ai/specfact-requirements` | --bundle, --format, --profile; args: - | - |  |
+| `specfact spec` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | --install-completion, --show-completion; args: - | backward-compat, generate-tests, mock, validate |  |
+| `specfact spec backward-compat` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | -; args: OLD_SPEC (required), NEW_SPEC (required) | - |  |
+| `specfact spec generate-tests` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | --bundle, --force, --out, --output; args: SPEC_PATH | - |  |
+| `specfact spec mock` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | --bundle, --examples, --no-interactive, --port, --spec, --strict; args: - | - |  |
+| `specfact spec validate` | nold-ai/specfact-spec | `specfact module install nold-ai/specfact-spec` | --bundle, --force, --no-interactive, --previous; args: SPEC_PATH | - |  |

--- a/openspec/changes/archive/2026-07-26-docs-16-core-accountability-sync/proposal.md
+++ b/openspec/changes/archive/2026-07-26-docs-16-core-accountability-sync/proposal.md
@@ -46,12 +46,12 @@ command-artifact update path.
 
 - **GitHub Issue**: [#339](https://github.com/nold-ai/specfact-cli-modules/issues/339)
 - **Parent Epic**: [#162](https://github.com/nold-ai/specfact-cli-modules/issues/162)
-- **Project**: SpecFact CLI (`Todo`)
+- **Project**: SpecFact CLI (`Done`)
 - **Labels**: `bug`, `documentation`, `change-proposal`
 - **Prerequisite**: core [#643](https://github.com/nold-ai/specfact-cli/issues/643),
   implemented by `specfact-cli/cli-val-05-ci-integration`; it owns the
   authoritative checker and is closed as of 2026-07-10 Europe/Berlin.
-- **Blockers / blocked-by**: no native GitHub dependency is currently recorded;
-  implementation readiness must recheck and reconcile the relationship before
-  production edits.
-- **Last Synced Status**: #339 open, assigned, Todo; #643 closed, Done
+- **Blockers / blocked-by**: no remaining blocker; core #643 is closed and the
+  implementation was merged before this archival finalization.
+- **Last Synced Status**: #339 closed as completed on 2026-07-10; #643 closed,
+  Done

--- a/openspec/changes/command-overview-typer-compatibility/.openspec.yaml
+++ b/openspec/changes/command-overview-typer-compatibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/command-overview-typer-compatibility/TDD_EVIDENCE.md
+++ b/openspec/changes/command-overview-typer-compatibility/TDD_EVIDENCE.md
@@ -18,6 +18,10 @@ Result: failed as expected. `_command_options` returned `[]` instead of
 `typer._click.core.Parameter`, not Click's public `Option` and `Argument`
 classes.
 
+Before the explicit-metavar repair, the focused Typer argument regression
+failed because the generated argument record changed `path/to/file` to
+`PATH/TO/FILE`.
+
 ## Passing-after
 
 ### 2026-07-26 Europe/Berlin
@@ -54,3 +58,16 @@ classes.
   `import_openspec_change` does not accept the `project_root` argument expected
   by the merged Requirements source. The change-specific Docs Review suite
   remains green under the CI dependency set.
+
+## Review and CI follow-up
+
+### 2026-07-26 Europe/Berlin
+
+- The explicit-metavar regression and the existing Typer parameter regression
+  passed under both the Hatch runtime and the exact Docs Review environment
+  (Typer 0.27.0, Click 8.4.2); the generated-artifact `--check` also passed.
+- `requirements-evidence.yaml` maps the modified OpenSpec requirement to
+  `tests/unit/docs/test_llms_overview_freshness.py`.
+- The repaired requirements-evidence gate passed against the current paired
+  core CLI `dev` source at version 0.53.5: one requirement imported, one test
+  link and evidence link recorded, and zero failed sources.

--- a/openspec/changes/command-overview-typer-compatibility/TDD_EVIDENCE.md
+++ b/openspec/changes/command-overview-typer-compatibility/TDD_EVIDENCE.md
@@ -1,0 +1,56 @@
+# TDD Evidence: command-overview-typer-compatibility
+
+## Failing-before
+
+### 2026-07-26 Europe/Berlin
+
+An isolated environment installed `requirements-docs-ci.txt`, including Typer
+0.27.0 and Click 8.4.2. Before the generator change:
+
+```bash
+PYTHONPATH=. <docs-review-python> -m pytest \
+  tests/unit/docs/test_llms_overview_freshness.py::test_command_overview_records_typer_parameters \
+  -q -p no:cacheprovider
+```
+
+Result: failed as expected. `_command_options` returned `[]` instead of
+`["--format"]` because Typer 0.27 parameters inherit from
+`typer._click.core.Parameter`, not Click's public `Option` and `Argument`
+classes.
+
+## Passing-after
+
+### 2026-07-26 Europe/Berlin
+
+- The generator now accepts the supported Click and Typer parameter classes and
+  normalizes argument display names, keeping the output stable across the
+  Hatch and Docs Review runtimes.
+- Under the exact Docs Review dependencies, the focused Typer regression passed
+  and `scripts/generate-command-overview.py --check` passed.
+- `scripts/generate-command-overview.py --write` was run under those same
+  dependencies; the three generated artifacts were already the expected bytes.
+- The Docs Review test selection passed: 43 tests across docs workflow,
+  documentation accountability, pre-commit parity, and overview freshness.
+- Local focused checks passed: the overview freshness suite (6 tests),
+  `check-command-overview`, `check-command-contract`,
+  `scripts/check-docs-commands.py`, and
+  `check-core-documentation-accountability`.
+- `openspec validate command-overview-typer-compatibility --strict` passed.
+
+## Final quality evidence
+
+### 2026-07-26 Europe/Berlin
+
+- `hatch run format`, `type-check`, `lint`, `yaml-lint`,
+  `check-bundle-imports`, `contract-test`, and `smart-test` passed.
+- The baseline signature check could not load any local public keys for the
+  seven unchanged manifests. The repository-approved
+  `--allow-missing-public-key` checksum and version-bump verification passed
+  for all seven manifests; this change does not touch signed assets.
+- `hatch run specfact code review run --enforcement changed --bug-hunt --json
+  --out .specfact/code-review.json` completed with no findings.
+- `hatch run test` retains four unrelated Requirements failures because the
+  local paired core checkout is `specfact-cli` 0.52.3, whose
+  `import_openspec_change` does not accept the `project_root` argument expected
+  by the merged Requirements source. The change-specific Docs Review suite
+  remains green under the CI dependency set.

--- a/openspec/changes/command-overview-typer-compatibility/design.md
+++ b/openspec/changes/command-overview-typer-compatibility/design.md
@@ -22,6 +22,8 @@ in the Docs Review environment.
 
 - Classify parameters against the supported Click and Typer option/argument
   classes instead of relying only on Click's public inheritance hierarchy.
+- Preserve an explicitly configured argument metavar verbatim; normalize the
+  runtime-provided default label only when no explicit metavar exists.
 - Add focused regression tests using Typer command construction and regenerate
   artifacts in an environment built from `requirements-docs-ci.txt`.
 
@@ -31,6 +33,8 @@ in the Docs Review environment.
   dependency file and retain focused parameter-class coverage.
 - [Broader type acceptance misclassifies a parameter] → Limit accepted classes
   to the runtime types emitted by Click and Typer.
+- [Label normalization changes user-provided syntax] → Use the parameter's
+  explicit metavar before applying the stable default-label normalization.
 
 ## Migration Plan
 

--- a/openspec/changes/command-overview-typer-compatibility/design.md
+++ b/openspec/changes/command-overview-typer-compatibility/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`scripts/generate-command-overview.py` identifies options and arguments with
+Click's public classes. Typer 0.27.0 uses implementation classes derived from
+its bundled Click compatibility layer, so valid Typer parameters are skipped
+in the Docs Review environment.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve every option and argument exposed by the pinned Typer runtime.
+- Keep existing Click parameter handling and generated-artifact schema stable.
+- Prove the behavior with the same Typer version that Docs Review installs.
+
+**Non-Goals:**
+
+- Change module command syntax, registry contents, or package dependencies.
+- Support arbitrary unpinned parameter implementations.
+
+## Decisions
+
+- Classify parameters against the supported Click and Typer option/argument
+  classes instead of relying only on Click's public inheritance hierarchy.
+- Add focused regression tests using Typer command construction and regenerate
+  artifacts in an environment built from `requirements-docs-ci.txt`.
+
+## Risks / Trade-offs
+
+- [Typer internals change again] → Pin the tested version in the Docs Review
+  dependency file and retain focused parameter-class coverage.
+- [Broader type acceptance misclassifies a parameter] → Limit accepted classes
+  to the runtime types emitted by Click and Typer.
+
+## Migration Plan
+
+1. Add a failing Typer 0.27 regression test.
+2. Implement the narrow classifier update.
+3. Regenerate artifacts using the CI dependency set and run Docs Review tests.
+4. Roll back by reverting the classifier and generated artifacts together.

--- a/openspec/changes/command-overview-typer-compatibility/proposal.md
+++ b/openspec/changes/command-overview-typer-compatibility/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Docs Review installs Typer 0.27.0, whose command parameters no longer inherit
+from Click's public option and argument classes. The command-overview generator
+therefore emits empty metadata in CI and rejects the checked-in artifacts as
+stale.
+
+## What Changes
+
+- Make command-parameter classification compatible with Typer 0.27.0 and the
+  project's Click version.
+- Add regression coverage for Typer-provided option and argument parameters.
+- Regenerate the command overview artifacts using the CI dependency set.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `module-command-overview`: Generate deterministic option and argument
+  metadata under the pinned Docs Review Typer runtime.
+
+## Impact
+
+- Affects `scripts/generate-command-overview.py`, its unit tests, and the
+  generated `llms.txt` and command-reference artifacts.
+- Does not change module manifests, registry entries, public command syntax,
+  package versions, or signatures.

--- a/openspec/changes/command-overview-typer-compatibility/requirements-evidence.yaml
+++ b/openspec/changes/command-overview-typer-compatibility/requirements-evidence.yaml
@@ -1,0 +1,4 @@
+requirements:
+  "openspec:command-overview-typer-compatibility:module-command-overview:modules-publish-generated-command-overview-artifacts":
+    test_links:
+      - tests/unit/docs/test_llms_overview_freshness.py

--- a/openspec/changes/command-overview-typer-compatibility/specs/module-command-overview/spec.md
+++ b/openspec/changes/command-overview-typer-compatibility/specs/module-command-overview/spec.md
@@ -26,6 +26,15 @@ and registry inventory.
 - **AND** it does not certify empty metadata caused only by the parameter's
   implementation class.
 
+#### Scenario: Explicit argument metavars remain intact
+
+- **GIVEN** a Click or Typer argument defines an explicit `metavar`
+- **WHEN** command overview generation records the argument
+- **THEN** it emits the configured metavar without changing its casing or
+  punctuation
+- **AND** it continues to normalize only default argument labels for stable
+  generated artifacts across supported runtimes.
+
 #### Scenario: Official inventory is not represented by command mounts
 
 - **GIVEN** an official package or grouped root in manifests and the registry is

--- a/openspec/changes/command-overview-typer-compatibility/specs/module-command-overview/spec.md
+++ b/openspec/changes/command-overview-typer-compatibility/specs/module-command-overview/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Modules Publish Generated Command Overview Artifacts
+
+The modules repository SHALL generate deterministic command overview artifacts
+from the actual module command tree and authoritative official-module manifest
+and registry inventory.
+
+#### Scenario: Module command overview artifacts are generated
+
+- **GIVEN** the module command overview generator runs in the modules repository
+- **WHEN** it writes artifacts under the pinned Docs Review dependency set
+- **THEN** it produces `llms.txt`, `docs/reference/commands.generated.md`, and
+  `docs/reference/commands.generated.json`
+- **AND** every command record includes command path, owning repo, owning module
+  package, install prerequisite, short help, arguments/options, subcommands,
+  source import path when known, and hidden/deprecated status
+- **AND** generated output is stable for the same source tree.
+
+#### Scenario: Typer-provided parameters preserve command metadata
+
+- **GIVEN** a command parameter is supplied by the pinned Docs Review Typer
+  runtime rather than Click's public option or argument class
+- **WHEN** command overview generation or freshness validation runs
+- **THEN** it records that parameter's long options or argument metadata
+- **AND** it does not certify empty metadata caused only by the parameter's
+  implementation class.
+
+#### Scenario: Official inventory is not represented by command mounts
+
+- **GIVEN** an official package or grouped root in manifests and the registry is
+  missing, renamed, or remapped relative to the command-mount inventory
+- **WHEN** command overview generation or freshness validation runs
+- **THEN** it exits non-zero and identifies the unrepresented or inconsistent
+  official record
+- **AND** it does not certify unchanged generated artifacts as current.
+
+#### Scenario: README links generated overview
+
+- **GIVEN** a user or AI agent opens the modules repository README
+- **WHEN** they look for command usage
+- **THEN** the README links to the generated module command overview artifact.
+
+#### Scenario: Stale generated artifacts fail checks
+
+- **GIVEN** any path under `packages/**` or `registry/**` changes, or command
+  overview, prompt, docs, or command-validation tooling changes
+- **WHEN** the command overview freshness check runs
+- **THEN** local pre-commit regenerates and stages all generated artifacts after
+  rejecting relevant unstaged inputs
+- **AND** CI performs a read-only check and fails if the artifacts are stale
+- **AND** the failure reports the command needed to regenerate them.

--- a/openspec/changes/command-overview-typer-compatibility/tasks.md
+++ b/openspec/changes/command-overview-typer-compatibility/tasks.md
@@ -1,0 +1,20 @@
+## 1. Specification and regression setup
+
+- [x] 1.1 Create the command-overview compatibility delta and design.
+- [x] 1.2 Add focused Typer 0.27 option and argument regression coverage.
+- [x] 1.3 Run the new test before production edits and record failing evidence.
+
+## 2. Implementation and artifacts
+
+- [x] 2.1 Update command-parameter classification for the supported Typer
+  runtime without changing public command behavior.
+- [x] 2.2 Regenerate `llms.txt` and command-reference artifacts under the Docs
+  Review dependency set.
+- [x] 2.3 Record passing evidence in `TDD_EVIDENCE.md`.
+
+## 3. Verification and review
+
+- [x] 3.1 Run strict OpenSpec validation and the focused Docs Review tests.
+- [x] 3.2 Run applicable formatting, lint, docs, and generated-artifact gates.
+- [x] 3.3 Run changed-line SpecFact code review with `--bug-hunt`, resolve all
+  findings, and record the result.

--- a/openspec/changes/command-overview-typer-compatibility/tasks.md
+++ b/openspec/changes/command-overview-typer-compatibility/tasks.md
@@ -3,6 +3,8 @@
 - [x] 1.1 Create the command-overview compatibility delta and design.
 - [x] 1.2 Add focused Typer 0.27 option and argument regression coverage.
 - [x] 1.3 Run the new test before production edits and record failing evidence.
+- [x] 1.4 Add coverage for an explicit Typer argument metavar that contains
+  lowercase characters and punctuation.
 
 ## 2. Implementation and artifacts
 
@@ -11,6 +13,8 @@
 - [x] 2.2 Regenerate `llms.txt` and command-reference artifacts under the Docs
   Review dependency set.
 - [x] 2.3 Record passing evidence in `TDD_EVIDENCE.md`.
+- [x] 2.4 Preserve explicit argument metavars while retaining stable default
+  argument labels.
 
 ## 3. Verification and review
 
@@ -18,3 +22,5 @@
 - [x] 3.2 Run applicable formatting, lint, docs, and generated-artifact gates.
 - [x] 3.3 Run changed-line SpecFact code review with `--bug-hunt`, resolve all
   findings, and record the result.
+- [x] 3.4 Link the modified requirement to its regression test for the
+  requirements-evidence gate.

--- a/scripts/generate-command-overview.py
+++ b/scripts/generate-command-overview.py
@@ -170,13 +170,17 @@ def _command_options(command: click.Command) -> list[str]:
     return sorted(options)
 
 
+def _argument_display_name(param: click.Argument | TyperArgument) -> str:
+    return param.metavar or param.human_readable_name.upper()
+
+
 def _command_arguments(command: click.Command) -> list[dict[str, Any]]:
     arguments: list[dict[str, Any]] = []
     for param in command.params:
         if isinstance(param, ARGUMENT_PARAMETER_TYPES):
             arguments.append(
                 {
-                    "name": param.human_readable_name.upper(),
+                    "name": _argument_display_name(param),
                     "required": bool(param.required),
                     "nargs": param.nargs,
                 }

--- a/scripts/generate-command-overview.py
+++ b/scripts/generate-command-overview.py
@@ -18,6 +18,7 @@ import click
 import yaml
 from beartype import beartype
 from icontract import ensure
+from typer.core import TyperArgument, TyperOption
 from typer.main import get_command
 
 
@@ -46,6 +47,9 @@ RUNTIME_VALIDATED_GROUPS = frozenset(
         "specfact code repro",
     }
 )
+
+OPTION_PARAMETER_TYPES = (click.Option, TyperOption)
+ARGUMENT_PARAMETER_TYPES = (click.Argument, TyperArgument)
 
 
 def _paired_worktree_repo(source_marker: str, target_marker: str) -> Path | None:
@@ -160,7 +164,7 @@ def validate_official_mount_inventory() -> None:
 def _command_options(command: click.Command) -> list[str]:
     options: set[str] = set()
     for param in command.params:
-        if isinstance(param, click.Option):
+        if isinstance(param, OPTION_PARAMETER_TYPES):
             secondary_opts = param.secondary_opts
             options.update(opt for opt in [*param.opts, *secondary_opts] if opt.startswith("--"))
     return sorted(options)
@@ -169,10 +173,10 @@ def _command_options(command: click.Command) -> list[str]:
 def _command_arguments(command: click.Command) -> list[dict[str, Any]]:
     arguments: list[dict[str, Any]] = []
     for param in command.params:
-        if isinstance(param, click.Argument):
+        if isinstance(param, ARGUMENT_PARAMETER_TYPES):
             arguments.append(
                 {
-                    "name": param.human_readable_name,
+                    "name": param.human_readable_name.upper(),
                     "required": bool(param.required),
                     "nargs": param.nargs,
                 }
@@ -216,9 +220,9 @@ def _has_bare_business_parameters(command: click.Command) -> bool:
         "--show-completion",
     }
     for param in command.params:
-        if isinstance(param, click.Argument):
+        if isinstance(param, ARGUMENT_PARAMETER_TYPES):
             return True
-        if isinstance(param, click.Option):
+        if isinstance(param, OPTION_PARAMETER_TYPES):
             opts = set(param.opts) | set(param.secondary_opts)
             if opts and opts.isdisjoint(ignored_options):
                 return True

--- a/tests/unit/docs/test_llms_overview_freshness.py
+++ b/tests/unit/docs/test_llms_overview_freshness.py
@@ -85,6 +85,23 @@ def test_command_overview_records_typer_parameters() -> None:
     )
 
 
+def test_command_overview_preserves_explicit_typer_argument_metavar() -> None:
+    """An explicit metavar is user-facing syntax, not a default label to normalize."""
+    generator = load_module_from_path("generate_command_overview_typer_metavar", GENERATOR)
+    app = typer.Typer()
+
+    @app.command()
+    def inspect(source_path: str = typer.Argument(..., metavar="path/to/file")) -> None:
+        del source_path
+
+    assert inspect.__name__ == "inspect"
+    command = get_typer_command(app)
+
+    assert {"name": "path/to/file", "required": True, "nargs": 1} in generator._command_arguments(  # pylint: disable=protected-access
+        command
+    )
+
+
 def test_command_overview_rejects_unrepresented_official_inventory(tmp_path: Path, monkeypatch) -> None:
     generator = load_module_from_path("generate_command_overview_inventory", GENERATOR)
     manifest = tmp_path / "packages" / "specfact-example" / "module-package.yaml"

--- a/tests/unit/docs/test_llms_overview_freshness.py
+++ b/tests/unit/docs/test_llms_overview_freshness.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import click
 import pytest
+import typer
+from typer.main import get_command as get_typer_command
 
 from tests.unit._script_test_utils import load_module_from_path
 
@@ -60,6 +62,27 @@ def test_command_overview_records_optional_click_arguments() -> None:
     assert generator._command_arguments(command) == [  # pylint: disable=protected-access
         {"name": "SOURCE_PATH", "required": False, "nargs": 1}
     ]
+
+
+def test_command_overview_records_typer_parameters() -> None:
+    """Typer's pinned Docs Review runtime must retain option and argument metadata."""
+    generator = load_module_from_path("generate_command_overview_typer", GENERATOR)
+    app = typer.Typer()
+
+    @app.command()
+    def inspect(
+        source_path: str = typer.Argument(...),
+        output_format: str = typer.Option("json", "--format"),
+    ) -> None:
+        del source_path, output_format
+
+    assert inspect.__name__ == "inspect"
+    command = get_typer_command(app)
+
+    assert "--format" in generator._command_options(command)  # pylint: disable=protected-access
+    assert {"name": "SOURCE_PATH", "required": True, "nargs": 1} in generator._command_arguments(  # pylint: disable=protected-access
+        command
+    )
 
 
 def test_command_overview_rejects_unrepresented_official_inventory(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Archives the completed `docs-16-core-accountability-sync` OpenSpec change via the OpenSpec CLI.

The archive records GitHub issue #339 as completed and refreshes the generated module command references required by the documentation-accountability gate.

## Scope

- Moves the completed change to `openspec/changes/archive/2026-07-26-docs-16-core-accountability-sync/`.
- Preserves the completed validation and TDD evidence.
- Updates generated command-reference artifacts and `llms.txt` through the repository pre-commit contract.

## Verification

- `openspec validate docs-16-core-accountability-sync --strict`
- Markdown and whitespace validation of archive artifacts
- Pre-commit: module signature, format, YAML manifests, bundle imports, command overview/contract, and core documentation accountability
- Changed-line Code Review: no reviewable code files in this documentation/OpenSpec-only diff

## Out of scope

- `requirements-05-dogfood-evidence-gate` remains open pending PR #360.
- The paired R06 changes are not included.