### PR TITLE
fix(docs): update json gem to 2.21.2

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -52,7 +52,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.21.1)
+    json (2.21.2)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)


### PR DESCRIPTION
## Summary

- update the transitive documentation `json` gem from `2.21.1` to the patched `2.21.2` release
- keep every other locked gem, platform, and Bundler version unchanged

## Scope

Dependency-maintenance only. The sole repository change is one line in `docs/Gemfile.lock`; there are no module payload, registry, workflow, runtime, or user-facing behavior changes. No OpenSpec delta is needed because this does not alter a behavioral contract.

## Verification

- `bundle _2.3.5_ lock --update json --conservative`
- isolated `bundle _2.3.5_ install --jobs 1 --retry 3`
- `bundle _2.3.5_ check`
- Bundler-initialized Ruby probe loaded `json 2.21.2`
- production Jekyll build passed
- `python scripts/check-docs-commands.py --jekyll-bundle-check` passed
- `pytest -q tests/unit/test_check_docs_commands_script.py` — 19 passed
- full repository pre-commit pipeline and commit hooks passed
- all seven module payload checksums verified under the formal `dev` policy; no module versions or signatures changed

## Security handling

This PR intentionally contains only the minimum patched dependency version and validation evidence. Alert-specific analysis remains in GitHub's private security surfaces.

## Rollback

Revert this commit to restore the prior lockfile entry. No module or runtime rollback is involved.
