### PR TITLE
fix(ci): constrain manual paired-core refs

### DIFF
--- a/.github/workflows/docs-review.yml
+++ b/.github/workflows/docs-review.yml
@@ -80,6 +80,7 @@ jobs:
           persist-credentials: false
       - name: Resolve paired core command sources ref
         id: core-ref
+        if: github.event_name != 'workflow_dispatch'
         shell: bash
         env:
           CANDIDATE_REF: ${{ github.head_ref || github.ref_name }}
@@ -98,11 +99,30 @@ jobs:
           fi
 
       - name: Checkout paired core command sources
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: nold-ai/specfact-cli
           path: specfact-cli
           ref: ${{ steps.core-ref.outputs.ref }}
+          persist-credentials: false
+
+      - name: Checkout paired core command sources (manual main)
+        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: nold-ai/specfact-cli
+          path: specfact-cli
+          ref: "main"
+          persist-credentials: false
+
+      - name: Checkout paired core command sources (manual dev)
+        if: github.event_name == 'workflow_dispatch' && github.ref_name != 'main'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: nold-ai/specfact-cli
+          path: specfact-cli
+          ref: "dev"
           persist-credentials: false
 
       - name: Export paired core source path

--- a/.github/workflows/pr-orchestrator.yml
+++ b/.github/workflows/pr-orchestrator.yml
@@ -129,7 +129,9 @@ jobs:
           persist-credentials: false
       - name: Resolve paired core CLI ref
         id: core-ref
-        if: needs.changes.outputs.skip_tests_dev_to_main != 'true'
+        if: >-
+          needs.changes.outputs.skip_tests_dev_to_main != 'true' &&
+          github.event_name != 'workflow_dispatch'
         shell: bash
         env:
           CANDIDATE_REF: ${{ github.head_ref || github.ref_name }}
@@ -148,12 +150,38 @@ jobs:
           fi
 
       - name: Checkout paired core CLI
-        if: needs.changes.outputs.skip_tests_dev_to_main != 'true'
+        if: >-
+          needs.changes.outputs.skip_tests_dev_to_main != 'true' &&
+          github.event_name != 'workflow_dispatch'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: nold-ai/specfact-cli
           path: specfact-cli
           ref: ${{ steps.core-ref.outputs.ref }}
+          persist-credentials: false
+
+      - name: Checkout paired core CLI (manual main)
+        if: >-
+          needs.changes.outputs.skip_tests_dev_to_main != 'true' &&
+          github.event_name == 'workflow_dispatch' &&
+          github.ref_name == 'main'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: nold-ai/specfact-cli
+          path: specfact-cli
+          ref: "main"
+          persist-credentials: false
+
+      - name: Checkout paired core CLI (manual dev)
+        if: >-
+          needs.changes.outputs.skip_tests_dev_to_main != 'true' &&
+          github.event_name == 'workflow_dispatch' &&
+          github.ref_name != 'main'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: nold-ai/specfact-cli
+          path: specfact-cli
+          ref: "dev"
           persist-credentials: false
       - name: Export paired core CLI path
         if: needs.changes.outputs.skip_tests_dev_to_main != 'true'

--- a/.github/workflows/requirements-evidence.yml
+++ b/.github/workflows/requirements-evidence.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Resolve paired core CLI ref
         id: core-ref
+        if: github.event_name != 'workflow_dispatch'
         shell: bash
         env:
           CANDIDATE_REF: ${{ github.head_ref || github.ref_name }}
@@ -47,11 +48,30 @@ jobs:
           fi
 
       - name: Checkout paired core CLI
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: nold-ai/specfact-cli
           path: specfact-cli
           ref: ${{ steps.core-ref.outputs.ref }}
+          persist-credentials: false
+
+      - name: Checkout paired core CLI (manual main)
+        if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: nold-ai/specfact-cli
+          path: specfact-cli
+          ref: "main"
+          persist-credentials: false
+
+      - name: Checkout paired core CLI (manual dev)
+        if: github.event_name == 'workflow_dispatch' && github.ref_name != 'main'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: nold-ai/specfact-cli
+          path: specfact-cli
+          ref: "dev"
           persist-credentials: false
 
       - name: Set up Python 3.12

--- a/openspec/CHANGE_ORDER.md
+++ b/openspec/CHANGE_ORDER.md
@@ -7,7 +7,7 @@ must be read together with the core repo change order in `nold-ai/specfact-cli`.
 
 | Bucket | Count | Location |
 |---|---:|---|
-| **Active** | 15 | [`openspec/changes/`](changes/) |
+| **Active** | 16 | [`openspec/changes/`](changes/) |
 | **Parked** | 16 | [`openspec/parking-lot/`](parking-lot/) |
 | **Archived** | 43 | [`openspec/changes/archive/`](changes/archive/) |
 
@@ -61,6 +61,16 @@ This track is first because no changed-scope assurance claim is trustworthy unti
 The first signed C14 module release advertises only the exact core 0.55.1 identity proven by its immutable compatibility smoke: lightweight tag `v0.55.1`, full commit `b1e517e60e669eaba15a18ecfa83ef5a9df65276`, and full tree `47984be5434d7ae65ed6908bf525a32053290337`. Paired core adoption remains downstream; after that core is released, a later module metadata release may advertise that new exact core version only after the same tag/commit/tree matrix smoke. The metadata uses strict `===0.55.1`; ordinary `==0.55.1` and local aliases such as `0.55.1+vendor` are rejected. No single lower-bound test authorizes a future-version range.
 
 Implementation must stay independent from Requirements replay work. The two changes may share evidence vocabulary only through the future governance schema; neither may silently define the other's verdict.
+
+## Immediate Release-Safety Track
+
+This bounded corrective change is independent of C14 and must merge to `dev`
+before the C14 release promotion proceeds. Alert-specific evidence remains in
+private GitHub Security records under the repository security policy.
+
+| Order | Change folder | GitHub # | Positioning | Blocked by |
+|---:|---|---|---|---|
+| 1 | `ci-01-workflow-dispatch-core-ref-trust` | private security tracking | Preserve paired feature-branch validation for non-manual events while restricting manual paired-core execution to literal `main` or `dev` refs | ancestry sync PR [#421](https://github.com/nold-ai/specfact-cli-modules/pull/421) |
 
 ## Active Tracks
 

--- a/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/.openspec.yaml
+++ b/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/TDD_EVIDENCE.md
+++ b/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/TDD_EVIDENCE.md
@@ -1,0 +1,57 @@
+# TDD Evidence: ci-01-workflow-dispatch-core-ref-trust
+
+## Failing-before
+
+### 2026-08-23 Europe/Berlin
+
+Before any workflow edit:
+
+```bash
+hatch run pytest tests/unit/workflows/test_paired_core_ref_trust.py \
+  -q -p no:cacheprovider
+```
+
+Result: 6 failed as expected. All three dynamic resolver/checkout pairs lacked
+the manual-event exclusion, and all three workflows lacked mutually exclusive
+literal `main` and `dev` manual checkout paths.
+
+## Passing-after
+
+### 2026-08-23 Europe/Berlin
+
+- The focused suite and the three pre-existing affected workflow suites passed:
+  39 tests initially, then 35 after consolidating parameterized cases into two
+  standard-library-only loop tests during review remediation.
+- The dynamic resolver and checkout remain available for non-manual events.
+- Manual `main` uses literal core `main`; every other manual ref uses literal
+  core `dev`; all paired-core checkouts retain `persist-credentials: false`.
+- `actionlint` passed for the three changed workflows.
+- `hatch run yaml-lint` and strict OpenSpec validation passed.
+
+## Final quality evidence
+
+### 2026-08-23 Europe/Berlin
+
+- `hatch run format`: 1,193 files unchanged.
+- `hatch run lint`: passed with a 10.00/10 Pylint score.
+- `hatch run type-check`: 0 errors, warnings, or notes.
+- `hatch run contract-test`: 28 passed.
+- `hatch run smart-test`: 1,567 passed and 2 pre-existing environment/C14
+  tests failed. The local paired core is 0.54.0 while the immutable C14 smoke
+  requires exactly 0.55.1; the other failure is the existing C14 signed-lock
+  capsule materialization test. This change modifies no package or C14 path.
+- After installing exact published core 0.55.1 in the disposable worktree
+  environment, the immutable C14 schema smoke passed. The unrelated signed-lock
+  capsule test remained failed with `capsule_runtime_unavailable:`.
+- `hatch run check-bundle-imports` passed.
+- Strict signature verification could not load local public keys for the seven
+  unchanged manifests. The repository-approved
+  `--allow-missing-public-key` payload checksum and version-bump verification
+  passed for all seven manifests.
+- The staged schema-v2 Requirements evidence gate passed at planned maturity.
+- The first changed-scope SpecFact review reported one CrossHair environment
+  warning because its isolated Python could not import `pytest`. The new test
+  was rewritten to use only the standard library while retaining both contract
+  assertions; the 35-test affected suite passed after that remediation.
+- The changed-scope SpecFact review rerun under exact core 0.55.1 passed with
+  zero findings, warnings, or advisories. CI remains pending.

--- a/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/design.md
+++ b/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The affected workflows check out `nold-ai/specfact-cli` and execute or install
+that checkout. Same-named feature branches are useful for pull-request parity,
+while manual dispatch has a different trust boundary because it is explicitly
+operator-triggered and does not need arbitrary paired-branch execution.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep matching paired-core branch validation for non-manual events.
+- Make every manual paired-core checkout resolve to a literal protected branch.
+- Express the boundary directly in workflow step conditions and prove it with
+  repository tests.
+
+**Non-Goals:**
+
+- Change pull-request permissions, workflow purpose, or validation commands.
+- Change C14 behavior, package dependencies, module metadata, publication, or
+  dependency scanner findings.
+- Generalize the change into a reusable workflow framework.
+
+## Decisions
+
+- Retain the existing resolver only when the event is not
+  `workflow_dispatch`.
+- Keep the existing dynamic checkout only for non-manual events.
+- Add mutually exclusive manual checkout steps with literal `main` and `dev`
+  refs. A manual run on `main` pairs with core `main`; every other manual
+  modules ref pairs with core `dev`.
+- Preserve `persist-credentials: false` on every paired-core checkout.
+- Use one focused text-level workflow contract suite so the security invariant
+  remains visible without coupling the tests to GitHub's YAML key coercion.
+
+## Risks / Trade-offs
+
+- [Manual feature-branch validation no longer pairs a same-named core branch]
+  -> Use a pull request for paired feature-branch integration; manual runs use
+  the trusted `dev` core baseline.
+- [A future workflow edit removes an event guard] -> Contract tests require the
+  resolver, dynamic checkout, and literal manual checkout conditions together.
+- [Literal branches diverge from a release candidate] -> This change does not
+  add release-candidate inputs; a future explicit immutable-ref design would
+  require its own review.
+
+## Migration Plan
+
+1. Add and strictly validate the OpenSpec contract.
+2. Add focused tests and record their pre-implementation failure.
+3. Apply the same bounded step split to the three workflows.
+4. Run focused tests, workflow lint, OpenSpec validation, and repository quality
+   gates.
+5. Roll back by reverting the workflow and contract-test commit together.

--- a/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/proposal.md
+++ b/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Three validation workflows can pair a modules branch with the same-named core
+branch. That behavior is required for pull-request integration testing, but a
+manual workflow run must not use a caller-selected core branch as executable
+CI input.
+
+## What Changes
+
+- Preserve same-named paired-core branch resolution for pull-request and other
+  non-manual validation runs.
+- Restrict manual workflow runs to literal `main` or `dev` paired-core refs.
+- Add focused workflow contract tests covering all three affected workflows.
+
+## Capabilities
+
+### New Capabilities
+
+- `paired-core-workflow-ref-trust`: Event-specific trust boundaries for paired
+  core source executed by modules validation workflows.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects only `.github/workflows/docs-review.yml`,
+  `.github/workflows/pr-orchestrator.yml`,
+  `.github/workflows/requirements-evidence.yml`, one focused workflow contract
+  test, and this OpenSpec change.
+- Does not change module source, manifests, registry metadata, versions,
+  signatures, C14 artifacts, dependency lockfiles, or marketplace contents.
+- Does not alter the exact-core C14 compatibility job or its immutable core
+  identity.
+- A separate dependency-only change owns documentation dependency maintenance.
+
+## Tracking
+
+The authoritative findings remain in the repository's private GitHub Security
+records. In accordance with `SECURITY.md`, no public vulnerability issue is
+created and no alert-specific mechanics are reproduced here.

--- a/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/requirements-evidence.yaml
+++ b/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/requirements-evidence.yaml
@@ -1,0 +1,27 @@
+schema_version: "2"
+requirements:
+  openspec:ci-01-workflow-dispatch-core-ref-trust:paired-core-workflow-ref-trust:manual-runs-use-trusted-paired-core-refs:
+    rationale: Manual workflow runs must execute only explicitly trusted paired-core refs while pull requests retain matching-branch integration.
+    stakeholder_refs:
+      - SECURITY.md
+    touchpoints:
+      - id: paired-core-workflow-checkouts
+        kind: workflow
+        locator: .github/workflows/{docs-review,pr-orchestrator,requirements-evidence}.yml
+    verification_cases:
+      - case_id: CI-01-001
+        scenario_id: manual-runs-use-trusted-paired-core-refs
+        method: test
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_paired_core_ref_trust.py::test_dynamic_paired_core_resolution_excludes_manual_dispatch
+        intent: Preserve non-manual matching-branch validation while excluding manual events from dynamic core-ref resolution.
+        observable: Each workflow guards its dynamic resolver and checkout from manual events while retaining credential-disabled matching-branch checkout.
+      - case_id: CI-01-002
+        scenario_id: manual-runs-use-trusted-paired-core-refs
+        method: test
+        selector:
+          runner: pytest
+          node_id: tests/unit/workflows/test_paired_core_ref_trust.py::test_manual_dispatch_uses_mutually_exclusive_literal_core_refs
+        intent: Restrict manual runs to one eligible literal paired-core branch.
+        observable: Each workflow has mutually exclusive literal main/dev manual checkout steps with credentials disabled.

--- a/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/specs/paired-core-workflow-ref-trust/spec.md
+++ b/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/specs/paired-core-workflow-ref-trust/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Manual Runs Use Trusted Paired-Core Refs
+
+Modules validation workflows that execute paired core source SHALL separate
+manual-dispatch core selection from pull-request matching-branch validation.
+
+#### Scenario: Pull request retains matching paired-core validation
+
+- **GIVEN** a validation workflow runs for a non-manual event
+- **WHEN** the same-named branch exists in the paired core repository
+- **THEN** the workflow may resolve and check out that matching paired-core
+  branch
+- **AND** the checkout does not persist credentials.
+
+#### Scenario: Manual main run uses core main
+
+- **GIVEN** a validation workflow is manually dispatched from modules `main`
+- **WHEN** it checks out paired core source
+- **THEN** it uses the literal core `main` ref
+- **AND** it does not evaluate a caller-selected core ref.
+
+#### Scenario: Other manual runs use core dev
+
+- **GIVEN** a validation workflow is manually dispatched from any modules ref
+  other than `main`
+- **WHEN** it checks out paired core source
+- **THEN** it uses the literal core `dev` ref
+- **AND** it does not evaluate a caller-selected core ref.
+
+#### Scenario: Manual runs cannot reach the dynamic resolver
+
+- **GIVEN** the event is `workflow_dispatch`
+- **WHEN** workflow conditions are evaluated
+- **THEN** the dynamic paired-core resolver and dynamic checkout are skipped
+- **AND** exactly one literal paired-core checkout path is eligible.

--- a/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/tasks.md
+++ b/openspec/changes/ci-01-workflow-dispatch-core-ref-trust/tasks.md
@@ -1,0 +1,33 @@
+## 1. Specification and scope
+
+- [x] 1.1 Create an isolated worktree from merged `origin/dev`.
+- [x] 1.2 Define the manual-dispatch paired-core trust boundary and explicit
+  non-goals before workflow edits.
+- [x] 1.3 Record the `SECURITY.md` exception to public issue tracking; keep
+  alert-specific evidence in private GitHub Security records.
+- [x] 1.4 Strictly validate the OpenSpec change.
+
+## 2. Test-first evidence
+
+- [x] 2.1 Add focused contract tests for non-manual matching-branch behavior and
+  literal manual `main`/`dev` checkout behavior in all three workflows.
+- [x] 2.2 Run the focused tests before workflow edits and record the expected
+  failure in `TDD_EVIDENCE.md`.
+
+## 3. Bounded implementation
+
+- [x] 3.1 Guard each dynamic core-ref resolver and checkout from manual events.
+- [x] 3.2 Add mutually exclusive literal `main` and `dev` paired-core checkout
+  steps for manual events.
+- [x] 3.3 Confirm module packages, manifests, registry data, dependency files,
+  and C14 release artifacts remain unchanged.
+
+## 4. Verification and review
+
+- [x] 4.1 Run focused tests, workflow/YAML lint, and strict OpenSpec validation.
+- [x] 4.2 Record passing and quality evidence in `TDD_EVIDENCE.md`.
+- [x] 4.3 Run fresh SpecFact changed-scope and final review evidence; resolve all
+  findings or document an approved exception.
+- [ ] 4.4 Open a narrowly scoped PR to `dev` without public alert details.
+- [ ] 4.5 After merge, archive with
+  `openspec archive ci-01-workflow-dispatch-core-ref-trust`.

--- a/tests/unit/workflows/test_paired_core_ref_trust.py
+++ b/tests/unit/workflows/test_paired_core_ref_trust.py
@@ -1,0 +1,71 @@
+"""Trust-boundary contracts for paired core workflow checkouts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS = (
+    (
+        "docs-review.yml",
+        "docs-review",
+        "Resolve paired core command sources ref",
+        "Checkout paired core command sources",
+    ),
+    (
+        "pr-orchestrator.yml",
+        "quality",
+        "Resolve paired core CLI ref",
+        "Checkout paired core CLI",
+    ),
+    (
+        "requirements-evidence.yml",
+        "requirements-evidence",
+        "Resolve paired core CLI ref",
+        "Checkout paired core CLI",
+    ),
+)
+
+
+def _step_text(workflow_name: str, job_name: str, step_name: str) -> str:
+    workflow = (REPO_ROOT / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+    job_match = re.search(
+        rf"(?ms)^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)",
+        workflow,
+    )
+    assert job_match is not None, f"missing workflow job: {workflow_name}:{job_name}"
+    step_match = re.search(
+        rf"(?ms)^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - (?:name|uses): |\Z)",
+        job_match.group("body"),
+    )
+    assert step_match is not None, f"missing workflow step: {workflow_name}:{job_name}:{step_name}"
+    return step_match.group(0)
+
+
+def test_dynamic_paired_core_resolution_excludes_manual_dispatch() -> None:
+    for workflow_name, job_name, resolver_name, checkout_name in WORKFLOWS:
+        resolver = _step_text(workflow_name, job_name, resolver_name)
+        dynamic_checkout = _step_text(workflow_name, job_name, checkout_name)
+
+        assert "github.event_name != 'workflow_dispatch'" in resolver
+        assert "github.event_name != 'workflow_dispatch'" in dynamic_checkout
+        assert "ref: ${{ steps.core-ref.outputs.ref }}" in dynamic_checkout
+        assert "persist-credentials: false" in dynamic_checkout
+
+
+def test_manual_dispatch_uses_mutually_exclusive_literal_core_refs() -> None:
+    for workflow_name, job_name, _resolver_name, checkout_name in WORKFLOWS:
+        manual_main = _step_text(workflow_name, job_name, f"{checkout_name} (manual main)")
+        manual_dev = _step_text(workflow_name, job_name, f"{checkout_name} (manual dev)")
+
+        assert "github.event_name == 'workflow_dispatch'" in manual_main
+        assert "github.ref_name == 'main'" in manual_main
+        assert 'ref: "main"' in manual_main
+        assert "persist-credentials: false" in manual_main
+
+        assert "github.event_name == 'workflow_dispatch'" in manual_dev
+        assert "github.ref_name != 'main'" in manual_dev
+        assert 'ref: "dev"' in manual_dev
+        assert "persist-credentials: false" in manual_dev


### PR DESCRIPTION
## Summary

- keep same-named paired-core branch validation for non-manual events
- exclude `workflow_dispatch` from all dynamic paired-core resolver and checkout steps
- make manual runs use only literal core `main` or `dev` refs with credentials disabled
- add one focused workflow trust-boundary contract suite and the bounded OpenSpec change

## Scope boundary

This PR changes only three GitHub Actions workflows, one focused workflow test file, and the OpenSpec/evidence records for `ci-01-workflow-dispatch-core-ref-trust`.

It does not change module source, manifests, versions, signatures, registry entries, C14 artifacts, dependency lockfiles, or marketplace contents. The exact-core C14 compatibility job and immutable 0.55.1 identity are unchanged. Documentation dependency maintenance is a separate follow-up.

Alert-specific evidence remains in the repository's private GitHub Security records in accordance with `SECURITY.md`; this public PR describes only the enforced trust-boundary behavior.

## Verification

- strict OpenSpec validation: passed
- staged schema-v2 Requirements evidence gate: passed at planned maturity
- `actionlint` for all three changed workflows: passed
- affected workflow tests: 35 passed
- formatter, lint, type check, YAML lint, bundle-import check: passed
- contract tests: 28 passed
- module payload checksum/version-bump verification: all 7 unchanged manifests passed with the approved local missing-public-key fallback
- SpecFact changed-scope review under exact core 0.55.1: `PASS`, 0 findings/warnings/advisories
- complete pre-commit pipeline under immutable core commit `b1e517e60e669eaba15a18ecfa83ef5a9df65276`: passed

The broader smart-test run produced 1,567 passes. Its exact-core C14 schema smoke passed after correcting the local core from 0.54.0 to 0.55.1; one unrelated pre-existing C14 signed-lock capsule materialization test remains locally unavailable and is outside this diff.

## Release sequencing

Merge this PR to `dev` before the C14 promotion PR #420. GitHub CodeQL/security checks on this PR are part of the promotion gate. The separate low-severity documentation dependency update follows in its own PR.

## Rollback

Revert this commit to restore the prior event handling. No package, registry, signature, or migration rollback is required.
